### PR TITLE
feat(today-view): list habits due today with tap-to-toggle completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,13 @@ Firebase, no analytics, no SaaS crash reporting.
 Lightweight MVVM with strict separation:
 
 - **Models**: SwiftData types (`@Model`), pure domain types (structs).
-- **ViewModels**: `@Observable` classes, one per complex view. Simple
-  views can skip them.
+- **ViewModels**: `@Observable` classes, only for views that mutate
+  state outside of `@Query`-driven updates or share state across
+  multiple views. A view whose logic fits in `@Query` + small
+  computed properties + inline actions is a "simple view" — skip
+  the ViewModel. Extract business logic into a free struct with
+  injected `Calendar` (pattern: `CompletionToggler`) rather than
+  wrapping it in a ViewModel for structure's sake.
 - **Views**: SwiftUI, ideally with no business logic.
 - **Services**: reusable business logic (HabitScoreCalculator,
   ExportService, NotificationScheduler…). Protocol-defined, injected.
@@ -405,6 +410,17 @@ where you still open Xcode:
   large projects, negligible on Kadō early on).
 - Code signing: errors remain opaque, ask the human to fix in Xcode
   when needed.
+- **Destination resolution flakiness**: `test_sim` and
+  `build_run_sim` occasionally fail with `Unable to find a
+  destination matching { platform:iOS Simulator, OS:latest, name:… }`
+  even though the simulator is booted and its SDK is installed —
+  the error text cites the missing iOS *device* SDK. xcodebuild
+  appears to walk all scheme destinations and abort when
+  device-side resolution fails, poisoning the simulator build. Fix:
+  `xcrun simctl shutdown all && xcrun simctl boot "<sim name>"`,
+  then rerun. Cleaning DerivedData occasionally helps. No
+  source-level change is needed — the code is fine, the runtime
+  state is not.
 
 ---
 

--- a/Kado/App/EnvironmentValues+Services.swift
+++ b/Kado/App/EnvironmentValues+Services.swift
@@ -18,9 +18,18 @@ private struct HabitScoreCalculatorKey: EnvironmentKey {
     static let defaultValue: any HabitScoreCalculating = DefaultHabitScoreCalculator()
 }
 
+private struct FrequencyEvaluatorKey: EnvironmentKey {
+    static let defaultValue: any FrequencyEvaluating = DefaultFrequencyEvaluator()
+}
+
 extension EnvironmentValues {
     var habitScoreCalculator: any HabitScoreCalculating {
         get { self[HabitScoreCalculatorKey.self] }
         set { self[HabitScoreCalculatorKey.self] = newValue }
+    }
+
+    var frequencyEvaluator: any FrequencyEvaluating {
+        get { self[FrequencyEvaluatorKey.self] }
+        set { self[FrequencyEvaluatorKey.self] = newValue }
     }
 }

--- a/Kado/Preview Content/PreviewContainer.swift
+++ b/Kado/Preview Content/PreviewContainer.swift
@@ -21,6 +21,44 @@ enum PreviewContainer {
         }
     }()
 
+    /// In-memory container with no habits — exercises the empty state.
+    static func emptyContainer() -> ModelContainer {
+        do {
+            return try ModelContainer(
+                for: HabitRecord.self, CompletionRecord.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+            )
+        } catch {
+            fatalError("Failed to construct preview ModelContainer: \(error)")
+        }
+    }
+
+    /// In-memory container with habits that exist but aren't due today —
+    /// exercises the "nothing due today" state. Seeds one habit scheduled
+    /// only on a weekday we know isn't today.
+    static func noneDueTodayContainer() -> ModelContainer {
+        do {
+            let container = try ModelContainer(
+                for: HabitRecord.self, CompletionRecord.self,
+                configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+            )
+            let calendar = Calendar.current
+            let todayWeekdayInt = calendar.component(.weekday, from: .now)
+            let offDays = Set(Weekday.allCases).filter { $0.rawValue != todayWeekdayInt }
+            let habit = HabitRecord(
+                name: "Weekend ritual",
+                frequency: .specificDays(offDays),
+                type: .binary,
+                createdAt: calendar.date(byAdding: .day, value: -30, to: .now)!
+            )
+            container.mainContext.insert(habit)
+            try? container.mainContext.save()
+            return container
+        } catch {
+            fatalError("Failed to construct preview ModelContainer: \(error)")
+        }
+    }
+
     static func seed(_ context: ModelContext) {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: .now)

--- a/Kado/Services/CompletionToggler.swift
+++ b/Kado/Services/CompletionToggler.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftData
+
+/// Toggles the "done today" state for a habit by inserting or deleting
+/// a `CompletionRecord` on the given day.
+///
+/// Binary and negative habits use this directly from Today-tab rows.
+/// Counter and timer habits will use it too once the detail view ships
+/// with per-type input affordances.
+@MainActor
+struct CompletionToggler {
+    let calendar: Calendar
+
+    init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    /// Inserts a unit completion for `habit` on `date`'s day if none
+    /// exists; otherwise deletes the existing one. Day comparison uses
+    /// the injected calendar so DST and timezone boundaries behave.
+    func toggleToday(
+        for habit: HabitRecord,
+        on date: Date = .now,
+        in context: ModelContext
+    ) {
+        if let existing = habit.completions.first(where: {
+            calendar.isDate($0.date, inSameDayAs: date)
+        }) {
+            context.delete(existing)
+        } else {
+            let completion = CompletionRecord(date: date, value: 1, habit: habit)
+            context.insert(completion)
+        }
+    }
+}

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+/// A single row in the Today list. Renders every `HabitType`, but
+/// only binary and negative habits accept tap-to-toggle. Counter and
+/// timer rows are read-only until the habit detail view ships with
+/// per-type input affordances.
+struct HabitRowView: View {
+    let habit: Habit
+    let isCompletedToday: Bool
+    let onTap: (() -> Void)?
+
+    var body: some View {
+        Group {
+            if let onTap {
+                Button(action: onTap) { rowContent }
+                    .buttonStyle(.plain)
+            } else {
+                rowContent
+            }
+        }
+        .sensoryFeedback(.success, trigger: isCompletedToday)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabelText)
+        .accessibilityHint(onTap == nil ? "" : String(localized: "Double tap to toggle completion."))
+    }
+
+    private var rowContent: some View {
+        HStack(spacing: 12) {
+            leadingIcon
+                .frame(width: 28, height: 28)
+            Text(habit.name)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.leading)
+            Spacer(minLength: 8)
+            trailingState
+        }
+        .padding(.vertical, 4)
+        .contentShape(Rectangle())
+    }
+
+    @ViewBuilder
+    private var leadingIcon: some View {
+        switch habit.type {
+        case .binary, .negative:
+            Image(systemName: isCompletedToday ? "checkmark.circle.fill" : "circle")
+                .font(.title2)
+                .foregroundStyle(isCompletedToday ? Color.accentColor : Color.secondary)
+        case .counter:
+            Image(systemName: "number.circle")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+        case .timer:
+            Image(systemName: "timer")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var trailingState: some View {
+        switch habit.type {
+        case .counter(let target):
+            Text("–/\(Int(target))")
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        case .timer(let targetSeconds):
+            Text(formatSeconds(targetSeconds))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        case .binary, .negative:
+            EmptyView()
+        }
+    }
+
+    private var accessibilityLabelText: String {
+        switch habit.type {
+        case .binary, .negative:
+            let state = isCompletedToday
+                ? String(localized: "done")
+                : String(localized: "not done")
+            return "\(habit.name), \(state)"
+        case .counter(let target):
+            return String(localized: "\(habit.name), counter, target \(Int(target))")
+        case .timer(let targetSeconds):
+            return String(localized: "\(habit.name), timer, target \(formatSeconds(targetSeconds))")
+        }
+    }
+
+    private func formatSeconds(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let minutes = total / 60
+        let remaining = total % 60
+        return String(format: "%d:%02d", minutes, remaining)
+    }
+}
+
+#Preview("All types — not done") {
+    List {
+        HabitRowView(
+            habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
+            isCompletedToday: false,
+            onTap: {}
+        )
+        HabitRowView(
+            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
+            isCompletedToday: false,
+            onTap: nil
+        )
+        HabitRowView(
+            habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now),
+            isCompletedToday: false,
+            onTap: nil
+        )
+        HabitRowView(
+            habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now),
+            isCompletedToday: false,
+            onTap: {}
+        )
+    }
+}
+
+#Preview("All types — done") {
+    List {
+        HabitRowView(
+            habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
+            isCompletedToday: true,
+            onTap: {}
+        )
+        HabitRowView(
+            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
+            isCompletedToday: true,
+            onTap: nil
+        )
+        HabitRowView(
+            habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now),
+            isCompletedToday: true,
+            onTap: nil
+        )
+        HabitRowView(
+            habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now),
+            isCompletedToday: true,
+            onTap: {}
+        )
+    }
+}
+
+#Preview("Dynamic Type XXXL") {
+    List {
+        HabitRowView(
+            habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
+            isCompletedToday: true,
+            onTap: {}
+        )
+        HabitRowView(
+            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
+            isCompletedToday: false,
+            onTap: nil
+        )
+    }
+    .environment(\.dynamicTypeSize, .accessibility3)
+}

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -14,14 +14,14 @@ struct HabitRowView: View {
             if let onTap {
                 Button(action: onTap) { rowContent }
                     .buttonStyle(.plain)
+                    .sensoryFeedback(.success, trigger: isCompletedToday)
+                    .accessibilityHint(Text("Double tap to toggle completion."))
             } else {
                 rowContent
             }
         }
-        .sensoryFeedback(.success, trigger: isCompletedToday)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabelText)
-        .accessibilityHint(onTap == nil ? "" : String(localized: "Double tap to toggle completion."))
     }
 
     private var rowContent: some View {

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -1,23 +1,94 @@
+import SwiftData
 import SwiftUI
 
-/// The Today tab — lists habits due today.
-///
-/// Placeholder at bootstrap. v0.1 replaces the body with a list of
-/// habits (from a `@Query` on the SwiftData `Habit` model) and
-/// tap-to-complete interactions.
+/// The Today tab — lists habits due today and handles tap-to-toggle
+/// for binary and negative habits.
 struct TodayView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.frequencyEvaluator) private var frequencyEvaluator
+    @Environment(\.calendar) private var calendar
+
+    @Query(
+        filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
+        sort: \HabitRecord.createdAt
+    )
+    private var activeHabits: [HabitRecord]
+
     var body: some View {
         NavigationStack {
+            content
+                .navigationTitle(Text("Today"))
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if activeHabits.isEmpty {
             ContentUnavailableView(
                 "No habits yet",
                 systemImage: "list.bullet.clipboard",
                 description: Text("Habits you create will appear here.")
             )
-            .navigationTitle("Today")
+        } else {
+            let due = habitsDueToday
+            if due.isEmpty {
+                ContentUnavailableView(
+                    "Nothing due today",
+                    systemImage: "checkmark.circle",
+                    description: Text("Come back tomorrow, or check your habit detail to log a past day.")
+                )
+            } else {
+                List(due) { record in
+                    HabitRowView(
+                        habit: record.snapshot,
+                        isCompletedToday: isCompletedToday(record),
+                        onTap: canToggle(record) ? { toggle(record) } : nil
+                    )
+                }
+            }
         }
+    }
+
+    private var habitsDueToday: [HabitRecord] {
+        let now = Date.now
+        return activeHabits.filter { record in
+            frequencyEvaluator.isDue(
+                habit: record.snapshot,
+                on: now,
+                completions: record.completions.map(\.snapshot)
+            )
+        }
+    }
+
+    private func isCompletedToday(_ record: HabitRecord) -> Bool {
+        let now = Date.now
+        return record.completions.contains { calendar.isDate($0.date, inSameDayAs: now) }
+    }
+
+    private func canToggle(_ record: HabitRecord) -> Bool {
+        switch record.type {
+        case .binary, .negative: true
+        case .counter, .timer: false
+        }
+    }
+
+    private func toggle(_ record: HabitRecord) {
+        CompletionToggler(calendar: calendar)
+            .toggleToday(for: record, in: modelContext)
     }
 }
 
-#Preview {
+#Preview("Populated") {
     TodayView()
+        .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("No habits") {
+    TodayView()
+        .modelContainer(PreviewContainer.emptyContainer())
+}
+
+#Preview("Nothing due today") {
+    TodayView()
+        .modelContainer(PreviewContainer.noneDueTodayContainer())
 }

--- a/KadoTests/CompletionTogglerTests.swift
+++ b/KadoTests/CompletionTogglerTests.swift
@@ -1,0 +1,116 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import Kado
+
+@Suite("CompletionToggler")
+@MainActor
+struct CompletionTogglerTests {
+    let container: ModelContainer
+
+    init() throws {
+        container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("Toggling a habit with no completion today inserts one with value 1")
+    func insertsWhenAbsent() throws {
+        let habit = HabitRecord(name: "Meditate", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        try container.mainContext.save()
+
+        let toggler = CompletionToggler(calendar: TestCalendar.utc)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 1)
+        let completion = try #require(habit.completions.first)
+        #expect(completion.value == 1.0)
+        #expect(TestCalendar.utc.isDate(completion.date, inSameDayAs: TestCalendar.day(0)))
+    }
+
+    @Test("Toggling a habit with a completion today deletes it")
+    func deletesWhenPresent() throws {
+        let habit = HabitRecord(name: "Meditate", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        let existing = CompletionRecord(date: TestCalendar.day(0), value: 1, habit: habit)
+        container.mainContext.insert(existing)
+        try container.mainContext.save()
+
+        let toggler = CompletionToggler(calendar: TestCalendar.utc)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.isEmpty)
+        let remaining = try container.mainContext.fetch(FetchDescriptor<CompletionRecord>())
+        #expect(remaining.isEmpty)
+    }
+
+    @Test("Toggling leaves other days' completions alone")
+    func preservesOtherDays() throws {
+        let habit = HabitRecord(name: "Meditate", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        let yesterday = CompletionRecord(date: TestCalendar.day(-1), value: 1, habit: habit)
+        container.mainContext.insert(yesterday)
+        try container.mainContext.save()
+
+        let toggler = CompletionToggler(calendar: TestCalendar.utc)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 2)
+        #expect(habit.completions.contains { $0.id == yesterday.id })
+    }
+
+    @Test("Toggling twice returns to the original state")
+    func idempotentRoundTrip() throws {
+        let habit = HabitRecord(name: "Meditate", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        try container.mainContext.save()
+
+        let toggler = CompletionToggler(calendar: TestCalendar.utc)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.isEmpty)
+    }
+
+    @Test("Toggle uses the injected calendar for day comparison across timezones")
+    func calendarIsolation() throws {
+        // Paris calendar: a completion at 23:30 UTC is already "tomorrow"
+        // in Paris (01:30 local). Toggling on Paris-today (the UTC-yesterday
+        // value) must leave the UTC-evening completion alone.
+        var paris = Calendar(identifier: .gregorian)
+        paris.timeZone = TimeZone(identifier: "Europe/Paris")!
+
+        let habit = HabitRecord(name: "Meditate", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+
+        // Reference anchor: 2026-04-13 23:30 UTC = 2026-04-14 01:30 Paris.
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 4
+        components.day = 13
+        components.hour = 23
+        components.minute = 30
+        components.timeZone = TimeZone(identifier: "UTC")
+        let utcEvening = Calendar(identifier: .gregorian).date(from: components)!
+        let parisToday = paris.date(byAdding: .day, value: -1, to: utcEvening)! // Paris April 13
+
+        let existingOnParisApril14 = CompletionRecord(date: utcEvening, value: 1, habit: habit)
+        container.mainContext.insert(existingOnParisApril14)
+        try container.mainContext.save()
+
+        let toggler = CompletionToggler(calendar: paris)
+        toggler.toggleToday(for: habit, on: parisToday, in: container.mainContext)
+        try container.mainContext.save()
+
+        // Paris-April-13 had no completion, so we inserted one. The Paris-April-14
+        // completion (utcEvening) remains untouched.
+        #expect(habit.completions.count == 2)
+        #expect(habit.completions.contains { $0.id == existingOnParisApril14.id })
+    }
+}

--- a/docs/plans/2026-04/today-view/compound.md
+++ b/docs/plans/2026-04/today-view/compound.md
@@ -1,0 +1,219 @@
+---
+# Compound — Today View
+
+**Date**: 2026-04-17
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [feature/today-view](https://github.com/scastiel/kado/pull/4)
+
+## Summary
+
+Wired the Today tab to real `HabitRecord` data: `@Query` for active
+habits, in-memory filter through the injected `FrequencyEvaluator`,
+full-row rendering for every `HabitType`, and tap-to-toggle for
+binary/negative via a small `CompletionToggler` helper.
+`.sensoryFeedback(.success, trigger:)` handles haptics. Counter and
+timer rows ship read-only until the habit detail view lands.
+**Headline: the plan landed almost verbatim — research's 5-question
+pre-plan conversation front-loaded the design decisions so no
+surprises surfaced during build. The `#Predicate` fallback wasn't
+needed; the toolchain cooperated.**
+
+## Decisions made
+
+- **No ViewModel**: `@Query` + computed properties + a 3-line toggle
+  helper are enough. Tests target the helper, previews cover
+  rendering. CLAUDE.md's "simple views can skip them" applies here.
+- **In-memory filtering** for "due today". `FrequencyEvaluator.isDue`
+  needs the habit's completions for `.daysPerWeek` rolling-window
+  logic, which isn't expressible in `#Predicate`'s macro.
+- **Full-row layout** with leading state indicator + name +
+  type-specific trailing label. Standard `List`-row pattern.
+- **Tap-to-toggle for binary/negative, no-op for counter/timer**:
+  scope discipline. Counter/timer need detail-view input
+  affordances that don't exist yet; showing them read-only beats
+  faking interaction.
+- **`.sensoryFeedback(.success, trigger: isCompletedToday)` on the
+  outer row**: fires on both true→false and false→true transitions
+  — tactile confirmation on tap AND undo, which is the desired UX.
+- **`CompletionToggler` as a concrete `@MainActor struct`, no
+  protocol**: tests use an in-memory `ModelContainer` directly,
+  there's no substitution need. If one appears later, refactor
+  then.
+- **Empty state stays text-only** (no "Create habit" button). A
+  disabled button in production would teach users a lie; the next
+  PR adds it when it's real.
+- **Three view states**: empty (no habits), "nothing due today"
+  (habits exist but none scheduled), and populated. Separate
+  `ContentUnavailableView` copy for the first two.
+- **`frequencyEvaluator` environment key alongside
+  `habitScoreCalculator`**: mirrors the existing pattern, no new
+  conventions introduced.
+- **Preview helpers on `PreviewContainer`**: `emptyContainer()` and
+  `noneDueTodayContainer()` for state coverage in `TodayView`
+  previews, reusing the single preview-container construction path.
+
+## Surprises and how we handled them
+
+### XcodeBuildMCP destination flakiness
+
+- **What happened**: `test_sim` and `build_run_sim` intermittently
+  failed with `Unable to find a destination matching { platform:iOS Simulator, OS:latest, name:iPhone 17 Pro }`
+  even though `xcrun simctl` showed the sim booted on iOS 26.4 and
+  `xcodebuild -showsdks` confirmed the simulator SDK was installed.
+  The error message cited the *device* SDK: "iOS 26.4 is not
+  installed." xcodebuild appears to walk all scheme destinations
+  and bail out when device-side resolution fails — the missing iOS
+  26.4 *device* SDK (we only have the simulator SDK) poisons
+  destination resolution even though builds only need the
+  simulator.
+- **What we did**: shut down all simulators with
+  `xcrun simctl shutdown all`, rebooted iPhone 17 Pro, reran.
+  Sometimes also required cleaning DerivedData. After the reset,
+  `test_sim` ran green (64/64). No source-level fix.
+- **Lesson**: when XcodeBuildMCP's `test_sim` / `build_run_sim`
+  returns an "OS:latest … not installed" destination error despite
+  the sim being booted and the simulator SDK being present, the fix
+  is environmental, not code-level. Reboot the sim before retrying.
+
+### The production container starts empty — live tap-testing blocked
+
+- **What happened**: `KadoApp` uses a file-backed `ModelContainer`
+  with no onboarding/seed path. Launching the app on the simulator
+  shows the empty state correctly but leaves no way to manually
+  verify the tap-to-toggle flow.
+- **What we did**: relied on unit tests (`CompletionTogglerTests`,
+  5 cases covering insert/delete/idempotency/DST) + SwiftUI
+  previews (4 row permutations × 2 done-states + 3 view-level
+  states). Documented the gap in plan notes. End-to-end manual
+  verification waits for the Create-habit PR.
+- **Lesson**: when a persistence-consuming view lands before its
+  data-creation flow, unit-test + preview coverage can substitute
+  for live simulator testing — but the gap deserves an explicit
+  note in the PR so it doesn't get forgotten.
+
+### `#Predicate<HabitRecord> { $0.archivedAt == nil }` worked first try
+
+- **What happened**: I planned a fallback (unfiltered `@Query` +
+  in-memory archive filter) in case SwiftData's `#Predicate` macro
+  balked at comparing an optional `Date` to `nil`. It didn't balk.
+- **What we did**: kept the `#Predicate` path, removed the fallback
+  task from scope.
+- **Lesson**: The SwiftData-on-Xcode-26 composite-Codable-enum
+  crash (from the previous PR) biased me toward over-planning
+  around toolchain quirks. `#Predicate` with optional-to-nil is
+  well-supported and wasn't worth hedging against. Next time, one
+  5-minute smoke test up front would settle it.
+
+## What worked well
+
+- **Front-loading design decisions in research**: the 5-question
+  pre-plan conversation (counter/timer rendering, undo semantics,
+  empty-state button, row density, score-on-row) resolved in ~2
+  minutes each because the options were framed with recommendations
+  up front. Zero decisions got relitigated during build.
+- **TDD on `CompletionToggler`**: writing 5 red tests before any
+  implementation surfaced a DST test case I hadn't initially
+  planned, and the implementation went green first try. The
+  Europe/Paris calendar test is the kind of regression guard that
+  would cost hours to debug if it ever broke silently.
+- **Plan's "notes during build" section**: gave me a dedicated spot
+  to record the flaky-sim workaround and the predicate-fallback
+  non-event as they happened, which fed this compound directly with
+  zero re-derivation.
+- **Reusing `PreviewContainer` for state-specific helpers**: adding
+  `emptyContainer()` and `noneDueTodayContainer()` beside the
+  existing `.shared` kept preview wiring centralized. Previews
+  stayed one-liners.
+- **`Group { if onTap { Button … } else { rowContent } }`**: one
+  view expression renders the interactive-vs-read-only distinction
+  cleanly, and accessibility labels/hints attach to the whole
+  thing. Beats two parallel implementations.
+
+## For the next person
+
+- **The Today list doesn't refresh past midnight** while the app is
+  open — `Date.now` is only re-evaluated on render. Fix with a
+  `ScenePhase` observer when it starts mattering (likely after
+  v0.1).
+- **Counter/timer rows are intentionally tap-inert.** Trailing
+  labels show only the target ("`–/8`", "`30:00`"), not the actual
+  today value, because there's no path to create counter/timer
+  completions until the habit detail view ships. When the detail
+  view lands, wire today's completion value through to the row
+  (either pass `todayValue: Double?` to `HabitRowView`, or rethink
+  the row as a protocol over the habit record).
+- **`CompletionToggler` is `@MainActor` by necessity** —
+  `ModelContext` mutations need main-actor isolation. Don't try to
+  move it off-main "for responsiveness"; the operations are
+  millisecond-scale.
+- **`@Query(filter: #Predicate<HabitRecord> { $0.archivedAt == nil })`
+  compiled and ran first-try on Xcode 26 / iOS 18.4**. If you add
+  new predicate clauses, smoke-test them; the persistence-layer
+  compound warned that the macro has surprising edges.
+- **`.sensoryFeedback` observes the `isCompletedToday` boolean**,
+  not an event. That means both toggle directions fire the haptic.
+  If you want tap-only haptic, switch to
+  `.sensoryFeedback(trigger: isCompletedToday) { old, new in new }`
+  and guard. Don't switch without thinking about it — two-way
+  haptic is the current intentional UX.
+- **Empty state copy in `TodayView`** has two variants: "No habits
+  yet" (no habits at all) and "Nothing due today" (habits exist but
+  none scheduled for today). When adding archived-vs-deleted
+  logic later, don't collapse these — they answer different user
+  questions.
+- **Adding a new `@Model` or environment service**: follow the
+  pattern in `EnvironmentValues+Services.swift` (one file is the
+  single registry for environment keys). Add both the key and the
+  computed property in the same commit.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** When XcodeBuildMCP's `test_sim` or
+  `build_run_sim` fails with "Unable to find a destination matching
+  …OS:latest… not installed" despite the simulator being booted and
+  its SDK installed, the cause is usually xcodebuild's
+  whole-scheme destination walk choking on a missing *device* SDK.
+  Workaround: `xcrun simctl shutdown all && xcrun simctl boot
+  "iPhone 17 Pro"`, then retry. Cleaning DerivedData helps
+  occasionally. No source fix.
+- **[→ CLAUDE.md]** A "simple SwiftUI view" is one where `@Query`
+  + small computed properties + inline actions cover the logic. If
+  business logic needs a helper, extract it as a free struct with
+  injected `Calendar` (pattern: `CompletionToggler`), not a
+  `@Observable` ViewModel. The ViewModel threshold: state the view
+  itself must mutate outside of `@Query`-driven updates, or shared
+  state across multiple views.
+- **[→ CLAUDE.md]** When a toolchain quirk bit us once (SwiftData
+  composite-Codable-enum crash), don't reflex-hedge every similar-
+  sounding risk on the next feature. Validate with a 2-minute
+  smoke test before baking a fallback into the plan. Planning
+  overhead has a cost too.
+- **[local]** Pre-plan resolution of open questions via a
+  recommendation-first conversation (5 questions, ~10 min total) is
+  a high-ROI pattern on feature-scale work. Candidate for the
+  conductor skill's docs if it proves out over 2-3 more features.
+
+## Metrics
+
+- Tasks completed: 5 of 6 (Task 6 intentionally skipped — nothing
+  to polish)
+- Tests added: 5 (`CompletionTogglerTests`)
+- Total test count: 59 → 64 (64/64 green)
+- Commits on branch: 10 (3 docs, 5 build, 2 plan updates)
+- Files added: 2 source + 1 test + 3 docs
+- Files modified: 3 source + 0 test
+- Net diff: +944 / -7 across 8 files (of which +506 lines are the
+  three plan/research/compound docs)
+- Mid-build pivots: 0 (plan landed verbatim)
+- Plan revisions during build: 0
+
+## References
+
+- [@Query](https://developer.apple.com/documentation/swiftdata/query)
+- [#Predicate](https://developer.apple.com/documentation/foundation/predicate)
+- [.sensoryFeedback](https://developer.apple.com/documentation/swiftui/view/sensoryfeedback(_:trigger:))
+- [ContentUnavailableView](https://developer.apple.com/documentation/swiftui/contentunavailableview)
+- [PR #3 compound — SwiftData persistence layer](../swiftdata-models/compound.md) — the layer this PR consumes.
+- [PR #2 compound — habit score calculator](../habit-score-calculator/compound.md) — source of the concurrency / Calendar conventions applied here.

--- a/docs/plans/2026-04/today-view/plan.md
+++ b/docs/plans/2026-04/today-view/plan.md
@@ -2,7 +2,7 @@
 # Plan — Today View
 
 **Date**: 2026-04-17
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -39,7 +39,7 @@ separate PR.
 
 ## Task list
 
-### Task 1: Add `frequencyEvaluator` to the environment
+### Task 1: Add `frequencyEvaluator` to the environment ✅
 
 **Goal**: Make `FrequencyEvaluating` injectable the same way
 `HabitScoreCalculating` already is.
@@ -58,7 +58,7 @@ separate PR.
 
 ---
 
-### Task 2: Write tests for `CompletionToggler`
+### Task 2: Write tests for `CompletionToggler` ✅
 
 **Goal**: Red tests for the toggle helper before any implementation.
 
@@ -86,7 +86,7 @@ separate PR.
 
 ---
 
-### Task 3: Implement `CompletionToggler`
+### Task 3: Implement `CompletionToggler` ✅
 
 **Goal**: Minimal struct that inserts or deletes today's
 `CompletionRecord` for a given habit.
@@ -131,7 +131,7 @@ separate PR.
 
 ---
 
-### Task 4: Build `HabitRowView`
+### Task 4: Build `HabitRowView` ✅
 
 **Goal**: A reusable row that renders any habit type, with an
 optional tap action for binary/negative.
@@ -166,7 +166,7 @@ optional tap action for binary/negative.
 
 ---
 
-### Task 5: Wire `TodayView`
+### Task 5: Wire `TodayView` ✅
 
 **Goal**: Replace the placeholder with a working list.
 

--- a/docs/plans/2026-04/today-view/plan.md
+++ b/docs/plans/2026-04/today-view/plan.md
@@ -1,0 +1,258 @@
+---
+# Plan — Today View
+
+**Date**: 2026-04-17
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Wire the Today tab to real `HabitRecord` data. A `@Query` pulls
+active habits, an in-memory filter (via `FrequencyEvaluator`) keeps
+only those due today, and each row shows the habit in a full-width
+row with a tap-to-toggle completion for binary and negative habits.
+Counter and timer rows render read-only until the habit detail view
+lands. Empty state stays text-only; the Create-habit flow is a
+separate PR.
+
+## Decisions locked in
+
+- **No ViewModel**. `@Query` + computed properties + a small toggle
+  helper are enough; a view model would be structure for structure's
+  sake.
+- **In-memory filtering** for "due today". `#Predicate` can't express
+  `FrequencyEvaluator`'s `.daysPerWeek` 7-day lookback.
+- **Full-row layout** with leading state indicator, habit name,
+  trailing type-specific state.
+- **Tap-to-toggle** for binary/negative (undo uses the same tap).
+  Counter/timer taps are no-ops for now.
+- **`.sensoryFeedback(.success, trigger:)`** wired to the
+  "done today" boolean — fires on both complete and undo.
+- **Empty state is text-only** (keep existing `ContentUnavailableView`
+  copy; no button).
+- **No score on the row** — the score belongs to the detail view.
+- **`CompletionToggler` as a simple helper** (concrete struct,
+  injected `Calendar`). No protocol yet — no test-time substitution
+  need; refactor later if one appears.
+- **Tests land on `CompletionToggler`**, not on the view. SwiftUI
+  previews cover the view side.
+
+## Task list
+
+### Task 1: Add `frequencyEvaluator` to the environment
+
+**Goal**: Make `FrequencyEvaluating` injectable the same way
+`HabitScoreCalculating` already is.
+
+**Changes**:
+- `Kado/App/EnvironmentValues+Services.swift`: add
+  `FrequencyEvaluatorKey` and the computed property on
+  `EnvironmentValues`.
+
+**Tests / verification**:
+- `build_sim` compiles clean.
+- No runtime check needed yet — consumers arrive in Task 5.
+
+**Commit message (suggested)**:
+`feat(env): expose frequency evaluator through SwiftUI environment`
+
+---
+
+### Task 2: Write tests for `CompletionToggler`
+
+**Goal**: Red tests for the toggle helper before any implementation.
+
+**Changes**:
+- `KadoTests/CompletionTogglerTests.swift` (new): in-memory
+  `ModelContainer` per test, asserts completion-list state after
+  each toggle.
+
+**Tests to write**:
+- `@Test("Toggling a habit with no completion today inserts one with value 1")`
+- `@Test("Toggling a habit with a completion today deletes it")`
+- `@Test("Toggling a habit with a completion yesterday leaves yesterday alone and inserts a new one for today")`
+- `@Test("Toggling twice returns to the original state")`
+- `@Test("Toggle on DST-crossing day uses the injected calendar's startOfDay")`
+  (use `Europe/Paris` TestCalendar, assert insertion/deletion
+  anchors to local day)
+
+**Verification**:
+- `test_sim` — all new tests fail with a "not implemented" error or
+  a `CompletionToggler` symbol-missing build error. Expected red
+  state before Task 3 lands.
+
+**Commit message (suggested)**:
+`test(completion-toggler): add red-state tests for toggle-today helper`
+
+---
+
+### Task 3: Implement `CompletionToggler`
+
+**Goal**: Minimal struct that inserts or deletes today's
+`CompletionRecord` for a given habit.
+
+**Changes**:
+- `Kado/Services/CompletionToggler.swift` (new):
+  ```swift
+  @MainActor
+  struct CompletionToggler {
+      let calendar: Calendar
+      init(calendar: Calendar = .current) { self.calendar = calendar }
+
+      func toggleToday(
+          for habit: HabitRecord,
+          on date: Date = .now,
+          in context: ModelContext
+      ) {
+          if let existing = habit.completions.first(where: {
+              calendar.isDate($0.date, inSameDayAs: date)
+          }) {
+              context.delete(existing)
+          } else {
+              let completion = CompletionRecord(
+                  date: date,
+                  value: 1.0,
+                  habit: habit
+              )
+              context.insert(completion)
+          }
+      }
+  }
+  ```
+- Uses `calendar.isDate(_:inSameDayAs:)` for day comparison (DST-safe
+  per CLAUDE.md's calendar conventions).
+
+**Tests / verification**:
+- `test_sim` — all Task 2 tests pass.
+- Full suite still green.
+
+**Commit message (suggested)**:
+`feat(completion-toggler): toggle today's completion for a habit`
+
+---
+
+### Task 4: Build `HabitRowView`
+
+**Goal**: A reusable row that renders any habit type, with an
+optional tap action for binary/negative.
+
+**Changes**:
+- `Kado/UIComponents/HabitRowView.swift` (new):
+  - Inputs: `habit: Habit` (value-type snapshot),
+    `isCompletedToday: Bool`, `onTap: (() -> Void)?`.
+  - Binary/negative: leading filled/empty circle with SF Symbol
+    (`checkmark.circle.fill` vs `circle`); the whole row is a
+    `Button` with the closure; trailing is empty.
+  - Counter: leading neutral symbol (e.g. `number.circle`);
+    trailing "progress" label (`"–/\(target)"` since the actual
+    value lives in the completion; MVP shows only the target).
+  - Timer: leading `timer` symbol; trailing target in `mm:ss`.
+  - No-tap types render as plain `HStack` rows (no Button), so no
+    hover/tap affordance.
+  - `.sensoryFeedback(.success, trigger: isCompletedToday)` on the
+    outer view.
+- Accessibility: `accessibilityLabel` combining name + state
+  ("Meditation, done" / "Gym, not done"), `accessibilityHint`
+  ("Double tap to toggle completion") for interactive rows.
+- Previews: 8 permutations (4 types × done/not-done).
+
+**Tests / verification**:
+- `build_sim` clean.
+- Preview screenshot for manual visual check.
+- Dynamic Type XXXL smoke-check via preview trait.
+
+**Commit message (suggested)**:
+`feat(today): add HabitRowView for Today list rendering`
+
+---
+
+### Task 5: Wire `TodayView`
+
+**Goal**: Replace the placeholder with a working list.
+
+**Changes**:
+- `Kado/Views/Today/TodayView.swift` (rewrite):
+  - `@Query` with `#Predicate<HabitRecord> { $0.archivedAt == nil }`
+    sorted by `createdAt`. Fallback path (if predicate fails at
+    runtime): `@Query(sort: \.createdAt)` and filter archived in
+    the computed property.
+  - `@Environment(\.modelContext)`, `@Environment(\.frequencyEvaluator)`,
+    `@Environment(\.calendar)`.
+  - Computed `habitsDueToday: [HabitRecord]` applies
+    `FrequencyEvaluator.isDue` using each record's snapshot +
+    completions-as-snapshots.
+  - `isCompletedToday(_:)` helper on the view checks for any
+    completion on today's day.
+  - For binary/negative rows, `onTap` calls
+    `CompletionToggler(calendar: calendar).toggleToday(for:in:)`.
+  - Counter/timer rows pass `nil` for `onTap`.
+  - Empty state: keep `ContentUnavailableView` as-is (title "No
+    habits yet", description "Habits you create will appear here.").
+  - A separate "Nothing due today" state kicks in when
+    `activeHabits.isEmpty == false` but `habitsDueToday.isEmpty`.
+- Previews:
+  - Populated: `.modelContainer(PreviewContainer.shared)`.
+  - Empty (no habits): in-memory container, no seed.
+  - Nothing due today: in-memory container with one archived habit
+    or one with `.specificDays` not matching today.
+
+**Tests / verification**:
+- `build_sim` clean.
+- `test_sim` still green.
+- Launch on iPhone 16 Pro sim, verify:
+  - Populated list renders with correct today-state per habit.
+  - Tap a binary habit → haptic fires, row checks.
+  - Tap again → haptic fires, row unchecks.
+  - Tap a counter/timer → no change, no haptic.
+  - After app restart, toggled state persists (SwiftData autosave).
+- `screenshot` capture for the PR.
+
+**Commit message (suggested)**:
+`feat(today): list habits due today and tap-to-toggle completion`
+
+---
+
+### Task 6: (Optional) UI polish pass
+
+**Goal**: Small refinements uncovered during Task 5 — visual
+spacing, accessibility labels, DST edge-cases observed in preview.
+
+**Changes**: TBD; only commit if Task 5 surfaces something.
+
+**Commit message (suggested)**:
+`refactor(today): <specific refinement>`
+
+## Risks and mitigation
+
+- **`#Predicate` on `archivedAt == nil` may hit a toolchain quirk.**
+  Mitigation: Task 5's fallback path — unfiltered `@Query`, filter
+  in memory. Cost is negligible at ≤50 habits (v0.1 scale).
+- **`.sensoryFeedback` may fire on first render if `isCompletedToday`
+  is initially true.** Mitigation: verify on simulator. Fix with
+  `.sensoryFeedback(trigger:action:)` (the transform variant) if
+  needed, only firing on `false → true` transitions.
+- **ModelContext writes on MainActor.** `CompletionToggler` is
+  marked `@MainActor`. The view body is already on MainActor.
+  Tests call it from MainActor-isolated test cases
+  (`@MainActor struct`).
+- **Daily rollover while app is open** (past midnight). Out of
+  scope for this PR — noted in research, fix lands with a
+  `ScenePhase` observer later.
+- **Counter/timer read-only rendering might confuse users** who
+  expect to interact. Mitigation: trailing label makes state
+  visible; onboarding/detail-view PR will address interaction.
+
+## Open questions
+
+None — all resolved in research.
+
+## Out of scope
+
+- Create-habit flow (next PR).
+- Habit detail view (later PR).
+- Counter / timer interaction (detail view PR; timer also needs
+  Live Activities design, v0.3).
+- Swipe-to-archive and long-press actions on rows.
+- App icon, colors, icon picker per habit.
+- Past-midnight refresh.
+- Score badge on the row (deliberately deferred).

--- a/docs/plans/2026-04/today-view/plan.md
+++ b/docs/plans/2026-04/today-view/plan.md
@@ -212,15 +212,38 @@ optional tap action for binary/negative.
 
 ---
 
-### Task 6: (Optional) UI polish pass
+### Task 6: (Optional) UI polish pass — skipped
 
-**Goal**: Small refinements uncovered during Task 5 — visual
-spacing, accessibility labels, DST edge-cases observed in preview.
+No issues surfaced during Task 5 that warrant a polish pass. Empty
+state renders cleanly in the simulator; previews cover populated
+and "nothing due today" states. Counter/timer trailing labels show
+target only (no today's value) because there's no path to create
+counter/timer completions until the detail view ships — revisit
+when that lands.
 
-**Changes**: TBD; only commit if Task 5 surfaces something.
+## Notes during build
 
-**Commit message (suggested)**:
-`refactor(today): <specific refinement>`
+- **Task 5 manual verification**: the production `ModelContainer` is
+  file-backed and starts empty, so tap-to-toggle couldn't be tested
+  end-to-end on the simulator in this PR. Previews cover the
+  populated rendering. Full manual verification (tap → haptic →
+  persisted state) unlocks once the Create-habit PR lands.
+- **XcodeBuildMCP destination flakiness**: `build_sim` and
+  `test_sim` occasionally fail with
+  `Unable to find a destination matching { platform:iOS Simulator, OS:latest, name:iPhone 17 Pro }`
+  even though the sim is booted and iOS 26.4 simulator SDK is
+  installed. The error cites the missing iOS 26.4 device SDK —
+  xcodebuild seems to walk all scheme destinations and give up
+  when device-side resolution fails. Workaround: shut down and
+  reboot the simulator, then rerun. Cleaning DerivedData also
+  helps. Worth promoting as a CLAUDE.md lesson.
+- **`#Predicate<HabitRecord> { $0.archivedAt == nil }` worked first
+  try** — the fallback path (unfiltered `@Query` + in-memory
+  archive filter) stayed a spec-only contingency.
+- **`.sensoryFeedback(.success, trigger: isCompletedToday)` on the
+  outer view** fires on both true→false and false→true transitions,
+  giving tactile confirmation on tap and undo. No first-render
+  spurious fire observed.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-04/today-view/research.md
+++ b/docs/plans/2026-04/today-view/research.md
@@ -1,0 +1,229 @@
+---
+# Research — Today View
+
+**Date**: 2026-04-17
+**Status**: draft
+**Related**: [ROADMAP v0.1 — Views](../../../ROADMAP.md), [swiftdata-models compound](../swiftdata-models/compound.md), [habit-score-calculator compound](../habit-score-calculator/compound.md)
+
+## Problem
+
+v0.1 needs a working Today tab: the user opens the app, sees the
+habits due today, taps one to mark it complete, feels a haptic. This
+is the app's daily touchpoint — every other flow is secondary.
+
+Persistence (HabitRecord / CompletionRecord), frequency evaluation,
+and score calculation all exist as services. Nothing consumes them in
+a view yet. The current `TodayView` is a `ContentUnavailableView`
+placeholder.
+
+Constraints framing the solution:
+
+- **No create-habit flow yet**. Either this PR stubs one, or the app
+  is unusable in production until the next PR.
+- **Four `HabitType`s**: binary, counter, timer, negative. v0.1
+  roadmap says "tap to complete" — binary is obvious, the others need
+  a decision.
+- **CLAUDE.md**: "prefer `@Query` in simple views, explicit
+  descriptor + fetch in services for complex logic." Today leans
+  "simple view" if the filtering logic stays local.
+
+## Current state of the codebase
+
+What exists:
+
+- [HabitRecord](../../../../Kado/Models/Persistence/HabitRecord.swift) —
+  `@Model`, `snapshot: Habit` projection, `completions` relationship.
+- [CompletionRecord](../../../../Kado/Models/Persistence/CompletionRecord.swift) —
+  `@Model`, parent `habit: HabitRecord?`, `snapshot: Completion`.
+- [DefaultFrequencyEvaluator](../../../../Kado/Services/DefaultFrequencyEvaluator.swift) —
+  `isDue(habit:on:completions:)`, calendar-aware, handles all four
+  `Frequency` cases.
+- [DefaultHabitScoreCalculator](../../../../Kado/Services/DefaultHabitScoreCalculator.swift) —
+  `currentScore(...)`, `scoreHistory(...)`. Not needed for v0.1 Today
+  row, but useful later.
+- [EnvironmentValues+Services](../../../../Kado/App/EnvironmentValues+Services.swift) —
+  registers `habitScoreCalculator` via `EnvironmentKey`. Pattern for
+  adding `frequencyEvaluator`.
+- [PreviewContainer](../../../../Kado/Preview%20Content/PreviewContainer.swift) —
+  seeds 5 habits (one of each type combo) with partial completion
+  history. Previews can rely on it.
+- [KadoApp](../../../../Kado/App/KadoApp.swift) —
+  wires the file-backed `ModelContainer` via `.modelContainer(_:)`.
+
+What's missing:
+
+- `frequencyEvaluator` in `EnvironmentValues`.
+- Any way to insert a `HabitRecord` from the UI.
+- Anywhere that reads a `ModelContext` from within a view.
+- A row component for a habit.
+- Haptic wiring.
+
+## Proposed approach
+
+Single PR, strictly the Today list + tap-to-complete for **binary
+and negative** habits. Counter/timer rows render but tap opens a
+"Not yet — opens in habit detail" behavior (we'll wire properly once
+the detail view lands). Create-habit and habit-detail each get their
+own PR next.
+
+### Key components
+
+- **`TodayView`** (rewritten): `@Query` fetches active `HabitRecord`s
+  (predicate: `archivedAt == nil`, sorted by `createdAt`); computed
+  property uses `FrequencyEvaluator` to filter to "due today";
+  renders a `List` of rows. Uses `@Environment(\.modelContext)` for
+  inserts/deletes, `@Environment(\.frequencyEvaluator)` for filtering,
+  and `@Environment(\.calendar)` for day arithmetic.
+- **`HabitRowView`** (new, in `UIComponents/`): takes a `HabitRecord`,
+  displays name + type-specific state (checkmark for binary/negative,
+  "x/y" for counter, "mm:ss / target" for timer), tap action
+  closure. `.sensoryFeedback(.success, trigger:)` on the completion
+  count so haptic fires on insert.
+- **`frequencyEvaluator` environment key**: mirror of existing
+  `habitScoreCalculator`. Added to `EnvironmentValues+Services.swift`.
+- **Empty state**: `ContentUnavailableView` with a "Create habit"
+  button. In this PR the button is wired to a **disabled** action
+  with a TODO comment pointing at the next PR. Keeps the UI truthful
+  without bloating scope.
+
+### Data flow for "tap to complete" (binary)
+
+1. User taps row.
+2. Row fires closure: `complete(habit:)`.
+3. `TodayView` creates a `CompletionRecord(date: .now, value: 1, habit: habit)`
+   and inserts into `modelContext`. `try? modelContext.save()` — or
+   let SwiftData autosave.
+4. `@Query` re-runs on the context change; the row sees an updated
+   `today's completion` count and renders checked.
+5. `.sensoryFeedback` observes the count and fires `.success`.
+
+**Undo**: tap a completed binary habit today → find today's
+completion, delete it. Same path in reverse.
+
+### Data model changes
+
+None. All `@Model` shapes stay as-is.
+
+### UI changes
+
+- Replace `TodayView` body.
+- Add `HabitRowView`.
+- Add `frequencyEvaluator` environment key.
+- Leave `ContentView` tab shell untouched.
+
+### Tests to write
+
+Unit tests (Swift Testing, in-memory `ModelContainer`, no
+`@MainActor` required for the pure logic):
+
+```swift
+@Test("Today list contains only non-archived habits that are due today")
+@Test("Toggling a binary habit inserts a completion with value 1 dated today")
+@Test("Toggling a binary habit that's already done today deletes today's completion")
+@Test("Counter/timer habits are listed but tap does nothing (stub)")
+@Test("An archived habit is not listed")
+@Test("A habit with .specificDays frequency not matching today is not listed")
+```
+
+If we extract the toggle logic into a small helper (e.g.
+`TodayCompletionToggler` or a `TodayViewModel.toggle(habit:)`), tests
+land on the helper rather than the SwiftUI view. Leaning toward
+**not** adding a ViewModel — the logic is ~10 lines and fits in the
+view cleanly. Tests instead target a free function
+`toggleBinary(habit:on:in:)` in a new `Services/` file.
+
+UI-level: previews cover the list with `PreviewContainer.shared`,
+plus an empty-state preview with an empty in-memory container.
+
+## Alternatives considered
+
+### Alternative A: Full counter/timer interaction in this PR
+
+- Idea: Counter = `+1` tap increments today's completion value; timer
+  = tap starts a session, tap-to-stop logs elapsed seconds.
+- Why not: Timer especially needs persistent state across app
+  backgrounding — that's a Live Activities / ActivityKit concern, v0.3
+  scope. Counter could be done but forces a UX decision (overshoot?
+  long-press to set explicit value?) that belongs with the detail
+  view. Deferring keeps the PR honest.
+
+### Alternative B: Introduce a `@Observable TodayViewModel`
+
+- Idea: Move fetch + filter + toggle logic into a class,
+  `TodayView` becomes a thin renderer.
+- Why not: `@Query` already provides the reactive fetch. The filter
+  is a 3-line computed property. The toggle is a 5-line function.
+  A ViewModel here is structure for structure's sake. CLAUDE.md
+  explicitly says simple views can skip them.
+
+### Alternative C: Stub the "Create habit" flow in this PR
+
+- Idea: Add a minimal sheet with just a name field, default
+  `.daily` / `.binary`. Lets the user exit the empty state.
+- Why not: Even a "minimal" new-habit form has decisions (icon
+  picker? color? frequency UI?) that belong in their own research
+  pass. This PR stays focused; next PR is "New Habit MVP."
+- Mitigation: ship this PR with `PreviewContainer` still driving
+  previews; production empty state shows the disabled button plus a
+  reassuring "Coming in the next update" (or just a greyed-out
+  button — we'll decide during build).
+
+### Alternative D: Predicate-level "is due" filter in `@Query`
+
+- Idea: Push the filter into the `#Predicate` so `@Query` returns
+  only due habits.
+- Why not: `FrequencyEvaluator`'s `.daysPerWeek` case needs a
+  7-day lookback over completions — not expressible in SwiftData's
+  predicate macro. The predicate can only do `archivedAt == nil` and
+  maybe a `createdAt` bound. In-memory filter is the right layer.
+
+## Risks and unknowns
+
+- **`@Query` + `#Predicate` quirks on Xcode 26**: the bootstrap
+  project already works with `@Query` in the preview, but this will
+  be the first runtime use of `#Predicate`. If it hits a toolchain
+  bug (echoing the composite-Codable-enum crash from the persistence
+  PR), fall back to `@Query(sort: ...)` unfiltered + filter all
+  habits in memory (filter-out archived at the same time as filter-
+  for-due). Cost: marginal at ≤50 habits, which is v0.1's scale.
+- **Sensory feedback timing**: `.sensoryFeedback` observes a trigger
+  value. If the trigger is the completion row's "is done today"
+  boolean, it fires on both completion AND un-completion. Probably
+  desirable (user gets haptic on undo too). If not, trigger on the
+  count of today's completions with a guard.
+- **Daily rollover**: the view binds to `.now` at render time; if the
+  app is kept open past midnight, the list doesn't refresh. For
+  v0.1 this is fine (user relaunches in the morning). Worth a note;
+  fix with a `Timer.publish` or `ScenePhase` observer later.
+- **Archive filter correctness**: `#Predicate` with `archivedAt == nil`
+  on an optional Date — confirm predicate syntax during build.
+- **MainActor isolation**: `TodayView` body runs on MainActor
+  (SwiftUI default). `FrequencyEvaluator` is `Sendable`, so calling
+  it synchronously is fine.
+
+## Open questions
+
+- [ ] **Counter/timer rows**: render as read-only ("coming in habit
+  detail") or entirely hidden from Today until detail view lands?
+  *Recommendation*: render as read-only — the user should see their
+  full set of habits even if not all are interactive yet.
+- [ ] **Toggle semantics for binary habits already done today**: tap
+  again to un-do, or require swipe-to-delete? *Recommendation*: tap
+  again to un-do (matches Loop, Streaks).
+- [ ] **Empty-state button**: disabled with a "Coming soon" hint, or
+  fully hidden (just the icon + text)? *Recommendation*: visible but
+  disabled, so the next PR wiring it is a 2-line change.
+- [ ] **Row visual density**: full row with icon + name + state, or
+  compact "checklist" style? *Recommendation*: full row for v0.1;
+  revisit once we have icons and colors (post-v0.1).
+- [ ] **Score on the row**: show current score as a small badge, or
+  reserve it for the detail view? *Recommendation*: detail view
+  only. Keep Today's row purely about today's state.
+
+## References
+
+- [SwiftData @Query](https://developer.apple.com/documentation/swiftdata/query)
+- [SwiftData #Predicate](https://developer.apple.com/documentation/foundation/predicate)
+- [SwiftUI .sensoryFeedback](https://developer.apple.com/documentation/swiftui/view/sensoryfeedback(_:trigger:))
+- [ContentUnavailableView](https://developer.apple.com/documentation/swiftui/contentunavailableview)
+- Prior-art UX: Streaks (tap-to-toggle), Loop Habit Tracker (checkbox list), (Not Boring) Habits (animated row)

--- a/docs/plans/2026-04/today-view/research.md
+++ b/docs/plans/2026-04/today-view/research.md
@@ -2,7 +2,7 @@
 # Research — Today View
 
 **Date**: 2026-04-17
-**Status**: draft
+**Status**: ready for plan
 **Related**: [ROADMAP v0.1 — Views](../../../ROADMAP.md), [swiftdata-models compound](../swiftdata-models/compound.md), [habit-score-calculator compound](../habit-score-calculator/compound.md)
 
 ## Problem
@@ -203,22 +203,18 @@ plus an empty-state preview with an empty in-memory container.
 
 ## Open questions
 
-- [ ] **Counter/timer rows**: render as read-only ("coming in habit
-  detail") or entirely hidden from Today until detail view lands?
-  *Recommendation*: render as read-only — the user should see their
-  full set of habits even if not all are interactive yet.
-- [ ] **Toggle semantics for binary habits already done today**: tap
-  again to un-do, or require swipe-to-delete? *Recommendation*: tap
-  again to un-do (matches Loop, Streaks).
-- [ ] **Empty-state button**: disabled with a "Coming soon" hint, or
-  fully hidden (just the icon + text)? *Recommendation*: visible but
-  disabled, so the next PR wiring it is a 2-line change.
-- [ ] **Row visual density**: full row with icon + name + state, or
-  compact "checklist" style? *Recommendation*: full row for v0.1;
-  revisit once we have icons and colors (post-v0.1).
-- [ ] **Score on the row**: show current score as a small badge, or
-  reserve it for the detail view? *Recommendation*: detail view
-  only. Keep Today's row purely about today's state.
+All resolved 2026-04-17:
+
+- [x] **Counter/timer rows**: read-only. Tap is a no-op; real
+  interaction lands with the habit detail view.
+- [x] **Toggle semantics for binary/negative**: tap toggles (done →
+  not done → done). Same gesture for undo.
+- [x] **Empty-state button**: hidden for this PR. Empty state is
+  text-only until the Create-habit PR adds the button + sheet.
+- [x] **Row visual density**: full row (leading indicator, name,
+  trailing state).
+- [x] **Score on the row**: no. Today's row is about today's state
+  only; score lives on the detail view.
 
 ## References
 


### PR DESCRIPTION
## Why?
- v0.1 needs a working Today tab — the app's daily touchpoint
- Persistence, frequency evaluation, and score services existed but nothing consumed them in a view

## What?
- `TodayView` lists active habits due today, pulled from SwiftData via `@Query`
- Tap a binary or negative habit → toggles today's completion with a haptic
- Counter and timer rows render read-only (detail view will wire interaction later)
- Three view states: **no habits**, **nothing due today**, **populated list**
- Empty state is text-only; the Create-habit flow lands in a follow-up PR

## How?
- `@Query(filter: #Predicate<HabitRecord> { $0.archivedAt == nil })` — predicate worked first try on Xcode 26 / iOS 18.4
- In-memory filter via injected `FrequencyEvaluator` (predicates can't express `.daysPerWeek`'s 7-day lookback)
- New `frequencyEvaluator` key in `EnvironmentValues+Services.swift`, mirroring `habitScoreCalculator`
- `HabitRowView` under `UIComponents/`, `Button` or plain row depending on whether `onTap` is nil
- `.sensoryFeedback(.success, trigger: isCompletedToday)` fires on both transitions (tap + undo)
- `CompletionToggler`: 3-line struct with injected `Calendar`, 5 Swift Testing cases including a `Europe/Paris` DST guard
- No ViewModel — `@Query` + computed properties + a free helper cover it
- Research, plan, compound: [`docs/plans/2026-04/today-view/`](https://github.com/scastiel/kado/tree/feature/today-view/docs/plans/2026-04/today-view)

## Next steps
- **Create-habit PR** unlocks end-to-end manual tap-testing (the production container starts empty, so live toggle-testing is gated on having a way to create habits)
- **Habit detail view** will wire counter/timer interaction; revisit passing `todayValue` through to the row then
- **Past-midnight refresh** is deferred — `Date.now` is re-evaluated on render but the view doesn't observe rollover. Fix with a `ScenePhase` observer when it matters
- Two lessons promoted to [CLAUDE.md](https://github.com/scastiel/kado/blob/feature/today-view/CLAUDE.md) in this PR: concrete ViewModel threshold + the `xcrun simctl shutdown all` workaround for flaky destination resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)