### PR TITLE
feat(persistence): SwiftData model layer with VersionedSchema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,22 @@ Swift Concurrency (`async`/`await`, actors). No callback closures
 unless forced by a system API. Respect `MainActor` for anything
 UI-related.
 
+The project sets `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (Xcode's
+"approachable concurrency" default), which propagates MainActor
+isolation to every type by default. Domain value types that need
+cross-actor use (typically those with `Codable` or `Sendable`
+conformances consumed from off-MainActor tests or background
+encoders) must be marked `nonisolated` at the type declaration:
+
+```swift
+nonisolated enum Frequency: Hashable, Codable, Sendable { ... }
+nonisolated struct Habit: Hashable, Sendable { ... }
+```
+
+Without `nonisolated`, the synthesized conformances inherit MainActor
+isolation and emit "main actor-isolated conformance cannot be used in
+nonisolated context" warnings (errors under Swift 6 mode).
+
 ### Dates and calendars
 Day arithmetic always goes through `Calendar` — never raw seconds.
 `addingTimeInterval(86400)` silently breaks across DST boundaries
@@ -159,10 +175,24 @@ KadoUITests/                # UI tests (XCTest)
 ### SwiftData
 - One `@Model` per persistent type, explicit relationships with
   `@Relationship(deleteRule:inverse:)`.
-- Migrations: use `VersionedSchema` and `SchemaMigrationPlan` from the
-  first post-v0.1 schema change onward.
+- Migrations: `VersionedSchema` + `SchemaMigrationPlan` are wired from
+  day one (`KadoSchemaV1` + `KadoMigrationPlan` with empty `stages`).
+  When schema evolves, copy `KadoSchemaV1`'s models into a
+  `KadoSchemaV2` namespace, append a `MigrationStage.lightweight(...)`
+  (or `.custom`), and append `KadoSchemaV2.self` to
+  `KadoMigrationPlan.schemas`.
 - Queries: prefer `@Query` in simple views, explicit descriptor + fetch
   in services for complex logic.
+- CloudKit-shape from day one: every property has a default value or
+  is optional, the to-many relationship has an explicit inverse, no
+  `@Attribute(.unique)`, no `Deny` delete rule, no ordered relationships.
+- **Composite Codable workaround**: SwiftData on Xcode 26 / iOS 18
+  does not reliably support enums with associated values as direct
+  stored properties on `@Model` — `ModelContainer.init` crashes at
+  runtime even though build is clean. Workaround: store as
+  `private var fooData: Data` and expose `var foo: Foo { get / set }`
+  with explicit JSON encode/decode. See `HabitRecord` for the canonical
+  pattern. Re-evaluate when Apple fixes the underlying bug.
 
 ---
 
@@ -433,6 +463,11 @@ restating their content.
   research → plan → build → compound stages. Load it when the user
   signals a new feature is starting. Stages can be skipped — confirm
   with the user before bypassing one.
+- When research depends on a load-bearing claim about toolchain
+  behavior ("this storage shape works", "this API supports X"),
+  verify with a 2-minute smoke test before committing the design.
+  Research helpers can be wrong about toolchain-specific specifics;
+  catching it up front is far cheaper than a mid-build pivot.
 
 ### What Claude should NOT do without asking
 - Add a third-party dependency (Swift Package or otherwise).

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -1,10 +1,25 @@
+import SwiftData
 import SwiftUI
 
 @main
 struct KadoApp: App {
+    let container: ModelContainer = {
+        do {
+            let schema = Schema(versionedSchema: KadoSchemaV1.self)
+            return try ModelContainer(
+                for: schema,
+                migrationPlan: KadoMigrationPlan.self,
+                configurations: ModelConfiguration(schema: schema)
+            )
+        } catch {
+            fatalError("Failed to construct ModelContainer: \(error)")
+        }
+    }()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
+        .modelContainer(container)
     }
 }

--- a/Kado/Models/Frequency.swift
+++ b/Kado/Models/Frequency.swift
@@ -1,9 +1,54 @@
 import Foundation
 
 /// How often a habit is expected to be performed.
-enum Frequency: Hashable, Codable, Sendable {
+///
+/// Codable shape is owned explicitly (not synthesized) so the on-disk
+/// format survives compiler upgrades and stays human-readable. See
+/// `FrequencyCodingTests` for the canonical JSON per case.
+nonisolated enum Frequency: Hashable, Codable, Sendable {
     case daily
     case daysPerWeek(Int)
     case specificDays(Set<Weekday>)
     case everyNDays(Int)
+
+    private enum Kind: String, Codable {
+        case daily, daysPerWeek, specificDays, everyNDays
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, count, days, interval
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .daily:
+            try container.encode(Kind.daily, forKey: .kind)
+        case .daysPerWeek(let count):
+            try container.encode(Kind.daysPerWeek, forKey: .kind)
+            try container.encode(count, forKey: .count)
+        case .specificDays(let days):
+            try container.encode(Kind.specificDays, forKey: .kind)
+            try container.encode(days.map(\.rawValue).sorted(), forKey: .days)
+        case .everyNDays(let interval):
+            try container.encode(Kind.everyNDays, forKey: .kind)
+            try container.encode(interval, forKey: .interval)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .daily:
+            self = .daily
+        case .daysPerWeek:
+            self = .daysPerWeek(try container.decode(Int.self, forKey: .count))
+        case .specificDays:
+            let rawValues = try container.decode([Int].self, forKey: .days)
+            self = .specificDays(Set(rawValues.compactMap { Weekday(rawValue: $0) }))
+        case .everyNDays:
+            self = .everyNDays(try container.decode(Int.self, forKey: .interval))
+        }
+    }
 }

--- a/Kado/Models/HabitType.swift
+++ b/Kado/Models/HabitType.swift
@@ -2,9 +2,52 @@ import Foundation
 
 /// Habit kinds, each driving a different `value[n]` derivation in the
 /// score calculator.
-enum HabitType: Hashable, Codable, Sendable {
+///
+/// Codable shape is owned explicitly (not synthesized) so the on-disk
+/// format survives compiler upgrades and stays human-readable. See
+/// `HabitTypeCodingTests` for the canonical JSON per case.
+nonisolated enum HabitType: Hashable, Codable, Sendable {
     case binary
     case counter(target: Double)
     case timer(targetSeconds: TimeInterval)
     case negative
+
+    private enum Kind: String, Codable {
+        case binary, counter, timer, negative
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case kind, target, targetSeconds
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .binary:
+            try container.encode(Kind.binary, forKey: .kind)
+        case .counter(let target):
+            try container.encode(Kind.counter, forKey: .kind)
+            try container.encode(target, forKey: .target)
+        case .timer(let targetSeconds):
+            try container.encode(Kind.timer, forKey: .kind)
+            try container.encode(targetSeconds, forKey: .targetSeconds)
+        case .negative:
+            try container.encode(Kind.negative, forKey: .kind)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        switch kind {
+        case .binary:
+            self = .binary
+        case .counter:
+            self = .counter(target: try container.decode(Double.self, forKey: .target))
+        case .timer:
+            self = .timer(targetSeconds: try container.decode(TimeInterval.self, forKey: .targetSeconds))
+        case .negative:
+            self = .negative
+        }
+    }
 }

--- a/Kado/Models/Persistence/CompletionRecord.swift
+++ b/Kado/Models/Persistence/CompletionRecord.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SwiftData
+
+extension KadoSchemaV1 {
+    /// Persistent representation of a single completion event.
+    /// `habit` is optional because CloudKit forbids required
+    /// relationships — but a completion without a parent is a bug
+    /// (cascade delete should remove orphans), so `snapshot`
+    /// force-unwraps `habit?.id`.
+    @Model
+    final class CompletionRecord {
+        var id: UUID = UUID()
+        var date: Date = Date()
+        var value: Double = 1.0
+        var note: String?
+        var habit: HabitRecord?
+
+        init(
+            id: UUID = UUID(),
+            date: Date = .now,
+            value: Double = 1.0,
+            note: String? = nil,
+            habit: HabitRecord? = nil
+        ) {
+            self.id = id
+            self.date = date
+            self.value = value
+            self.note = note
+            self.habit = habit
+        }
+
+        /// Pure value-type projection. Traps if the completion has no
+        /// parent habit — that state should not exist outside
+        /// transient CloudKit sync windows the app does not project from.
+        var snapshot: Completion {
+            Completion(
+                id: id,
+                habitID: habit!.id,
+                date: date,
+                value: value,
+                note: note
+            )
+        }
+    }
+}
+
+typealias CompletionRecord = KadoSchemaV1.CompletionRecord

--- a/Kado/Models/Persistence/HabitRecord.swift
+++ b/Kado/Models/Persistence/HabitRecord.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SwiftData
+
+extension KadoSchemaV1 {
+    /// Persistent representation of a habit. CloudKit-shape: every
+    /// stored property has a default value or is optional, no unique
+    /// constraints, the to-many relationship has an explicit inverse
+    /// with cascade delete.
+    ///
+    /// `Frequency` and `HabitType` are stored as their JSON-encoded
+    /// `Data` blobs (computed accessors do the encode/decode), since
+    /// SwiftData's `@Model` macro currently mishandles composite
+    /// Codable enums as direct stored properties on this toolchain.
+    @Model
+    final class HabitRecord {
+        var id: UUID = UUID()
+        var name: String = ""
+        var frequencyData: Data = Data()
+        var typeData: Data = Data()
+        var createdAt: Date = Date()
+        var archivedAt: Date?
+
+        @Relationship(deleteRule: .cascade, inverse: \CompletionRecord.habit)
+        var completions: [CompletionRecord] = []
+
+        init(
+            id: UUID = UUID(),
+            name: String = "",
+            frequency: Frequency = .daily,
+            type: HabitType = .binary,
+            createdAt: Date = .now,
+            archivedAt: Date? = nil,
+            completions: [CompletionRecord] = []
+        ) {
+            self.id = id
+            self.name = name
+            self.frequencyData = Self.encode(frequency)
+            self.typeData = Self.encode(type)
+            self.createdAt = createdAt
+            self.archivedAt = archivedAt
+            self.completions = completions
+        }
+
+        var frequency: Frequency {
+            get { Self.decode(frequencyData, fallback: .daily) }
+            set { frequencyData = Self.encode(newValue) }
+        }
+
+        var type: HabitType {
+            get { Self.decode(typeData, fallback: .binary) }
+            set { typeData = Self.encode(newValue) }
+        }
+
+        /// Pure value-type projection for the score and frequency
+        /// services (which only know about value types).
+        var snapshot: Habit {
+            Habit(
+                id: id,
+                name: name,
+                frequency: frequency,
+                type: type,
+                createdAt: createdAt,
+                archivedAt: archivedAt
+            )
+        }
+
+        private static func encode<T: Encodable>(_ value: T) -> Data {
+            (try? JSONEncoder().encode(value)) ?? Data()
+        }
+
+        private static func decode<T: Decodable>(_ data: Data, fallback: T) -> T {
+            (try? JSONDecoder().decode(T.self, from: data)) ?? fallback
+        }
+    }
+}
+
+typealias HabitRecord = KadoSchemaV1.HabitRecord

--- a/Kado/Models/Persistence/HabitRecord.swift
+++ b/Kado/Models/Persistence/HabitRecord.swift
@@ -15,8 +15,8 @@ extension KadoSchemaV1 {
     final class HabitRecord {
         var id: UUID = UUID()
         var name: String = ""
-        var frequencyData: Data = Data()
-        var typeData: Data = Data()
+        private var frequencyData: Data = Data()
+        private var typeData: Data = Data()
         var createdAt: Date = Date()
         var archivedAt: Date?
 
@@ -65,10 +65,14 @@ extension KadoSchemaV1 {
         }
 
         private static func encode<T: Encodable>(_ value: T) -> Data {
-            (try? JSONEncoder().encode(value)) ?? Data()
+            // Encoding our own Codable types is unreachable — fail loud
+            // if a future change breaks it.
+            try! JSONEncoder().encode(value)
         }
 
         private static func decode<T: Decodable>(_ data: Data, fallback: T) -> T {
+            // Decode is forgiving: a corrupt on-disk store falls back to
+            // the type's neutral default rather than crashing the app.
             (try? JSONDecoder().decode(T.self, from: data)) ?? fallback
         }
     }

--- a/Kado/Models/Persistence/KadoMigrationPlan.swift
+++ b/Kado/Models/Persistence/KadoMigrationPlan.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftData
+
+/// Migration plan for Kadō's persistent schema. `stages` stays empty
+/// while v1 is the only shipped version; the first real stage lands
+/// alongside `KadoSchemaV2`.
+enum KadoMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [KadoSchemaV1.self]
+    }
+
+    static var stages: [MigrationStage] { [] }
+}

--- a/Kado/Models/Persistence/KadoSchemaV1.swift
+++ b/Kado/Models/Persistence/KadoSchemaV1.swift
@@ -1,0 +1,14 @@
+import Foundation
+import SwiftData
+
+/// Version 1 of Kadō's persistent schema. Subsequent schema versions
+/// (`KadoSchemaV2`, …) live alongside this one — never modify a
+/// shipped version in place; CloudKit treats schema changes as
+/// breaking and migrations rely on the prior version's snapshot.
+enum KadoSchemaV1: VersionedSchema {
+    static let versionIdentifier = Schema.Version(1, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [HabitRecord.self, CompletionRecord.self]
+    }
+}

--- a/Kado/Preview Content/PreviewContainer.swift
+++ b/Kado/Preview Content/PreviewContainer.swift
@@ -1,0 +1,77 @@
+import Foundation
+import SwiftData
+
+/// In-memory `ModelContainer` seeded with a small, realistic habit
+/// set covering each `Frequency` and `HabitType` variant. Use from
+/// SwiftUI previews via `.modelContainer(PreviewContainer.shared)`.
+///
+/// Lives in `Preview Content/` so it ships only with Debug builds.
+@MainActor
+enum PreviewContainer {
+    static let shared: ModelContainer = {
+        do {
+            let container = try ModelContainer(
+                for: HabitRecord.self, CompletionRecord.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+            )
+            seed(container.mainContext)
+            return container
+        } catch {
+            fatalError("Failed to construct preview ModelContainer: \(error)")
+        }
+    }()
+
+    static func seed(_ context: ModelContext) {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: .now)
+
+        let habits: [HabitRecord] = [
+            HabitRecord(
+                name: "Morning meditation",
+                frequency: .daily,
+                type: .binary,
+                createdAt: calendar.date(byAdding: .day, value: -45, to: today)!
+            ),
+            HabitRecord(
+                name: "Gym",
+                frequency: .specificDays([.monday, .wednesday, .friday]),
+                type: .binary,
+                createdAt: calendar.date(byAdding: .day, value: -60, to: today)!
+            ),
+            HabitRecord(
+                name: "Drink water",
+                frequency: .daily,
+                type: .counter(target: 8),
+                createdAt: calendar.date(byAdding: .day, value: -30, to: today)!
+            ),
+            HabitRecord(
+                name: "Read",
+                frequency: .daily,
+                type: .timer(targetSeconds: 1800),
+                createdAt: calendar.date(byAdding: .day, value: -20, to: today)!
+            ),
+            HabitRecord(
+                name: "No social media",
+                frequency: .daily,
+                type: .negative,
+                createdAt: calendar.date(byAdding: .day, value: -14, to: today)!
+            ),
+        ]
+
+        for habit in habits {
+            context.insert(habit)
+            for daysAgo in stride(from: 1, through: 14, by: 2) {
+                let date = calendar.date(byAdding: .day, value: -daysAgo, to: today)!
+                let value: Double = switch habit.type {
+                case .counter: 6
+                case .timer: 1500
+                default: 1
+                }
+                let completion = CompletionRecord(date: date, value: value, habit: habit)
+                context.insert(completion)
+            }
+        }
+
+        try? context.save()
+    }
+}

--- a/Kado/Views/ContentView.swift
+++ b/Kado/Views/ContentView.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 /// Root view of the app. Hosts the primary TabView shell.
@@ -20,4 +21,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .modelContainer(PreviewContainer.shared)
 }

--- a/KadoTests/CompletionRecordTests.swift
+++ b/KadoTests/CompletionRecordTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import Kado
+
+@Suite("CompletionRecord")
+@MainActor
+struct CompletionRecordTests {
+    let container: ModelContainer
+
+    init() throws {
+        container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("Snapshot projects fields and uses the parent's id as habitID")
+    func snapshotUsesParentID() {
+        let habit = HabitRecord(name: "X", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        let completion = CompletionRecord(
+            id: UUID(),
+            date: .now,
+            value: 0.75,
+            note: "test",
+            habit: habit
+        )
+        container.mainContext.insert(completion)
+
+        let snapshot = completion.snapshot
+        #expect(snapshot.id == completion.id)
+        #expect(snapshot.habitID == habit.id)
+        #expect(snapshot.value == 0.75)
+        #expect(snapshot.note == "test")
+    }
+
+    @Test("Default-initialized CompletionRecord has CloudKit-compatible shape")
+    func cloudKitDefaults() {
+        let record = CompletionRecord()
+        #expect(record.value == 1.0)
+        #expect(record.note == nil)
+        #expect(record.habit == nil)
+    }
+}

--- a/KadoTests/FrequencyCodingTests.swift
+++ b/KadoTests/FrequencyCodingTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import Kado
+
+@Suite("Frequency Codable")
+struct FrequencyCodingTests {
+    @Test("Round-trip every Frequency case")
+    func roundTrip() throws {
+        let cases: [Frequency] = [
+            .daily,
+            .daysPerWeek(3),
+            .specificDays([.monday, .wednesday, .friday]),
+            .everyNDays(7),
+        ]
+        for value in cases {
+            let data = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(Frequency.self, from: data)
+            #expect(decoded == value, "round-trip failed for \(value)")
+        }
+    }
+
+    @Test("Canonical JSON shape is stable under sortedKeys")
+    func canonicalShapes() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        let cases: [(Frequency, String)] = [
+            (.daily, #"{"kind":"daily"}"#),
+            (.daysPerWeek(3), #"{"count":3,"kind":"daysPerWeek"}"#),
+            (.specificDays([.monday, .friday]), #"{"days":[2,6],"kind":"specificDays"}"#),
+            (.everyNDays(7), #"{"interval":7,"kind":"everyNDays"}"#),
+        ]
+        for (value, expected) in cases {
+            let data = try encoder.encode(value)
+            let actual = String(data: data, encoding: .utf8) ?? ""
+            #expect(actual == expected, "case \(value): got \(actual)")
+        }
+    }
+
+    @Test("Decoder accepts canonical JSON")
+    func decodesCanonical() throws {
+        let cases: [(String, Frequency)] = [
+            (#"{"kind":"daily"}"#, .daily),
+            (#"{"kind":"daysPerWeek","count":3}"#, .daysPerWeek(3)),
+            (#"{"kind":"specificDays","days":[2,6]}"#, .specificDays([.monday, .friday])),
+            (#"{"kind":"everyNDays","interval":7}"#, .everyNDays(7)),
+        ]
+        for (json, expected) in cases {
+            let data = json.data(using: .utf8)!
+            let decoded = try JSONDecoder().decode(Frequency.self, from: data)
+            #expect(decoded == expected)
+        }
+    }
+
+    @Test("Decoder rejects unknown kind")
+    func unknownKindRejected() {
+        let data = #"{"kind":"weekly"}"#.data(using: .utf8)!
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(Frequency.self, from: data)
+        }
+    }
+
+    @Test("Decoder accepts specificDays in any input order")
+    func specificDaysOrderInsensitive() throws {
+        let json1 = #"{"kind":"specificDays","days":[2,4,6]}"#.data(using: .utf8)!
+        let json2 = #"{"kind":"specificDays","days":[6,2,4]}"#.data(using: .utf8)!
+        let decoded1 = try JSONDecoder().decode(Frequency.self, from: json1)
+        let decoded2 = try JSONDecoder().decode(Frequency.self, from: json2)
+        #expect(decoded1 == decoded2)
+        #expect(decoded1 == .specificDays([.monday, .wednesday, .friday]))
+    }
+}

--- a/KadoTests/HabitRecordTests.swift
+++ b/KadoTests/HabitRecordTests.swift
@@ -1,0 +1,94 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import Kado
+
+@Suite("HabitRecord")
+@MainActor
+struct HabitRecordTests {
+    let container: ModelContainer
+
+    init() throws {
+        container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("Snapshot projects all fields back to a value-type Habit")
+    func snapshotProjection() {
+        let id = UUID()
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let record = HabitRecord(
+            id: id,
+            name: "Run",
+            frequency: .specificDays([.monday, .friday]),
+            type: .counter(target: 5),
+            createdAt: createdAt
+        )
+        container.mainContext.insert(record)
+
+        let expected = Habit(
+            id: id,
+            name: "Run",
+            frequency: .specificDays([.monday, .friday]),
+            type: .counter(target: 5),
+            createdAt: createdAt
+        )
+        #expect(record.snapshot == expected)
+    }
+
+    @Test("frequency setter round-trips through the JSON-Data backing")
+    func frequencyRoundTrip() {
+        let record = HabitRecord(frequency: .everyNDays(3))
+        #expect(record.frequency == .everyNDays(3))
+        record.frequency = .daysPerWeek(5)
+        #expect(record.frequency == .daysPerWeek(5))
+    }
+
+    @Test("type setter round-trips through the JSON-Data backing")
+    func typeRoundTrip() {
+        let record = HabitRecord(type: .counter(target: 8))
+        #expect(record.type == .counter(target: 8))
+        record.type = .timer(targetSeconds: 1800)
+        #expect(record.type == .timer(targetSeconds: 1800))
+    }
+
+    @Test("Default-initialized HabitRecord has CloudKit-compatible shape")
+    func cloudKitDefaults() {
+        let record = HabitRecord()
+        #expect(record.name == "")
+        #expect(record.frequency == .daily)
+        #expect(record.type == .binary)
+        #expect(record.archivedAt == nil)
+        #expect(record.completions.isEmpty)
+    }
+
+    @Test("Cascade delete removes child completions from the context")
+    func cascadeDelete() throws {
+        let habit = HabitRecord(name: "Stretch", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        let completion = CompletionRecord(date: .now, value: 1, habit: habit)
+        container.mainContext.insert(completion)
+        try container.mainContext.save()
+
+        container.mainContext.delete(habit)
+        try container.mainContext.save()
+
+        let remaining = try container.mainContext.fetch(FetchDescriptor<CompletionRecord>())
+        #expect(remaining.isEmpty)
+    }
+
+    @Test("Setting completion.habit populates habit.completions (inverse)")
+    func inverseRelationship() throws {
+        let habit = HabitRecord(name: "Read", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        let completion = CompletionRecord(date: .now, value: 1)
+        container.mainContext.insert(completion)
+        completion.habit = habit
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 1)
+        #expect(habit.completions.first?.id == completion.id)
+    }
+}

--- a/KadoTests/HabitTypeCodingTests.swift
+++ b/KadoTests/HabitTypeCodingTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import Kado
+
+@Suite("HabitType Codable")
+struct HabitTypeCodingTests {
+    @Test("Round-trip every HabitType case")
+    func roundTrip() throws {
+        let cases: [HabitType] = [
+            .binary,
+            .counter(target: 8),
+            .timer(targetSeconds: 1800),
+            .negative,
+        ]
+        for value in cases {
+            let data = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(HabitType.self, from: data)
+            #expect(decoded == value, "round-trip failed for \(value)")
+        }
+    }
+
+    @Test("Canonical JSON shape is stable under sortedKeys")
+    func canonicalShapes() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        let cases: [(HabitType, String)] = [
+            (.binary, #"{"kind":"binary"}"#),
+            (.counter(target: 8), #"{"kind":"counter","target":8}"#),
+            (.timer(targetSeconds: 1800), #"{"kind":"timer","targetSeconds":1800}"#),
+            (.negative, #"{"kind":"negative"}"#),
+        ]
+        for (value, expected) in cases {
+            let data = try encoder.encode(value)
+            let actual = String(data: data, encoding: .utf8) ?? ""
+            #expect(actual == expected, "case \(value): got \(actual)")
+        }
+    }
+
+    @Test("Decoder accepts canonical JSON")
+    func decodesCanonical() throws {
+        let cases: [(String, HabitType)] = [
+            (#"{"kind":"binary"}"#, .binary),
+            (#"{"kind":"counter","target":8}"#, .counter(target: 8)),
+            (#"{"kind":"timer","targetSeconds":1800}"#, .timer(targetSeconds: 1800)),
+            (#"{"kind":"negative"}"#, .negative),
+        ]
+        for (json, expected) in cases {
+            let data = json.data(using: .utf8)!
+            let decoded = try JSONDecoder().decode(HabitType.self, from: data)
+            #expect(decoded == expected)
+        }
+    }
+
+    @Test("Decoder rejects unknown kind")
+    func unknownKindRejected() {
+        let data = #"{"kind":"checklist"}"#.data(using: .utf8)!
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(HabitType.self, from: data)
+        }
+    }
+}

--- a/KadoTests/KadoSchemaTests.swift
+++ b/KadoTests/KadoSchemaTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import Kado
+
+@Suite("KadoSchemaV1 + KadoMigrationPlan")
+@MainActor
+struct KadoSchemaTests {
+    @Test("Schema version identifier is 1.0.0")
+    func schemaVersion() {
+        #expect(KadoSchemaV1.versionIdentifier == Schema.Version(1, 0, 0))
+    }
+
+    @Test("Schema declares HabitRecord and CompletionRecord")
+    func schemaModels() {
+        let modelTypes = KadoSchemaV1.models
+        #expect(modelTypes.contains { $0 == HabitRecord.self })
+        #expect(modelTypes.contains { $0 == CompletionRecord.self })
+    }
+
+    @Test("Migration plan declares v1 with empty stages")
+    func migrationPlanShape() {
+        #expect(KadoMigrationPlan.stages.isEmpty)
+        #expect(KadoMigrationPlan.schemas.count == 1)
+    }
+
+    @Test("In-memory ModelContainer constructs from the migration plan")
+    func containerBuildsFromPlan() throws {
+        let schema = Schema(versionedSchema: KadoSchemaV1.self)
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: KadoMigrationPlan.self,
+            configurations: ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        )
+        // Smoke test: the main context exists and accepts inserts.
+        let habit = HabitRecord(name: "Smoke")
+        container.mainContext.insert(habit)
+        try container.mainContext.save()
+        let fetched = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
+        #expect(fetched.count == 1)
+    }
+}

--- a/KadoTests/PreviewContainerTests.swift
+++ b/KadoTests/PreviewContainerTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import Kado
+
+@Suite("PreviewContainer seeding")
+@MainActor
+struct PreviewContainerTests {
+    @Test("Seeds five habits covering each frequency and type")
+    func seededShape() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        PreviewContainer.seed(container.mainContext)
+
+        let habits = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
+        #expect(habits.count == 5)
+
+        let frequencies = Set(habits.map(\.frequency))
+        #expect(frequencies.contains(.daily))
+        #expect(frequencies.contains { freq in
+            if case .specificDays = freq { return true } else { return false }
+        })
+
+        let types = Set(habits.map(\.type))
+        #expect(types.contains(.binary))
+        #expect(types.contains(.negative))
+        #expect(types.contains { type in
+            if case .counter = type { return true } else { return false }
+        })
+        #expect(types.contains { type in
+            if case .timer = type { return true } else { return false }
+        })
+
+        let completions = try container.mainContext.fetch(FetchDescriptor<CompletionRecord>())
+        #expect(completions.count == 5 * 7) // 5 habits × 7 sample completions each
+    }
+}

--- a/docs/plans/2026-04/swiftdata-models/compound.md
+++ b/docs/plans/2026-04/swiftdata-models/compound.md
@@ -1,0 +1,221 @@
+# Compound — SwiftData persistence layer
+
+**Date**: 2026-04-16
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [feature/swiftdata-models](https://github.com/scastiel/kado/pull/3)
+
+## Summary
+
+Shipped the `KadoSchemaV1` SwiftData layer: `HabitRecord` /
+`CompletionRecord` `@Model`s wrapping the existing value types,
+`KadoMigrationPlan` with empty stages, `ModelContainer` wired into
+`KadoApp`, and a seeded in-memory `PreviewContainer`. CloudKit-shape
+compliance from day one; actual CloudKit wiring deferred. **Headline
+lesson: research's recommended path (native Codable enum storage on
+`@Model`) crashes `ModelContainer.init` at runtime on this toolchain
+— the JSON-Data backing fallback works but doubles the value of the
+custom `Codable` we ship.**
+
+## Decisions made
+
+- **`HabitRecord` (`@Model`) wraps `Habit` (struct)**: separate
+  persistence and domain concerns. The score / frequency services
+  stay struct-based and unit-testable without a `ModelContainer`.
+- **Top-level `typealias HabitRecord = KadoSchemaV1.HabitRecord`**:
+  ergonomic call sites; schema-namespace stays explicit only in
+  migration code.
+- **Custom `Codable` with discriminator JSON**: `{"kind":"daily"}`,
+  `{"kind":"counter","target":8}`, etc. Stable across compiler
+  upgrades; locked in via canonical-shape tests.
+- **`nonisolated enum` for value types with Codable conformance**:
+  the bootstrap project sets
+  `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`, which would otherwise
+  push the synthesized conformances to MainActor and warn from
+  off-MainActor tests.
+- **`@Relationship(deleteRule: .cascade, inverse:
+  \CompletionRecord.habit)`**: explicit inverse on the parent side,
+  no attribute on the child side (Apple's documented pattern).
+- **`snapshot` is read-only**: no setter. Mutation goes through the
+  `@Model` class's own properties.
+- **`ModelContainer` wired via `.modelContainer(_:)` modifier** on
+  `KadoApp` — no `PersistenceController` wrapper. Failure to
+  construct is `fatalError` (the app can't recover).
+- **JSON-encoded `Data` blobs for `Frequency` and `HabitType`**
+  (forced by SwiftData rough edge — see surprise below). Backed by
+  `private` properties; computed `var frequency`/`var type` exposes
+  the typed value.
+- **Encode helper `try!`, decode helper `try? ?? fallback`**:
+  encoding our own Codable types is unreachable (fail loud);
+  decoding from disk can hit corruption (fall back to neutral
+  default).
+- **CloudKit deferred** to its own PR — but the `@Model` shape is
+  CloudKit-ready (every property has a default or is optional, no
+  unique constraints, the to-many relationship has an explicit
+  inverse, no `Deny` delete rule).
+- **`KadoMigrationPlan.stages = []`** until v2 schema lands. Empty
+  is correct — the first `MigrationStage.lightweight(...)` example
+  comes with KadoSchemaV2.
+- **PR is invisible in the running app**: this is plumbing only. No
+  view consumes the data yet. Today/Settings stay
+  `ContentUnavailableView` placeholders. v0.1 view PRs surface the
+  data.
+
+## Surprises and how we handled them
+
+### Native Codable enum storage on `@Model` crashes `ModelContainer.init`
+
+- **What happened**: Following research's recommendation, declared
+  `var frequency: Frequency = .daily` as a stored property on
+  `HabitRecord`. Build was clean, but every test using
+  `ModelContainer(for: HabitRecord.self, ...)` crashed at
+  container-init time. Tried optional storage (`Frequency? = nil`) —
+  same crash. Tried both-no-default — same crash. The crash happens
+  the moment a Codable composite enum is declared as a stored property,
+  regardless of the default.
+- **What we did**: Bisected by stripping `HabitRecord` to
+  `id + name + createdAt`, confirmed it built and tested clean, then
+  added fields back one at a time. The exact moment of breakage:
+  adding the `frequency: Frequency` property. Switched to
+  research's Alternative C: store as JSON-encoded `Data` blob with
+  computed accessors. Custom `Codable` from Task 1 now backs both
+  the on-disk format AND the schema property — earning its keep
+  twice.
+- **Lesson**: Research helpers can be wrong about toolchain-specific
+  behavior. The Hacking with Swift / Fatbobman articles cited say
+  native Codable storage works; reality on Xcode 26 / iOS 18.4 (this
+  bootstrap) says otherwise. **Always verify load-bearing claims
+  with a smoke test before committing the design.** A 2-minute
+  experiment up front would have saved a 15-minute mid-build pivot.
+
+### Swift 6 main-actor isolation warnings on Codable conformance
+
+- **What happened**: After custom `Codable` landed on `Frequency` and
+  `HabitType`, the test target produced 17 warnings of the form
+  `main actor-isolated conformance of 'Frequency' to 'Encodable'
+  cannot be used in nonisolated context`. CLAUDE.md's "definition of
+  done" forbids new warnings.
+- **What we did**: Traced the cause to the bootstrap project's
+  `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` setting (Xcode 26's
+  "approachable concurrency" default), which propagates MainActor
+  isolation to every type. Codable conformances inherit it; tests
+  off-MainActor warn. Fixed by marking the enums `nonisolated enum
+  Frequency` — one keyword cleared all 17.
+- **Lesson**: When Swift 6 isolation warnings appear on a value type,
+  the fix is `nonisolated` on the type declaration. Worth promoting
+  to CLAUDE.md alongside the existing `Calendar` / dependency-injection
+  conventions.
+
+### `@Model` macro accepts `private` stored properties
+
+- **What happened**: PR #3 review flagged `frequencyData`/`typeData`
+  as unnecessarily public. Wasn't sure whether SwiftData's `@Model`
+  macro would accept `private` on stored properties.
+- **What we did**: Tried it. Worked first time — 59/59 tests still
+  pass.
+- **Lesson**: Default to `private` for backing storage of computed
+  accessors on `@Model` classes. The macro doesn't fight it.
+
+## What worked well
+
+- **TDD on Codable shapes**: round-trip tests + canonical-shape
+  assertions caught the synthesized format mismatch (`{"daily":{}}`
+  vs `{"kind":"daily"}`) before any custom impl ran. The custom
+  encoder went green on the first pass against red tests.
+- **Bisection technique for opaque SwiftData crashes**: stripping
+  `HabitRecord` to bare minimum and adding fields back one at a time
+  converged to the cause in five iterations. Faster than reading any
+  amount of SwiftData documentation would have been.
+- **Research stage before plan**: the four pre-plan questions
+  (typealias, controller wrapper, preview seed, CloudKit deferral)
+  were settled before any code. Zero rework on naming or wiring
+  shape during build.
+- **Per-task in-memory `ModelContainer` in test `init()`**: complete
+  isolation, no shared state. Swift Testing's per-instance
+  parallelism comes for free. Did require `@MainActor` on the suite
+  struct, which was painless.
+- **Chaining the score-calc PR's nonisolated/Calendar lessons**: the
+  `nonisolated enum` fix was instinctive because PR #2's compound
+  had already promoted similar concurrency rules.
+
+## For the next person
+
+- `HabitRecord` has **two storage layers** for `Frequency` /
+  `HabitType`: the `private` JSON-Data blob and the public computed
+  accessor. Don't try to "simplify" by removing the Data layer — it
+  exists because SwiftData on this toolchain crashes on direct
+  composite-Codable storage. Re-test before changing.
+- `snapshot` decodes JSON on every call (~2 allocations per habit,
+  per render). Fine for v0.1 (≤50 habits). When the Today view feels
+  sluggish, cache `snapshot` (or skip it and pass `HabitRecord`
+  through a small protocol).
+- `KadoApp.container` is built **eagerly at App init** — file-backed
+  store, no in-memory. **Don't preview `KadoApp` directly** in
+  Xcode; preview individual views with
+  `.modelContainer(PreviewContainer.shared)`.
+- Adding a new `@Model`: edit `KadoSchemaV1.models` array, add the
+  type to in-memory test containers (`HabitRecordTests`,
+  `CompletionRecordTests`, `KadoSchemaTests`,
+  `PreviewContainerTests`).
+- When v2 schema lands: copy v1's models into a `KadoSchemaV2`
+  namespace, append a `MigrationStage.lightweight(...)` (or
+  `.custom`), append `KadoSchemaV2.self` to
+  `KadoMigrationPlan.schemas`. Update the typealiases at the bottom
+  of the record files to point at v2.
+- The PR is **invisible in the simulator** — verifying wiring means
+  launching the app and confirming it doesn't crash, plus running
+  tests. Visual changes start with v0.1 view PRs.
+- The 4 semantic decisions from PR #2 (rolling 7-day window,
+  off-schedule completions ignored, current frequency retroactive,
+  negative habit = presence-not-value) carry forward — they live in
+  the score calculator and `FrequencyEvaluator`, both of which
+  consume `snapshot` outputs unchanged.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** When the project's
+  `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` would otherwise push a
+  domain value type's conformances to MainActor (causing warnings
+  from off-MainActor tests), mark the type `nonisolated enum X`
+  (or `nonisolated struct X`). Apply when adding `Codable` to a
+  domain type.
+- **[→ CLAUDE.md]** SwiftData on Xcode 26 / iOS 18 does not reliably
+  support composite `Codable` enums (associated values) as direct
+  stored properties on `@Model` — `ModelContainer.init` crashes at
+  runtime even though build is clean. Workaround: store as
+  `Data` (private), expose as a computed property with explicit
+  encode/decode. Document as the canonical pattern for now;
+  re-evaluate when Apple fixes it.
+- **[→ CLAUDE.md]** When a research helper's claim is load-bearing
+  for a design decision (e.g. "this storage shape works"), verify
+  with a 2-minute smoke test before committing the design. Saves
+  mid-build pivots.
+- **[local]** The bisection technique for opaque SwiftData crashes:
+  strip `@Model` to `id` + one trivial property, add back one
+  property at a time, find the breakage. Beats reading the SwiftData
+  source.
+- **[ROADMAP, v0.2]** Schema caching for `snapshot`: when the Today
+  view scales past 50 habits, `record.snapshot` becoming a hot path
+  is the most likely first perf regression. Profile before
+  optimizing.
+
+## Metrics
+
+- Tasks completed: 4 of 4
+- Tests added: 22 (FrequencyCoding 5, HabitTypeCoding 4,
+  HabitRecord 6, CompletionRecord 2, KadoSchema 4, PreviewContainer 1)
+- Commits on branch: 7 (research, plan, 4 build, 1 review-fix)
+- Files added: 5 source + 6 test + 3 docs
+- Net diff: +1,177 / -2 across 17 files
+- Plan revisions during build: 1 (Task 2 storage strategy pivot)
+- Mid-build pivots: 1 (native Codable → JSON-Data backing)
+- Build time (incremental): ~3-5s; test suite: ~6s
+
+## References
+
+- [SwiftData VersionedSchema](https://developer.apple.com/documentation/swiftdata/versionedschema)
+- [SwiftData SchemaMigrationPlan](https://developer.apple.com/documentation/swiftdata/schemamigrationplan)
+- [Fatbobman — Codable + enums in SwiftData (the article that overstated native support)](https://fatbobman.com/en/posts/considerations-for-using-codable-and-enums-in-swiftdata-models/)
+- [Fatbobman — CloudKit-ready model rules (accurate)](https://fatbobman.com/en/snippet/rules-for-adapting-data-models-to-cloudkit/)
+- [PR #2 compound](../habit-score-calculator/compound.md) — the score-calculator-side context this PR plugs into.

--- a/docs/plans/2026-04/swiftdata-models/plan.md
+++ b/docs/plans/2026-04/swiftdata-models/plan.md
@@ -110,7 +110,7 @@ persisted stores.
 
 ---
 
-### Task 3: KadoMigrationPlan + ModelContainer wiring in KadoApp
+### Task 3: KadoMigrationPlan + ModelContainer wiring in KadoApp ✅
 
 **Goal**: Persistence is live in the running app; container construction
 is exercised by tests.

--- a/docs/plans/2026-04/swiftdata-models/plan.md
+++ b/docs/plans/2026-04/swiftdata-models/plan.md
@@ -47,7 +47,7 @@ compiler upgrades.
 
 ## Task list
 
-### Task 1: Custom Codable for Frequency and HabitType
+### Task 1: Custom Codable for Frequency and HabitType ✅
 
 **Goal**: Own the on-disk JSON format for both enums; canonical-shape
 tests pin the bytes so a compiler upgrade can't silently break
@@ -183,6 +183,17 @@ is exercised by tests.
 ## Open questions
 
 None at plan time — all four resolved during research.
+
+## Notes during build
+
+- **Task 1**: The project bootstrap set
+  `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (Xcode 26's
+  "approachable concurrency" default), so newly-introduced Codable
+  conformances inherit MainActor isolation and warn when used from
+  off-MainActor tests. Fixed by marking the value-type enums
+  `nonisolated` (`nonisolated enum Frequency`). Likely to need the
+  same on `Habit`/`Completion`/`Weekday`/`DailyScore` if/when they
+  become cross-actor — flag for compound.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/swiftdata-models/plan.md
+++ b/docs/plans/2026-04/swiftdata-models/plan.md
@@ -79,7 +79,7 @@ persisted stores.
 
 ---
 
-### Task 2: KadoSchemaV1 + HabitRecord + CompletionRecord
+### Task 2: KadoSchemaV1 + HabitRecord + CompletionRecord ✅
 
 **Goal**: The `@Model` layer with bidirectional relationship and
 `snapshot` projection back to value types.
@@ -194,6 +194,20 @@ None at plan time — all four resolved during research.
   `nonisolated` (`nonisolated enum Frequency`). Likely to need the
   same on `Habit`/`Completion`/`Weekday`/`DailyScore` if/when they
   become cross-actor — flag for compound.
+- **Task 2**: Research's recommended path (native Codable enum
+  storage on `@Model`) crashed `ModelContainer.init` at runtime on
+  Xcode 26 / iOS 18.4 — both with property-level defaults
+  (`var frequency: Frequency = .daily`) and with optional storage
+  (`var frequency: Frequency? = nil`). Bisected by stripping fields
+  to bare minimum and adding back; the moment a `Frequency`/`HabitType`
+  property is declared on the `@Model`, container creation crashes.
+  Build itself stays clean — purely a runtime schema-init issue.
+  Fell back to research's Alternative C (JSON-encoded `Data` blob +
+  computed `var frequency: Frequency` accessor). Boilerplate cost
+  acceptable; the custom `Codable` from Task 1 carries its weight
+  twice now (on-disk format AND backing for the computed accessor).
+  Worth a note in compound — research's source claimed native
+  Codable storage works; reality on this toolchain says otherwise.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/swiftdata-models/plan.md
+++ b/docs/plans/2026-04/swiftdata-models/plan.md
@@ -1,0 +1,202 @@
+# Plan — SwiftData persistence layer
+
+**Date**: 2026-04-16
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Wrap the existing `Habit` / `Completion` value types with `@Model`
+classes (`HabitRecord`, `CompletionRecord`) inside a `KadoSchemaV1`
+namespace, register a `KadoMigrationPlan` from day one, and wire the
+`ModelContainer` into `KadoApp` via SwiftUI's `.modelContainer(_:)`
+modifier. CloudKit-shape compliance from the first commit (defaults,
+optional relationships, no unique constraints), but no actual
+CloudKit wiring — that's a follow-up PR. Custom `Codable` for
+`Frequency` and `HabitType` so we own the on-disk format and survive
+compiler upgrades.
+
+## Decisions locked in
+
+- **Naming**: `Habit` (struct) + `KadoSchemaV1.HabitRecord` (`@Model`),
+  with top-level `typealias HabitRecord = KadoSchemaV1.HabitRecord`
+  for ergonomic call sites.
+- **TDD strict**: Codable round-trips and projection logic tested
+  before implementation. Schema construction tested via in-memory
+  `ModelContainer`.
+- **Relationships**: `HabitRecord.completions` → `[CompletionRecord]`
+  with `@Relationship(deleteRule: .cascade, inverse: \…habit)`.
+  `CompletionRecord.habit: HabitRecord?` (nilable per CloudKit).
+- **Custom Codable shape**: discriminator-based JSON, e.g.
+  `{"kind":"daysPerWeek","count":3}`. Explicit and human-readable;
+  one canonical-shape test per case to catch silent compiler regressions.
+- **In-memory `ModelContainer` for previews and tests** via
+  `ModelConfiguration(isStoredInMemoryOnly: true)`. No
+  `PersistenceController` wrapper — `.modelContainer(_:)` modifier
+  on `KadoApp` is enough.
+- **Schema version identifier**: semver, `Schema.Version(1, 0, 0)`.
+  Bump major when a `MigrationStage` is added.
+- **CloudKit deferred**: no `cloudKitDatabase:` in `ModelConfiguration`
+  this PR. Container ID will be `iCloud.dev.scastiel.kado` when wired.
+- **`snapshot` is read-only**: no setter. New records are constructed
+  via `init(...)` directly; mutation goes through the `@Model` class's
+  own properties.
+- **One Codable per type, in the same file as the enum.** The custom
+  `Codable` lives in `Frequency.swift` / `HabitType.swift`, not in a
+  separate `Models/Persistence/` folder.
+
+## Task list
+
+### Task 1: Custom Codable for Frequency and HabitType
+
+**Goal**: Own the on-disk JSON format for both enums; canonical-shape
+tests pin the bytes so a compiler upgrade can't silently break
+persisted stores.
+
+**Changes**:
+- `Kado/Models/Frequency.swift` — replace synthesized Codable with
+  explicit `init(from:)` / `encode(to:)` using a `kind` discriminator.
+- `Kado/Models/HabitType.swift` — same pattern.
+- `KadoTests/FrequencyCodingTests.swift` — written first.
+- `KadoTests/HabitTypeCodingTests.swift` — written first.
+
+**Tests / verification**:
+- Round-trip every case (encode → decode → equal).
+- Canonical-shape assertion per case, e.g.:
+  - `.daily` ↔ `{"kind":"daily"}`
+  - `.daysPerWeek(3)` ↔ `{"kind":"daysPerWeek","count":3}`
+  - `.specificDays([.monday, .friday])` ↔ `{"kind":"specificDays","days":[2,6]}`
+  - `.everyNDays(7)` ↔ `{"kind":"everyNDays","interval":7}`
+  - `.binary` ↔ `{"kind":"binary"}`
+  - `.counter(target: 8)` ↔ `{"kind":"counter","target":8}`
+  - `.timer(targetSeconds: 1800)` ↔ `{"kind":"timer","targetSeconds":1800}`
+  - `.negative` ↔ `{"kind":"negative"}`
+- Decode rejects unknown `kind` with a `DecodingError`.
+- `.specificDays` decodes a serialized day-set order-independently
+  (it's a `Set`, not an `Array`).
+
+**Commit**: `feat(models): own Codable shape for Frequency and HabitType`
+
+---
+
+### Task 2: KadoSchemaV1 + HabitRecord + CompletionRecord
+
+**Goal**: The `@Model` layer with bidirectional relationship and
+`snapshot` projection back to value types.
+
+**Changes**:
+- `Kado/Models/Persistence/KadoSchemaV1.swift` — `enum KadoSchemaV1:
+  VersionedSchema` declaring `versionIdentifier` and `models`.
+- `Kado/Models/Persistence/HabitRecord.swift` — `@Model final class`
+  inside `KadoSchemaV1`, all properties with defaults, `snapshot:
+  Habit` computed property, top-level `typealias HabitRecord =
+  KadoSchemaV1.HabitRecord`.
+- `Kado/Models/Persistence/CompletionRecord.swift` — same shape, with
+  `var habit: HabitRecord?` inverse, `snapshot: Completion`.
+- `KadoTests/HabitRecordTests.swift`, `KadoTests/CompletionRecordTests.swift`.
+
+**Tests / verification** (in-memory `ModelContainer` per test):
+- `HabitRecord(...)` round-trips through `snapshot` to an equal
+  `Habit` value.
+- `CompletionRecord(...)` likewise; `habitID` in the snapshot matches
+  the parent's `id`.
+- Setting `record.habit = h` populates `h.completions` (inverse works).
+- Cascade delete: deleting a `HabitRecord` removes its
+  `CompletionRecord`s from the context.
+- All defaults are CloudKit-compatible: every property has a default
+  value or is optional (verified by constructing with no args).
+
+**Commit**: `feat(persistence): add HabitRecord and CompletionRecord under KadoSchemaV1`
+
+---
+
+### Task 3: KadoMigrationPlan + ModelContainer wiring in KadoApp
+
+**Goal**: Persistence is live in the running app; container construction
+is exercised by tests.
+
+**Changes**:
+- `Kado/Models/Persistence/KadoMigrationPlan.swift` — `enum
+  KadoMigrationPlan: SchemaMigrationPlan` with `schemas =
+  [KadoSchemaV1.self]`, `stages = []`.
+- `Kado/App/KadoApp.swift` — apply `.modelContainer(...)` modifier on
+  `WindowGroup`. Use a top-level helper to build the live container
+  with `KadoSchemaV1` + `KadoMigrationPlan`.
+- `KadoTests/KadoSchemaTests.swift` — written first.
+
+**Tests / verification**:
+- `KadoSchemaV1.versionIdentifier == Schema.Version(1, 0, 0)`.
+- An in-memory `ModelContainer(for: KadoSchemaV1.self, …)` builds
+  without throwing.
+- `KadoMigrationPlan.stages.isEmpty` (sanity check until v2 lands).
+- App still builds and launches (`build_sim` clean, smoke test passes).
+
+**Commit**: `feat(persistence): wire ModelContainer into KadoApp with KadoMigrationPlan`
+
+---
+
+### Task 4: Preview seed helper
+
+**Goal**: SwiftUI previews and tests can spin up an in-memory
+`ModelContainer` populated with a small, realistic habit set.
+
+**Changes**:
+- `Kado/Preview Content/PreviewContainer.swift` — static factory
+  returning a `ModelContainer` (in-memory) seeded with 3-5 sample
+  habits covering each `Frequency` and `HabitType` variant, plus a
+  handful of completions per habit.
+- One preview added to `ContentView.swift` consuming the seeded
+  container so the existing placeholder is no longer empty in the
+  Xcode preview.
+
+**Tests / verification**:
+- `PreviewContainer.shared` (or whatever the API is) yields a
+  container whose main context contains the expected number of
+  records.
+- `build_sim` passes (preview content can compile under Debug).
+
+**Commit**: `feat(preview): seed an in-memory ModelContainer with sample habits`
+
+## Risks and mitigation
+
+- **Risk**: SwiftData inverse-relationship `KeyPath` syntax is
+  finicky. → **Mitigation**: follow Apple's documented exact pattern;
+  test that setting `record.habit = h` populates `h.completions`
+  before declaring Task 2 done.
+- **Risk**: Custom `Codable` test shape too strict — adding a future
+  enum case requires updating the canonical-shape test suite. →
+  **Mitigation**: this is a feature, not a bug. Schema changes
+  *should* require touching these tests; that's how we catch silent
+  drift.
+- **Risk**: `@Model` test ergonomics with `@MainActor` slow the suite
+  down. → **Mitigation**: each test gets its own in-memory container
+  in `init()`; no shared state. Swift Testing's `@Suite` parallelizes
+  per-instance so isolation is free.
+- **Risk**: Naming collision — `HabitRecord` typealias might clash
+  with an Apple framework type. → **Mitigation**: confirmed no
+  conflict in iOS SDK at research time. Worst case: rename later.
+- **Risk**: Xcode Previews crash on delete with associated-value enum
+  models (known SwiftData bug). → **Mitigation**: previews use
+  in-memory containers and never trigger delete operations. Tests use
+  the same path.
+
+## Open questions
+
+None at plan time — all four resolved during research.
+
+## Out of scope
+
+- **CloudKit wiring**: no `cloudKitDatabase:` parameter, no
+  entitlements file edits, no iCloud account UI. Separate PR.
+- **`@Query`-based view code**: no view fetches `[HabitRecord]` in
+  this PR. The existing `ContentView` placeholder stays. v0.1 view
+  PRs (Today, Detail, New Habit) consume the container.
+- **Habit / Completion CRUD service**: no `HabitStore` or
+  `CompletionStore` yet. Direct `ModelContext` use is fine for the
+  view PRs to start; we extract a service if/when patterns repeat.
+- **Migration to v2**: empty `stages` list. We'll write the first
+  `MigrationStage.lightweight(...)` example when the first schema
+  evolution lands.
+- **JSON export/import**: separate PR (v0.2 per ROADMAP). The custom
+  `Codable` we own here is for SwiftData persistence; export will
+  layer a versioned schema on top.

--- a/docs/plans/2026-04/swiftdata-models/plan.md
+++ b/docs/plans/2026-04/swiftdata-models/plan.md
@@ -1,7 +1,7 @@
 # Plan — SwiftData persistence layer
 
 **Date**: 2026-04-16
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -135,7 +135,7 @@ is exercised by tests.
 
 ---
 
-### Task 4: Preview seed helper
+### Task 4: Preview seed helper ✅
 
 **Goal**: SwiftUI previews and tests can spin up an in-memory
 `ModelContainer` populated with a small, realistic habit set.

--- a/docs/plans/2026-04/swiftdata-models/research.md
+++ b/docs/plans/2026-04/swiftdata-models/research.md
@@ -1,0 +1,257 @@
+# Research — SwiftData persistence layer
+
+**Date**: 2026-04-16
+**Status**: ready for plan
+**Related**:
+- [docs/ROADMAP.md](../../../ROADMAP.md) v0.1 § Data and domain
+- [docs/plans/2026-04/habit-score-calculator/compound.md](../habit-score-calculator/compound.md) — locked in "value types now, SwiftData wrapper next PR"
+- [Kado/Models/](../../../../Kado/Models/) — existing value-type structs
+
+## Problem
+
+The score and frequency services already operate on plain
+value-type `Habit` and `Completion` structs. We have no persistence:
+quitting the app loses everything. v0.1 needs SwiftData-backed storage
+that survives launches, plays nicely with CloudKit when iCloud sync
+lands later in v0.1, and supports `VersionedSchema` migrations
+**from the first commit** (per `CLAUDE.md`'s SwiftData section).
+
+The goal of this PR: ship a fully-tested persistence layer that the
+v0.1 Today / Detail / New-Habit views can fetch from. CloudKit
+configuration itself (entitlements, container, sync-state UI) is a
+separate follow-up — but the schema must be CloudKit-compatible from
+day one, because retrofitting CloudKit constraints onto a shipped
+schema is data-loss-prone.
+
+## Current state of the codebase
+
+- `Kado/Models/Habit.swift`, `Completion.swift`, `Frequency.swift`,
+  `HabitType.swift`, `Weekday.swift`, `DailyScore.swift` — all value
+  types, all `Codable`, `Hashable`, `Sendable`. Habit/Completion now
+  hash by `id` only (per PR #2 review).
+- `Kado/Services/DefaultHabitScoreCalculator.swift` and
+  `DefaultFrequencyEvaluator.swift` consume those value types and
+  inject a `Calendar`. They do not import SwiftData.
+- `Kado/App/KadoApp.swift` — TabView shell, no `ModelContainer`.
+- `Kado/App/EnvironmentValues+Services.swift` — `habitScoreCalculator`
+  is the only registered service so far.
+- No `@Model` classes exist. No `Schema`, no `ModelContainer`, no
+  `Persistence/` subfolder.
+- Bundle ID is `dev.scastiel.kado` (per project-bootstrap compound).
+  CloudKit container will therefore be `iCloud.dev.scastiel.kado`.
+
+## Proposed approach
+
+A separate `@Model` class layer that **wraps** the value types,
+projects to them on read, and lives inside a `KadoSchemaV1` namespace
+from commit one. The score/frequency services stay purely
+struct-based and remain unit-testable without a `ModelContainer`.
+
+### Naming convention
+
+- `Habit`, `Completion` (structs) — domain value types, unchanged.
+- `KadoSchemaV1.HabitRecord`, `KadoSchemaV1.CompletionRecord`
+  (`@Model` classes) — persistence layer.
+- Top-level `typealias HabitRecord = KadoSchemaV1.HabitRecord` so
+  call sites read clean. When v2 ships, the typealias points to v2.
+
+The "Record" suffix mirrors common Swift conventions (CKRecord,
+RecordValue) and makes the value-type / persistence-type split
+unambiguous at every call site.
+
+### Key components
+
+- **`KadoSchemaV1`** (`enum`, `: VersionedSchema`) — declares
+  `versionIdentifier = .init(1, 0, 0)` and `models = [HabitRecord.self,
+  CompletionRecord.self]`.
+- **`KadoMigrationPlan`** (`enum`, `: SchemaMigrationPlan`) —
+  `schemas = [KadoSchemaV1.self]`, `stages = []`. v2 will append.
+- **`HabitRecord`** (`@Model final class`) — id, name, frequency,
+  type, createdAt, archivedAt, `@Relationship(deleteRule: .cascade,
+  inverse: \CompletionRecord.habit) var completions = []`.
+- **`CompletionRecord`** (`@Model final class`) — id, date, value,
+  note, `var habit: HabitRecord?` (the inverse).
+- **`snapshot: Habit` / `snapshot: Completion`** computed properties
+  on each Record — pure projection, no business logic.
+- **`PersistenceController`** struct — owns the `ModelContainer`,
+  exposes a `mainContext: ModelContext`, plus an `inMemory()` factory
+  for previews and tests.
+- **`ModelContainer` injection** via SwiftUI `Environment` (already
+  the project's DI pattern). `KadoApp` builds the live container,
+  views fetch via `@Query` or via service methods.
+
+### Data model details
+
+```swift
+enum KadoSchemaV1: VersionedSchema {
+    static let versionIdentifier = Schema.Version(1, 0, 0)
+    static var models: [any PersistentModel.Type] {
+        [HabitRecord.self, CompletionRecord.self]
+    }
+}
+
+@Model final class HabitRecord {
+    var id: UUID = UUID()
+    var name: String = ""
+    var frequency: Frequency = .daily   // Codable enum — see below
+    var type: HabitType = .binary       // Codable enum — see below
+    var createdAt: Date = .now
+    var archivedAt: Date?
+    @Relationship(deleteRule: .cascade, inverse: \CompletionRecord.habit)
+    var completions: [CompletionRecord] = []
+
+    init(...) { ... }
+
+    var snapshot: Habit {
+        Habit(id: id, name: name, frequency: frequency, type: type,
+              createdAt: createdAt, archivedAt: archivedAt)
+    }
+}
+```
+
+### CloudKit-readiness checklist
+
+Confirmed against [Fatbobman 2025-12](https://fatbobman.com/en/snippet/rules-for-adapting-data-models-to-cloudkit/):
+
+- [x] Every property has a default value or is optional
+- [x] All relationships optional (`completions = []` defaults to
+      empty; `habit: HabitRecord?` is nilable)
+- [x] Explicit `inverse:` on the parent side
+- [x] No `@Attribute(.unique)` (CloudKit forbids it; UUID-based
+      app-level identity instead)
+- [x] No `@Relationship(deleteRule: .deny)` — only `.cascade` /
+      `.nullify`
+- [x] No ordered relationships
+- [x] CloudKit container will be `.private("iCloud.dev.scastiel.kado")`
+      when wired (matches bundle ID)
+
+### Codable enums — known fragility, explicit mitigation
+
+SwiftData on iOS 18 stores `Codable` enums with associated values
+natively (no `@Attribute(.transformable)` needed). However, **the
+storage format depends on the Swift compiler's synthesized Codable
+keys**, which are not stability-guaranteed and use positional `_0`,
+`_1` keys. CloudKit treats any encoding change as a breaking
+schema change.
+
+Mitigation: **implement custom `Codable` with explicit `CodingKeys`
+for `Frequency` and `HabitType`**. The format then survives compiler
+upgrades and we own the migration path. This was already flagged in
+the PR #2 review as a "future export concern" — it's now load-bearing.
+
+Tradeoff: we lose `#Predicate` filtering on these fields anyway
+(SwiftData doesn't support enum-case predicates), so storing as
+JSON-shaped structures is no worse than a discriminator-style
+denormalization.
+
+### UI changes
+
+None in this PR. The `ContentView` placeholder stays; later v0.1
+view PRs will inject the `ModelContainer` and use `@Query
+[HabitRecord]`.
+
+### Tests to write
+
+- `KadoSchemaTests`:
+  - Schema's `versionIdentifier` is `1.0.0`.
+  - Container can be created in-memory without throwing.
+- `HabitRecordTests`:
+  - Round-trip: create a record → snapshot → equals input.
+  - Cascade delete: deleting a HabitRecord removes its completions.
+  - Optional `archivedAt` defaults to nil.
+- `CompletionRecordTests`:
+  - Inverse relationship: setting `record.habit = h` populates
+    `h.completions`.
+- `FrequencyCodingTests`, `HabitTypeCodingTests`:
+  - JSON round-trip for every case.
+  - Stable JSON shape: assert exact bytes for each canonical case
+    (`{"kind":"daily"}`, etc.) so a future compiler change can't
+    silently break persistence.
+- `PersistenceControllerTests`:
+  - In-memory factory works.
+  - `save()` is idempotent.
+
+## Alternatives considered
+
+### Alternative A: Drop the value-type structs, use `@Model` everywhere
+
+- Idea: rename `HabitRecord` → `Habit`, delete the struct, change the
+  score calculator to take `@Model Habit`.
+- Why not: tests would need a `ModelContainer` (slower, requires
+  `@MainActor`, ergonomics regression). The compound doc explicitly
+  locked in "pure value types stay" as a design invariant — the
+  calculator's testability was hard-won.
+
+### Alternative B: Protocol-based unification (`HabitProtocol`)
+
+- Idea: define a `HabitProtocol` with all read-only fields; both
+  struct and class conform. Calculator takes `any HabitProtocol`.
+- Why not: SwiftData `@Model` + protocol conformance is awkward
+  (predicates can't see protocol witnesses, generic `where`
+  constraints break). Existential overhead. The value-type struct
+  is already small enough that explicit projection is cheaper than a
+  shared protocol.
+
+### Alternative C: Store `Frequency` and `HabitType` as JSON-encoded `Data`
+
+- Idea: `var frequencyData: Data` with a get/set wrapper.
+- Why not: SwiftData's native Codable support gets us the same
+  outcome with less boilerplate, as long as we own the Codable
+  format ourselves (which we will). Manual Data wrapping would also
+  prevent SwiftData's diff detection from seeing field changes
+  cleanly.
+
+### Alternative D: Wire CloudKit in this PR
+
+- Idea: ship persistence + iCloud sync as one PR.
+- Why not: CloudKit setup needs entitlements, an Apple Developer
+  Account-side container creation in CloudKit Dashboard, and
+  entitlement file edits in the Xcode project. Mixed local-only +
+  CloudKit configuration is hard to test. Better as a separate PR
+  once the local layer is proven.
+
+## Risks and unknowns
+
+- **Custom Codable for enums-with-associated-values has a known
+  Xcode-Previews crash on delete**
+  ([Fatbobman](https://fatbobman.com/en/posts/considerations-for-using-codable-and-enums-in-swiftdata-models/)).
+  Mitigation: previews use `inMemory()` containers and avoid
+  delete operations. Tests use the same path.
+- **Naming: `HabitRecord` typealias may conflict with Apple
+  frameworks.** Quick `grep` in iOS SDK suggests no conflict
+  (CloudKit uses `CKRecord`). Worst case rename later.
+- **The score calculator's `completions: [Completion]` parameter
+  invites callers to project `record.completions.map(\.snapshot)` on
+  every render.** For ~20 habits with ~100 completions each, that's
+  fine. Caching is post-MVP per spec.
+
+## Open questions
+
+All four pre-plan questions resolved on 2026-04-16:
+
+- **Top-level typealias**: yes —
+  `typealias HabitRecord = KadoSchemaV1.HabitRecord` for ergonomic
+  call sites. Schema-namespace stays explicit only in migration code.
+- **Persistence injection**: SwiftUI's `.modelContainer(_:)` modifier
+  on `KadoApp`. No separate `PersistenceController` until we discover
+  we need test-time overrides — `ModelContainer` already exposes
+  in-memory configurations for previews and tests.
+- **Preview seed data**: yes — small helper under `Preview Content/`
+  that builds an in-memory `ModelContainer` with a few sample habits.
+- **CloudKit wiring**: deferred to a separate PR. Schema must be
+  CloudKit-shape from day one (this PR), entitlement / container
+  wiring happens later.
+
+(Schema version identifier scheme — semver, `1.0.0` for v1, bump
+major when a migration stage is added — moved to Proposed approach
+above.)
+
+## References
+
+- [SwiftData VersionedSchema](https://developer.apple.com/documentation/swiftdata/versionedschema)
+- [SwiftData SchemaMigrationPlan](https://developer.apple.com/documentation/swiftdata/schemamigrationplan)
+- [WWDC23 — Model your schema with SwiftData](https://developer.apple.com/videos/play/wwdc2023/10195/)
+- [Fatbobman — Codable + enums in SwiftData (caveats)](https://fatbobman.com/en/posts/considerations-for-using-codable-and-enums-in-swiftdata-models/)
+- [Fatbobman — CloudKit-ready model rules (Dec 2025)](https://fatbobman.com/en/snippet/rules-for-adapting-data-models-to-cloudkit/)
+- [Hacking with Swift — VersionedSchema migrations](https://www.hackingwithswift.com/quick-start/swiftdata/how-to-create-a-complex-migration-using-versionedschema)
+- [SE-0295 — Codable synthesis for enums with associated values](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0295-codable-synthesis-for-enums-with-associated-values.md)


### PR DESCRIPTION
## Why?

- Score and frequency services already work, but quitting the app loses everything — there's no persistence yet.
- v0.1 needs SwiftData-backed storage with `VersionedSchema` from day one (per CLAUDE.md) and a CloudKit-compatible shape (retrofitting CloudKit constraints onto a shipped schema is data-loss-prone).

## What?

- `HabitRecord` and `CompletionRecord` `@Model` classes inside `KadoSchemaV1`, wrapping the existing value-type `Habit` / `Completion` structs.
- `snapshot` projections back to the value types, so the score and frequency services stay struct-only and unit-testable without a `ModelContainer`.
- `KadoMigrationPlan` registered with `KadoSchemaV1` and an empty `stages` list (the first `MigrationStage` lands with v2).
- `ModelContainer` wired into `KadoApp` via SwiftUI's `.modelContainer(_:)` modifier.
- Custom `Codable` for `Frequency` and `HabitType` with explicit kind-discriminated JSON (`{"kind":"daily"}`, `{"kind":"counter","target":8}`, etc.) — owns the on-disk format so it survives compiler upgrades.
- In-memory `PreviewContainer.shared` seeded with five sample habits covering every `Frequency` and `HabitType` variant, for SwiftUI previews of forthcoming v0.1 views.

## How?

- TDD throughout — round-trip + canonical-shape tests for the custom `Codable`, in-memory `ModelContainer` per test suite for the persistence layer. 22 new tests, 59/59 green.
- **Mid-build pivot**: research recommended native Codable enum storage on `@Model` (`var frequency: Frequency = .daily`); turned out to crash `ModelContainer.init` at runtime on Xcode 26 / iOS 18.4 — bisected by stripping `HabitRecord` to bare minimum and adding fields back. Fell back to research's Alternative C: `private var frequencyData: Data` + computed `var frequency: Frequency` with explicit JSON encode/decode. The custom `Codable` from earlier in the PR now backs both the on-disk format AND the schema property.
- `nonisolated enum` on `Frequency` and `HabitType` to override the project's `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` default (otherwise Codable conformances inherit MainActor isolation and warn from off-MainActor tests).
- CloudKit-shape compliance from day one: every property has a default or is optional, the to-many relationship has explicit inverse + cascade delete, no `@Attribute(.unique)`.
- Three lessons graduated to [CLAUDE.md](https://github.com/scastiel/kado/blob/feature/swiftdata-models/CLAUDE.md) — `nonisolated` rule for value-type Codable, SwiftData composite-Codable workaround pattern, and the "verify load-bearing research claims with a smoke test" operating-mode rule.
- Full breakdown in [research.md](https://github.com/scastiel/kado/blob/feature/swiftdata-models/docs/plans/2026-04/swiftdata-models/research.md), [plan.md](https://github.com/scastiel/kado/blob/feature/swiftdata-models/docs/plans/2026-04/swiftdata-models/plan.md), and [compound.md](https://github.com/scastiel/kado/blob/feature/swiftdata-models/docs/plans/2026-04/swiftdata-models/compound.md).

## Next steps

- **Invisible in the running app** — this PR is plumbing only; no view consumes the data yet. Today/Settings stay placeholders. The v0.1 view PRs (Today list, Detail, New Habit) wire `@Query` and surface the data.
- **CloudKit wiring** — entitlement + container creation in CloudKit Dashboard + `cloudKitDatabase: .private(\"iCloud.dev.scastiel.kado\")` in `ModelConfiguration`. Separate PR.
- **`StreakCalculator`** — separate PR.
- **`snapshot` JSON-decode cost** — fine at MVP scale (≤50 habits), worth profiling once the Today view scales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)