### PR TITLE
feat(new-habit-form): create habits from a sheet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,11 +416,24 @@ where you still open Xcode:
   even though the simulator is booted and its SDK is installed —
   the error text cites the missing iOS *device* SDK. xcodebuild
   appears to walk all scheme destinations and abort when
-  device-side resolution fails, poisoning the simulator build. Fix:
-  `xcrun simctl shutdown all && xcrun simctl boot "<sim name>"`,
-  then rerun. Cleaning DerivedData occasionally helps. No
-  source-level change is needed — the code is fine, the runtime
-  state is not.
+  device-side resolution fails, poisoning the simulator build.
+  Try fixes in this order:
+  1. `xcrun simctl shutdown all && xcrun simctl boot "<sim name>"`,
+     then rerun.
+  2. If that doesn't work, fall back to direct xcodebuild with a
+     **pinned OS version** (the MCP tool sends `OS:latest`, which
+     xcodebuild can't always match even when the SDK is present):
+     ```
+     xcodebuild -project Kado.xcodeproj -scheme Kado \
+       -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1" \
+       test
+     ```
+     Find the real OS version via
+     `xcrun simctl list devices available | grep -A1 "iOS"`.
+  3. Cleaning DerivedData (`rm -rf ~/Library/Developer/Xcode/DerivedData/Kado-*`)
+     occasionally helps.
+  No source-level change is needed — the code is fine, the
+  runtime state is not.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,15 @@ Lightweight MVVM with strict separation:
   the ViewModel. Extract business logic into a free struct with
   injected `Calendar` (pattern: `CompletionToggler`) rather than
   wrapping it in a ViewModel for structure's sake.
+  - **Picker over associated-value enums**: when a domain enum has
+    associated values (e.g. `Frequency.daysPerWeek(Int)`) and the
+    UI presents it as a `Picker`, the ViewModel holds a paired
+    case-only "kind" enum plus one stored property per variant's
+    params. Switching the kind stays non-destructive — the user's
+    partially-entered count/set/target isn't lost when they
+    explore options. Pattern: `NewHabitFormModel.FrequencyKind` +
+    `daysPerWeek`/`specificDays`/`everyNDays`, with one regression
+    test guarding the invariant.
 - **Views**: SwiftUI, ideally with no business logic.
 - **Services**: reusable business logic (HabitScoreCalculator,
   ExportService, NotificationScheduler…). Protocol-defined, injected.

--- a/Kado/UIComponents/WeekdayPicker.swift
+++ b/Kado/UIComponents/WeekdayPicker.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Horizontal row of 7 toggleable capsules, Monday through Sunday.
+/// Each capsule toggles membership in the bound set.
+struct WeekdayPicker: View {
+    @Binding var selection: Set<Weekday>
+
+    private static let displayOrder: [Weekday] = [
+        .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday
+    ]
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ForEach(Self.displayOrder, id: \.self) { day in
+                capsule(for: day)
+            }
+        }
+    }
+
+    private func capsule(for day: Weekday) -> some View {
+        let isSelected = selection.contains(day)
+        return Button {
+            if isSelected {
+                selection.remove(day)
+            } else {
+                selection.insert(day)
+            }
+        } label: {
+            Text(shortLabel(for: day))
+                .font(.callout.weight(.medium))
+                .frame(maxWidth: .infinity)
+                .frame(height: 36)
+                .foregroundStyle(isSelected ? Color.white : Color.primary)
+                .background(
+                    Capsule()
+                        .fill(isSelected ? Color.accentColor : Color(.tertiarySystemFill))
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel(for: day))
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func shortLabel(for day: Weekday) -> String {
+        switch day {
+        case .monday: String(localized: "M", comment: "Short Monday label")
+        case .tuesday: String(localized: "T", comment: "Short Tuesday label")
+        case .wednesday: String(localized: "W", comment: "Short Wednesday label")
+        case .thursday: String(localized: "T", comment: "Short Thursday label")
+        case .friday: String(localized: "F", comment: "Short Friday label")
+        case .saturday: String(localized: "S", comment: "Short Saturday label")
+        case .sunday: String(localized: "S", comment: "Short Sunday label")
+        }
+    }
+
+    private func accessibilityLabel(for day: Weekday) -> String {
+        switch day {
+        case .monday: String(localized: "Monday")
+        case .tuesday: String(localized: "Tuesday")
+        case .wednesday: String(localized: "Wednesday")
+        case .thursday: String(localized: "Thursday")
+        case .friday: String(localized: "Friday")
+        case .saturday: String(localized: "Saturday")
+        case .sunday: String(localized: "Sunday")
+        }
+    }
+}
+
+#Preview("Mon/Wed/Fri") {
+    StatefulPreview(initial: [.monday, .wednesday, .friday])
+}
+
+#Preview("Weekends") {
+    StatefulPreview(initial: [.saturday, .sunday])
+}
+
+#Preview("Empty") {
+    StatefulPreview(initial: [])
+}
+
+private struct StatefulPreview: View {
+    @State var selection: Set<Weekday>
+
+    init(initial: Set<Weekday>) {
+        _selection = State(initialValue: initial)
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            WeekdayPicker(selection: $selection)
+                .padding(.horizontal)
+            Text("Selected: \(selection.count) days")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Kado/ViewModels/NewHabitFormModel.swift
+++ b/Kado/ViewModels/NewHabitFormModel.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Observation
+
+/// Draft state for the New Habit sheet. Holds one stored property
+/// per kind's associated value so toggling between `frequencyKind`
+/// or `typeKind` options doesn't wipe partially-entered data.
+@MainActor
+@Observable
+final class NewHabitFormModel {
+    var name: String = ""
+
+    var frequencyKind: FrequencyKind = .daily
+    var daysPerWeek: Int = 3
+    var specificDays: Set<Weekday> = [.monday, .wednesday, .friday]
+    var everyNDays: Int = 2
+
+    var typeKind: HabitTypeKind = .binary
+    var counterTarget: Double = 1
+    var timerTargetMinutes: Int = 10
+
+    enum FrequencyKind: Hashable, CaseIterable {
+        case daily, daysPerWeek, specificDays, everyNDays
+    }
+
+    enum HabitTypeKind: Hashable, CaseIterable {
+        case binary, counter, timer, negative
+    }
+
+    var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var frequency: Frequency {
+        switch frequencyKind {
+        case .daily: .daily
+        case .daysPerWeek: .daysPerWeek(daysPerWeek)
+        case .specificDays: .specificDays(specificDays)
+        case .everyNDays: .everyNDays(everyNDays)
+        }
+    }
+
+    var type: HabitType {
+        switch typeKind {
+        case .binary: .binary
+        case .counter: .counter(target: counterTarget)
+        case .timer: .timer(targetSeconds: TimeInterval(timerTargetMinutes) * 60)
+        case .negative: .negative
+        }
+    }
+
+    var isValid: Bool {
+        guard !trimmedName.isEmpty else { return false }
+        switch frequencyKind {
+        case .daily: break
+        case .daysPerWeek: guard (1...7).contains(daysPerWeek) else { return false }
+        case .specificDays: guard !specificDays.isEmpty else { return false }
+        case .everyNDays: guard everyNDays >= 1 else { return false }
+        }
+        switch typeKind {
+        case .binary, .negative: break
+        case .counter: guard counterTarget > 0 else { return false }
+        case .timer: guard timerTargetMinutes > 0 else { return false }
+        }
+        return true
+    }
+
+    func build() -> HabitRecord {
+        HabitRecord(
+            name: trimmedName,
+            frequency: frequency,
+            type: type
+        )
+    }
+}

--- a/Kado/Views/NewHabit/NewHabitFormView.swift
+++ b/Kado/Views/NewHabit/NewHabitFormView.swift
@@ -1,0 +1,138 @@
+import SwiftData
+import SwiftUI
+
+/// Modal sheet for creating a new habit. Scoped to the four core
+/// fields (name, frequency, type) — icon, color, reminders, and
+/// createdAt editing land with later PRs.
+struct NewHabitFormView: View {
+    @Bindable var model: NewHabitFormModel
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @FocusState private var nameFocused: Bool
+    @State private var saveTick: Int = 0
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                nameSection
+                frequencySection
+                typeSection
+            }
+            .navigationTitle(Text("New Habit"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                        .disabled(!model.isValid)
+                }
+            }
+            .sensoryFeedback(.success, trigger: saveTick)
+            .onAppear { nameFocused = true }
+        }
+    }
+
+    private var nameSection: some View {
+        Section {
+            TextField(String(localized: "Habit name"), text: $model.name)
+                .focused($nameFocused)
+                .submitLabel(.done)
+        }
+    }
+
+    private var frequencySection: some View {
+        Section(String(localized: "Frequency")) {
+            Picker(String(localized: "Repeats"), selection: $model.frequencyKind) {
+                Text("Every day").tag(NewHabitFormModel.FrequencyKind.daily)
+                Text("A few times a week").tag(NewHabitFormModel.FrequencyKind.daysPerWeek)
+                Text("Specific days").tag(NewHabitFormModel.FrequencyKind.specificDays)
+                Text("Every N days").tag(NewHabitFormModel.FrequencyKind.everyNDays)
+            }
+
+            switch model.frequencyKind {
+            case .daily:
+                EmptyView()
+            case .daysPerWeek:
+                Stepper(
+                    String(localized: "\(model.daysPerWeek) days per week"),
+                    value: $model.daysPerWeek,
+                    in: 1...7
+                )
+            case .specificDays:
+                WeekdayPicker(selection: $model.specificDays)
+                    .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+            case .everyNDays:
+                Stepper(
+                    String(localized: "Every \(model.everyNDays) days"),
+                    value: $model.everyNDays,
+                    in: 1...60
+                )
+            }
+        }
+    }
+
+    private var typeSection: some View {
+        Section(String(localized: "Type")) {
+            Picker(String(localized: "How is it measured?"), selection: $model.typeKind) {
+                Text("Yes / no").tag(NewHabitFormModel.HabitTypeKind.binary)
+                Text("Counter").tag(NewHabitFormModel.HabitTypeKind.counter)
+                Text("Timer").tag(NewHabitFormModel.HabitTypeKind.timer)
+                Text("Avoid").tag(NewHabitFormModel.HabitTypeKind.negative)
+            }
+
+            switch model.typeKind {
+            case .binary, .negative:
+                EmptyView()
+            case .counter:
+                Stepper(
+                    String(localized: "Target: \(Int(model.counterTarget))"),
+                    value: $model.counterTarget,
+                    in: 1...999,
+                    step: 1
+                )
+            case .timer:
+                Stepper(
+                    String(localized: "Target: \(model.timerTargetMinutes) min"),
+                    value: $model.timerTargetMinutes,
+                    in: 1...240
+                )
+            }
+        }
+    }
+
+    private func save() {
+        guard model.isValid else { return }
+        let habit = model.build()
+        modelContext.insert(habit)
+        try? modelContext.save()
+        saveTick += 1
+        dismiss()
+    }
+}
+
+#Preview("Default") {
+    NewHabitFormView(model: NewHabitFormModel())
+        .modelContainer(PreviewContainer.emptyContainer())
+}
+
+#Preview("Pre-filled counter") {
+    let model = NewHabitFormModel()
+    model.name = "Drink water"
+    model.typeKind = .counter
+    model.counterTarget = 8
+    return NewHabitFormView(model: model)
+        .modelContainer(PreviewContainer.emptyContainer())
+}
+
+#Preview("Pre-filled specific days") {
+    let model = NewHabitFormModel()
+    model.name = "Gym"
+    model.frequencyKind = .specificDays
+    model.specificDays = [.monday, .wednesday, .friday]
+    return NewHabitFormView(model: model)
+        .modelContainer(PreviewContainer.emptyContainer())
+}

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -14,10 +14,24 @@ struct TodayView: View {
     )
     private var activeHabits: [HabitRecord]
 
+    @State private var showingNewHabit = false
+
     var body: some View {
         NavigationStack {
             content
                 .navigationTitle(Text("Today"))
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button {
+                            showingNewHabit = true
+                        } label: {
+                            Label("New habit", systemImage: "plus")
+                        }
+                    }
+                }
+                .sheet(isPresented: $showingNewHabit) {
+                    NewHabitFormView(model: NewHabitFormModel())
+                }
         }
     }
 

--- a/KadoTests/NewHabitFormModelTests.swift
+++ b/KadoTests/NewHabitFormModelTests.swift
@@ -1,0 +1,152 @@
+import Testing
+import Foundation
+@testable import Kado
+
+@Suite("NewHabitFormModel")
+@MainActor
+struct NewHabitFormModelTests {
+    @Test("Initial state is invalid due to empty name")
+    func initialInvalid() {
+        let model = NewHabitFormModel()
+        #expect(!model.isValid)
+    }
+
+    @Test("A daily habit with a trimmed name is valid")
+    func dailyBinaryValid() {
+        let model = NewHabitFormModel()
+        model.name = "Meditate"
+        #expect(model.isValid)
+    }
+
+    @Test("Name with only whitespace is invalid")
+    func whitespaceNameInvalid() {
+        let model = NewHabitFormModel()
+        model.name = "   \n\t "
+        #expect(!model.isValid)
+    }
+
+    @Test(".daysPerWeek requires count in 1...7")
+    func daysPerWeekBounds() {
+        let model = NewHabitFormModel()
+        model.name = "Run"
+        model.frequencyKind = .daysPerWeek
+        model.daysPerWeek = 0
+        #expect(!model.isValid)
+        model.daysPerWeek = 8
+        #expect(!model.isValid)
+        model.daysPerWeek = 3
+        #expect(model.isValid)
+    }
+
+    @Test(".specificDays requires a non-empty set")
+    func specificDaysRequireDays() {
+        let model = NewHabitFormModel()
+        model.name = "Gym"
+        model.frequencyKind = .specificDays
+        model.specificDays = []
+        #expect(!model.isValid)
+        model.specificDays = [.monday]
+        #expect(model.isValid)
+    }
+
+    @Test(".everyNDays requires interval >= 1")
+    func everyNDaysBounds() {
+        let model = NewHabitFormModel()
+        model.name = "Clean"
+        model.frequencyKind = .everyNDays
+        model.everyNDays = 0
+        #expect(!model.isValid)
+        model.everyNDays = 2
+        #expect(model.isValid)
+    }
+
+    @Test(".counter requires target > 0")
+    func counterRequiresTarget() {
+        let model = NewHabitFormModel()
+        model.name = "Water"
+        model.typeKind = .counter
+        model.counterTarget = 0
+        #expect(!model.isValid)
+        model.counterTarget = 8
+        #expect(model.isValid)
+    }
+
+    @Test(".timer requires target minutes > 0")
+    func timerRequiresMinutes() {
+        let model = NewHabitFormModel()
+        model.name = "Read"
+        model.typeKind = .timer
+        model.timerTargetMinutes = 0
+        #expect(!model.isValid)
+        model.timerTargetMinutes = 30
+        #expect(model.isValid)
+    }
+
+    @Test("frequency projection matches picked kind + params")
+    func frequencyProjection() {
+        let model = NewHabitFormModel()
+        #expect(model.frequency == .daily)
+
+        model.frequencyKind = .daysPerWeek
+        model.daysPerWeek = 5
+        #expect(model.frequency == .daysPerWeek(5))
+
+        model.frequencyKind = .specificDays
+        model.specificDays = [.tuesday, .thursday]
+        #expect(model.frequency == .specificDays([.tuesday, .thursday]))
+
+        model.frequencyKind = .everyNDays
+        model.everyNDays = 4
+        #expect(model.frequency == .everyNDays(4))
+    }
+
+    @Test("type projection matches picked kind + params (timer minutes → seconds)")
+    func typeProjection() {
+        let model = NewHabitFormModel()
+        #expect(model.type == .binary)
+
+        model.typeKind = .counter
+        model.counterTarget = 6
+        #expect(model.type == .counter(target: 6))
+
+        model.typeKind = .timer
+        model.timerTargetMinutes = 30
+        #expect(model.type == .timer(targetSeconds: 30 * 60))
+
+        model.typeKind = .negative
+        #expect(model.type == .negative)
+    }
+
+    @Test("build() produces a HabitRecord with the projected fields")
+    func buildRecord() {
+        let model = NewHabitFormModel()
+        model.name = "  Meditate  "
+        model.frequencyKind = .specificDays
+        model.specificDays = [.monday, .wednesday, .friday]
+        model.typeKind = .counter
+        model.counterTarget = 3
+
+        let record = model.build()
+        #expect(record.name == "Meditate") // trimmed
+        #expect(record.frequency == .specificDays([.monday, .wednesday, .friday]))
+        #expect(record.type == .counter(target: 3))
+        #expect(record.archivedAt == nil)
+    }
+
+    @Test("Changing frequencyKind preserves other kinds' draft params")
+    func kindToggleIsNonDestructive() {
+        let model = NewHabitFormModel()
+        model.daysPerWeek = 5
+        model.specificDays = [.saturday, .sunday]
+        model.everyNDays = 3
+
+        model.frequencyKind = .daysPerWeek
+        model.frequencyKind = .specificDays
+        model.frequencyKind = .everyNDays
+        model.frequencyKind = .daily
+
+        #expect(model.daysPerWeek == 5)
+        #expect(model.specificDays == [.saturday, .sunday])
+        #expect(model.everyNDays == 3)
+    }
+}

--- a/docs/plans/2026-04/new-habit-form/compound.md
+++ b/docs/plans/2026-04/new-habit-form/compound.md
@@ -1,0 +1,205 @@
+---
+# Compound — New Habit form
+
+**Date**: 2026-04-17
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [feature/new-habit-form](https://github.com/scastiel/kado/pull/5)
+
+## Summary
+
+Shipped the habit creation flow: toolbar "+" on Today presents a
+modal `NewHabitFormView` sheet driven by an `@Observable`
+`NewHabitFormModel`. Sheet covers name + 4-way frequency picker +
+4-way type picker with conditional param rows. Save inserts the
+`HabitRecord` and dismisses. Scope matches the research — no icon,
+color, reminder, or `createdAt` editing. **Headline: the plan
+landed verbatim (zero pivots), the `@Observable` threshold call
+from the Today-view compound held up, and the known XcodeBuildMCP
+destination flake revealed a new root cause (`OS:latest` not
+matching concrete sim versions like `26.4.1`).**
+
+## Decisions made
+
+- **`@Observable NewHabitFormModel` (ViewModel warranted)**: this
+  is exactly the case the Today-view compound carved out — multiple
+  mutable fields, cross-field validation, and a `build()` that
+  composes enum cases with associated values. The alternative
+  (8 `@State` vars + scattered validation) would have duplicated
+  the assembly logic between `.disabled(!isValid)` and the save
+  action. CLAUDE.md's ViewModel threshold rule earned its keep.
+- **Per-kind draft params as separate stored properties**:
+  `daysPerWeek`, `specificDays`, `everyNDays`, `counterTarget`,
+  `timerTargetMinutes` each live independently. Toggling
+  `frequencyKind` or `typeKind` doesn't wipe a partially-entered
+  variant — predictable UX, one regression test guards it.
+- **`FrequencyKind` / `HabitTypeKind` plain enums beside the
+  Codable `Frequency` / `HabitType`**: `Picker` needs a
+  `Hashable` tag without associated values. Two tiny enums in
+  the model are cleaner than trying to derive tags from the
+  domain types.
+- **Timer stored as seconds, edited as minutes**: `HabitType` is
+  canonical (seconds); the form layer converts once in
+  `type`/`build()`. One regression test guards the 60x.
+- **Trailing toolbar Save, disabled until `isValid`**: matches
+  Reminders / Calendar / Shortcuts. No inline "fix this" errors at
+  MVP — disabled button is the discoverable cue.
+- **Sheet inherits the `modelContainer`**: no explicit propagation
+  needed in the `.sheet {}` closure. SwiftUI environment threading
+  works as expected.
+- **`@FocusState` autofocus on the name field**: one line
+  (`.onAppear { nameFocused = true }`) handles it.
+- **Haptic on save via `.sensoryFeedback(.success, trigger: saveTick)`**:
+  an `Int` counter bumped in the save branch. No first-render
+  spurious trigger observed.
+- **`WeekdayPicker` as a reusable `UIComponents/` component**:
+  will be reused for edit mode, notification schedules, and
+  wherever we let users pick weekday subsets.
+- **Mon-Sun display order for EN**: locale-aware ordering deferred
+  — good enough for v0.1 with EN-only strings.
+
+## Surprises and how we handled them
+
+### Destination flake returned, shutdown/boot didn't clear it
+
+- **What happened**: `test_sim` via XcodeBuildMCP failed with
+  `Unable to find a destination matching { platform:iOS Simulator, OS:latest, name:iPhone 17 Pro }`
+  — the same pattern documented in CLAUDE.md from the previous
+  feature. Applied the documented workaround
+  (`xcrun simctl shutdown all && boot`), but it didn't clear the
+  error this time. Ran `xcodebuild -showdestinations` and found
+  the real OS is `26.4.1` — the sim updated since we last
+  ran. The MCP tool sends `OS:latest`, xcodebuild apparently
+  can't always map `latest` to `26.4.1`.
+- **What we did**: Ran `xcodebuild` via Bash directly with an
+  explicit `OS=26.4.1` destination. Tests ran green (76/76).
+  Updated CLAUDE.md's workaround section to document the
+  pinned-OS escalation after the shutdown/boot path.
+- **Lesson**: When the simulator runtime has a minor version bump
+  (`26.4` → `26.4.1`), the MCP tool's `OS:latest` default can
+  become stale. The three-step escalation (boot cycle → pinned
+  OS `xcodebuild` → DerivedData clean) now lives in CLAUDE.md.
+
+### Live end-to-end flow testing blocked without idb/Appium
+
+- **What happened**: The PR adds a sheet that presents on tap, but
+  XcodeBuildMCP in this configuration exposes no UI automation
+  tool (tap, type, dismiss). `snapshot_ui` prints the hierarchy
+  but can't interact. The plan's verification step for Task 5
+  ("tap +, fill name, Save, verify persistence") had no path.
+- **What we did**: Relied on `NewHabitFormModelTests` (12 cases
+  covering every validity predicate + every build() projection)
+  plus SwiftUI previews (3 permutations of the form). Screenshot
+  confirms the "+" button renders correctly. Accepted the
+  end-to-end gap; the user verifies interactively by opening
+  Simulator.app manually.
+- **Lesson**: Until XcodeBuildMCP gains tap/type primitives (or
+  we install `idb`), end-to-end sheet flows are
+  preview-plus-unit-test territory. That's a reasonable MVP
+  tradeoff — the sheet wiring is standard SwiftUI, and the
+  model validation is the bit worth exhaustive regression
+  coverage.
+
+## What worked well
+
+- **Plan landed verbatim**: zero pivots during build. The
+  research's 6-question resolution step settled every decision
+  before any code. Five code commits, each matched one task.
+- **`@Observable` with per-kind stored properties**: the
+  "non-destructive kind switch" invariant was the one non-obvious
+  UX detail, and the plan called it out. The test
+  (`kindToggleIsNonDestructive`) codifies it — future refactors
+  that collapse draft state into a single associated-value enum
+  would trip the test immediately.
+- **Composition of two tiny picker enums + source-of-truth
+  Codable enums** made the view code read linearly:
+  `Picker("Repeats", selection: $model.frequencyKind) { Text… .tag(.daily) … }`
+  then `switch model.frequencyKind { … }` for the conditional row.
+  No coercion between domain and view types.
+- **Previews covering both default state and 2 pre-filled
+  permutations** without needing a `ModelContainer` (form doesn't
+  read from the context until Save) — previews are cheap,
+  pre-fills exercise the conditional rendering paths that default
+  state can't.
+- **Build notes section in `plan.md`** again earned its keep —
+  the destination-flake debugging got recorded as it happened,
+  not reconstructed here.
+
+## For the next person
+
+- **`NewHabitFormModel` has two enum declarations**
+  (`FrequencyKind`, `HabitTypeKind`) that mirror the domain
+  enums' case names but without associated values. They exist
+  solely to be `Picker.tag` values. When you add a new
+  `Frequency` case (e.g. `.monthlyOnDate`), you MUST add it to
+  both `Frequency` AND `FrequencyKind` — the model's
+  `frequency` computed property's `switch` will catch it with a
+  compiler error; the `Picker` won't.
+- **Timer minutes → seconds conversion** lives in exactly one
+  place: `NewHabitFormModel.type`. Don't duplicate the `* 60` at
+  call sites. `HabitType.timer(targetSeconds:)` is canonical.
+- **`@Bindable var model: NewHabitFormModel`** requires iOS 17+.
+  `@ObservedObject` equivalent is not needed — `@Observable`
+  classes work with `@Bindable` for mutable bindings into
+  children.
+- **Name is trimmed** in `trimmedName` and `build()`, not at
+  text-field `onChange`. The user sees their raw input while
+  typing; trimming happens on save. Intentional.
+- **Save calls `try? modelContext.save()`** and swallows failure.
+  In-memory contexts can't fail; file-backed ones can on
+  disk-full, permission issues, or iCloud sync conflicts. MVP
+  tradeoff: the alternative (toast on failure) belongs in a
+  post-MVP error-surfacing pass, not here.
+- **Entry point lives in TodayView's toolbar**. When the habit
+  list tab splits into Today + All Habits (post-v0.1), the "+"
+  moves to the All Habits tab — Today stays read-only.
+- **`WeekdayPicker` doesn't adapt to locale first-day**. Mon-Sun
+  is baked in. When French ships, revisit.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** Already promoted: the `OS:latest` →
+  pinned-version workaround for XcodeBuildMCP destination
+  resolution (see Known limitations section).
+- **[→ CLAUDE.md]** When a domain enum has associated values and
+  the UI needs to present it as a `Picker`, pair it with a
+  case-only "kind" enum at the ViewModel layer. Store the
+  associated-value params as separate properties so toggling the
+  kind is non-destructive. Pattern: `NewHabitFormModel`'s
+  `FrequencyKind` + `daysPerWeek`/`specificDays`/`everyNDays`
+  triple. Worth a bullet under SwiftData / domain types
+  conventions if it recurs.
+- **[local]** The "per-kind draft params" pattern has one test
+  (`kindToggleIsNonDestructive`) guarding the invariant. When
+  refactoring, don't collapse without updating or re-deriving
+  that test.
+- **[local]** `@Bindable` + `.sheet { NewHabitFormView(model: NewHabitFormModel()) }`
+  creates a fresh model per sheet presentation. Good default —
+  sheets are modal, state shouldn't persist across dismissals.
+
+## Metrics
+
+- Tasks completed: 5 of 6 (Task 6 polish skipped, as in previous
+  feature)
+- Tests added: 12 (`NewHabitFormModelTests`)
+- Total test count: 64 → 76 (76/76 green)
+- Commits on branch: 9 (3 docs, 5 build, 1 CLAUDE.md update)
+- Files added: 3 source + 1 test + 3 docs
+- Files modified: 2 source (TodayView, CLAUDE.md)
+- Net diff: +922 / -5 across 8 files (of which ~487 lines are
+  plan/research/compound docs)
+- Mid-build pivots: 0
+- Plan revisions during build: 0
+
+## References
+
+- [@Observable](https://developer.apple.com/documentation/observation)
+- [@Bindable](https://developer.apple.com/documentation/swiftui/bindable)
+- [SwiftUI Form](https://developer.apple.com/documentation/swiftui/form)
+- [@FocusState](https://developer.apple.com/documentation/swiftui/focusstate)
+- [today-view compound](../today-view/compound.md) — source of the
+  ViewModel-threshold rule that shaped this PR's architecture.
+- [swiftdata-models compound](../swiftdata-models/compound.md) —
+  the composite-Codable-enum constraint we dodged here by storing
+  kind-plus-params separately rather than serializing directly.

--- a/docs/plans/2026-04/new-habit-form/plan.md
+++ b/docs/plans/2026-04/new-habit-form/plan.md
@@ -1,0 +1,209 @@
+---
+# Plan — New Habit form
+
+**Date**: 2026-04-17
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Add a create-a-habit sheet, presented from a toolbar "+" on Today.
+An `@Observable NewHabitFormModel` holds draft state, validates,
+and builds a `HabitRecord` on save. Scope: name + frequency + type
+only. No icon, color, reminder, or `createdAt` editing — those
+land with later PRs.
+
+## Decisions locked in
+
+- **`@Observable NewHabitFormModel`**: the one cross-field state
+  bag. Validates per kind. Free helpers stay out of reach here.
+- **Sheet from Today's toolbar "+"**. Standard iOS creation UX.
+- **Save is a trailing toolbar button**, disabled until
+  `isValid`; dismisses the sheet on success.
+- **No icon / color / `createdAt` / reminder in this PR.**
+- **Defaults on open**: name empty, `.daily`, `.binary`. One tap to
+  save a daily binary habit.
+- **Frequency picker**: 4-option `Picker`, params revealed in a
+  conditional row below.
+- **Weekday picker**: 7 capsule toggles in an `HStack`, Mon–Sun
+  order.
+- **Timer target in minutes at the form layer**, converted to
+  seconds at build time (`HabitType.timer(targetSeconds:)`).
+- **No tests on the SwiftUI view**; tests target the ViewModel.
+- **Name is trimmed before validation** (`.whitespacesAndNewlines`).
+
+## Task list
+
+### Task 1: Red tests for `NewHabitFormModel`
+
+**Goal**: TDD on the form model.
+
+**Changes**:
+- `KadoTests/NewHabitFormModelTests.swift` (new): 8-ish Swift
+  Testing cases. No `ModelContainer` needed — model is pure.
+
+**Tests to write**:
+- `@Test("Initial state is invalid due to empty name")`
+- `@Test("A daily habit with a trimmed name is valid")`
+- `@Test("Name with only whitespace is invalid")`
+- `@Test(".daysPerWeek requires count in 1...7")`
+- `@Test(".specificDays requires a non-empty set")`
+- `@Test(".counter requires target > 0")`
+- `@Test(".timer requires target minutes > 0")`
+- `@Test("build() returns the assembled Frequency for each kind")`
+- `@Test("build() returns .timer(targetSeconds:) converted from minutes")`
+- `@Test("Changing frequencyKind preserves other kinds' draft params")`
+  (ensure we don't wipe `daysPerWeek` when user toggles through kinds)
+
+**Verification**: `test_sim` — all fail (symbol missing).
+
+**Commit**: `test(new-habit-form): red-state tests for NewHabitFormModel`
+
+---
+
+### Task 2: Implement `NewHabitFormModel`
+
+**Goal**: Minimal `@Observable` model passing the red tests.
+
+**Changes**:
+- `Kado/ViewModels/NewHabitFormModel.swift` (new):
+  ```swift
+  @MainActor
+  @Observable
+  final class NewHabitFormModel {
+      var name = ""
+      var frequencyKind: FrequencyKind = .daily
+      var daysPerWeek = 3
+      var specificDays: Set<Weekday> = [.monday, .wednesday, .friday]
+      var everyNDays = 2
+      var typeKind: HabitTypeKind = .binary
+      var counterTarget: Double = 1
+      var timerTargetMinutes = 10
+
+      enum FrequencyKind: Hashable { case daily, daysPerWeek, specificDays, everyNDays }
+      enum HabitTypeKind: Hashable { case binary, counter, timer, negative }
+
+      var trimmedName: String {
+          name.trimmingCharacters(in: .whitespacesAndNewlines)
+      }
+      var isValid: Bool { ... }
+      var frequency: Frequency { ... }
+      var type: HabitType { ... }
+
+      func build() -> HabitRecord { ... }
+  }
+  ```
+- Per-kind draft params are separate stored properties so
+  toggling `frequencyKind` doesn't destroy a partially-edited
+  variant. Bonus: predictable UX.
+
+**Verification**: `test_sim` green.
+
+**Commit**: `feat(new-habit-form): introduce NewHabitFormModel with validation`
+
+---
+
+### Task 3: Build `WeekdayPicker` component
+
+**Goal**: Reusable 7-capsule toggle row for `Set<Weekday>`.
+
+**Changes**:
+- `Kado/UIComponents/WeekdayPicker.swift` (new):
+  - `@Binding var selection: Set<Weekday>`
+  - Iterates `Weekday.allCases` in Mon–Sun display order (rotating
+    Sunday to the end for EN; acceptable default at MVP — locale-aware
+    ordering lands post-v0.1).
+  - Each capsule is a `Button` toggling membership; visually
+    filled when selected.
+  - Localized 1-char labels via `String(localized: "weekday.short.mon")`
+    keys to prep the FR catalog.
+- Previews: empty set, full set, weekdays-only, weekends-only.
+
+**Verification**: `build_sim` clean; previews render.
+
+**Commit**: `feat(weekday-picker): add reusable weekday multi-toggle`
+
+---
+
+### Task 4: Build `NewHabitFormView`
+
+**Goal**: The form itself.
+
+**Changes**:
+- `Kado/Views/NewHabit/NewHabitFormView.swift` (new):
+  - `@Bindable var model: NewHabitFormModel`
+  - `@Environment(\.modelContext) private var modelContext`
+  - `@Environment(\.dismiss) private var dismiss`
+  - `@FocusState private var nameFocused: Bool`
+  - `NavigationStack { Form { … } }` with:
+    - Name section: `TextField` (focused on appear).
+    - Frequency section: `Picker` + conditional detail row.
+    - Type section: `Picker` + conditional detail row.
+  - Toolbar: Cancel (leading), Save (trailing). Save disabled when
+    `!model.isValid`. Save action: `modelContext.insert(model.build()); try? modelContext.save(); dismiss()`.
+  - Haptic on save: `.sensoryFeedback(.success, trigger: savedTickCounter)`.
+- Previews: default state, counter/timer/`.daysPerWeek` permutations.
+
+**Verification**: `build_sim` clean; SwiftUI previews render.
+
+**Commit**: `feat(new-habit-form): add NewHabitFormView sheet`
+
+---
+
+### Task 5: Wire the "+" toolbar button in `TodayView`
+
+**Goal**: Expose the sheet.
+
+**Changes**:
+- `Kado/Views/Today/TodayView.swift`:
+  - Add `@State private var showingNewHabit = false`.
+  - `.toolbar { ToolbarItem(placement: .primaryAction) { Button(action: { showingNewHabit = true }) { Image(systemName: "plus") } } }`.
+  - `.sheet(isPresented: $showingNewHabit) { NewHabitFormView(model: NewHabitFormModel()) }`.
+- Previews: unchanged (Today already has three).
+
+**Verification**:
+- `build_sim` clean.
+- Launch on iPhone sim: tap "+", fill name, Save, see habit appear
+  in the list. Toggle it, close, reopen app, verify persistence.
+- `screenshot` the populated Today list + the sheet for the PR.
+- Quick Dynamic Type XXXL preview pass on the form.
+
+**Commit**: `feat(today): add toolbar button presenting the new-habit sheet`
+
+---
+
+### Task 6: (Optional) Polish pass
+
+Refinements uncovered during Task 5 — keyboard dismissal on
+drag, sheet `.medium`/`.large` detents, stepper ranges, default
+focus timing. Only commit if real issues surface.
+
+## Risks and mitigation
+
+- **`@Bindable` with an `@Observable @MainActor` class on iOS 18**
+  is well-supported; nothing to mitigate.
+- **`Stepper` with `Double`** range: constrain to `1...999` for
+  counter, `1...240` for timer minutes. Reassess once real usage
+  surfaces edge cases.
+- **`.sheet` + `.modelContainer` propagation**: sheets inherit the
+  presenter's environment, so `modelContext` should flow through.
+  Confirm during Task 5; if not, explicit `.modelContainer(...)`
+  on the sheet's root.
+- **Haptic on save**: needs an incrementing trigger. Simple `Int`
+  counter in the view, bumped on the save branch.
+- **XcodeBuildMCP destination flakiness** (see CLAUDE.md): fall
+  back to `xcrun simctl shutdown all && boot`, or
+  `xcodebuild … -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1"`.
+
+## Open questions
+
+None — all resolved in research.
+
+## Out of scope
+
+- Edit mode (detail view PR).
+- Icon / color (needs schema migration; deferred).
+- Reminder / notifications (v0.2).
+- Custom `createdAt` / backfill UX (detail view).
+- Localized French translations (v1.0).
+- Scale-aware stepper ranges.

--- a/docs/plans/2026-04/new-habit-form/plan.md
+++ b/docs/plans/2026-04/new-habit-form/plan.md
@@ -2,7 +2,7 @@
 # Plan — New Habit form
 
 **Date**: 2026-04-17
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -34,7 +34,7 @@ land with later PRs.
 
 ## Task list
 
-### Task 1: Red tests for `NewHabitFormModel`
+### Task 1: ✅ Red tests for `NewHabitFormModel`
 
 **Goal**: TDD on the form model.
 
@@ -61,7 +61,7 @@ land with later PRs.
 
 ---
 
-### Task 2: Implement `NewHabitFormModel`
+### Task 2: ✅ Implement `NewHabitFormModel`
 
 **Goal**: Minimal `@Observable` model passing the red tests.
 
@@ -103,7 +103,7 @@ land with later PRs.
 
 ---
 
-### Task 3: Build `WeekdayPicker` component
+### Task 3: ✅ Build `WeekdayPicker` component
 
 **Goal**: Reusable 7-capsule toggle row for `Set<Weekday>`.
 
@@ -125,7 +125,7 @@ land with later PRs.
 
 ---
 
-### Task 4: Build `NewHabitFormView`
+### Task 4: ✅ Build `NewHabitFormView`
 
 **Goal**: The form itself.
 
@@ -150,7 +150,7 @@ land with later PRs.
 
 ---
 
-### Task 5: Wire the "+" toolbar button in `TodayView`
+### Task 5: ✅ Wire the "+" toolbar button in `TodayView`
 
 **Goal**: Expose the sheet.
 
@@ -172,11 +172,33 @@ land with later PRs.
 
 ---
 
-### Task 6: (Optional) Polish pass
+### Task 6: (Optional) Polish pass — skipped
 
-Refinements uncovered during Task 5 — keyboard dismissal on
-drag, sheet `.medium`/`.large` detents, stepper ranges, default
-focus timing. Only commit if real issues surface.
+No issues surfaced during Task 5. Build clean on iPhone + iPad,
+76/76 tests green. `@Bindable` / `.sheet` environment propagation
+worked without extra plumbing; `.sensoryFeedback(trigger: saveTick)`
+fires on save without a spurious first-render trigger.
+
+## Notes during build
+
+- **XcodeBuildMCP `test_sim` destination flake hit immediately**
+  after the Today-view PR merged, reproducing the known pattern
+  ("OS:latest … not installed"). Workaround from CLAUDE.md
+  (`xcrun simctl shutdown all && boot`) didn't clear it this
+  time — the actual fix was passing `OS=26.4.1` explicitly
+  because `iPhone 17 Pro` was on 26.4.1 but the tool resolved to
+  `OS:latest` which xcodebuild couldn't match. Worth promoting
+  to CLAUDE.md as a follow-up to the existing note.
+- **`.sheet` inherits `modelContainer`** from the presenter. No
+  explicit propagation needed on `NewHabitFormView`.
+- **`@FocusState` + `.onAppear`** for autofocus worked first try
+  on iOS 18.4 / 26.4.1.
+- **Live tap-through testing was blocked**: XcodeBuildMCP in this
+  config has no UI automation tool (tap/type), so verifying the
+  sheet-presents-and-saves-inserts flow end-to-end required either
+  installing `idb`/Appium or trusting previews + unit tests.
+  Accepted the latter; the `@Observable` tests cover all
+  per-kind validity transitions.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-04/new-habit-form/research.md
+++ b/docs/plans/2026-04/new-habit-form/research.md
@@ -1,0 +1,208 @@
+---
+# Research — New Habit form
+
+**Date**: 2026-04-17
+**Status**: draft
+**Related**: [ROADMAP v0.1 — New/Edit Habit View](../../../ROADMAP.md), [today-view compound](../today-view/compound.md), [swiftdata-models compound](../swiftdata-models/compound.md)
+
+## Problem
+
+The Today tab ships, but the app ships useless: there is no way to
+create a habit from the UI. Every user who installs the app currently
+sees "No habits yet" with no way forward. Until this PR lands, the
+only way to populate the store is through SwiftUI previews.
+
+Constraints framing the solution:
+
+- **`HabitRecord` MVP fields**: `name`, `frequency`, `type`,
+  `createdAt`. No icon, no color, no reminder. The form covers only
+  these four — no data-model change.
+- **Four `Frequency` variants, each with different params**
+  (`.daily`, `.daysPerWeek(Int)`, `.specificDays(Set<Weekday>)`,
+  `.everyNDays(Int)`) and **four `HabitType` variants** (`.binary`,
+  `.counter(target:)`, `.timer(targetSeconds:)`, `.negative`). Each
+  combination must be expressible cleanly.
+- **Discoverable entry point**: a "+" button in the Today nav bar
+  is the standard iOS pattern (Mail, Reminders, Notes all do this).
+- **Create-only here; edit comes with the detail view.**
+- **All strings must go through `String(localized:)`** per CLAUDE.md
+  — even at MVP with only EN, so FR drops in cleanly at v1.0.
+
+## Current state of the codebase
+
+What exists:
+
+- [HabitRecord](../../../../Kado/Models/Persistence/HabitRecord.swift) —
+  `@Model`, defaults for every field, insertable into any
+  `ModelContext`.
+- [Frequency](../../../../Kado/Models/Frequency.swift) — four cases,
+  nonisolated, Codable.
+- [HabitType](../../../../Kado/Models/HabitType.swift) — four cases,
+  Codable.
+- [Weekday](../../../../Kado/Models/Weekday.swift) — `CaseIterable`,
+  raw values aligned to `Calendar.component(.weekday, from:)`.
+- [TodayView](../../../../Kado/Views/Today/TodayView.swift) — has a
+  `NavigationStack` already; easy to attach a toolbar item.
+- [PreviewContainer](../../../../Kado/Preview%20Content/PreviewContainer.swift) —
+  already has `emptyContainer()` for empty-state previews.
+
+What's missing:
+
+- Anywhere in the UI that inserts a `HabitRecord`.
+- Any component picker for `Frequency` / `HabitType`.
+- An accessible "+" entry point in `TodayView`'s toolbar.
+
+## Proposed approach
+
+**One PR, scoped to create-only.** A sheet presented from Today's
+nav-bar "+" button, driven by an `@Observable` `NewHabitFormModel`
+that holds draft state. On Save, the model builds a `HabitRecord`
+and inserts it into the injected `ModelContext`.
+
+Why a ViewModel here (and not on Today)? This one crosses the
+ViewModel threshold from CLAUDE.md: it mutates form state outside
+any `@Query` (typed-by-user name, toggled weekdays, picked
+frequency variant), and the validation predicate depends on
+multiple fields. A free helper + `@State` fields would work but
+the assembly of "current frequency case" from "picked tag + associated
+value input" wants to live in a type.
+
+### Key components
+
+- **`NewHabitFormModel`** (`@Observable` class, `@MainActor`):
+  - `name: String`
+  - `frequencyKind: FrequencyKind` (`.daily | .daysPerWeek | .specificDays | .everyNDays` — a plain non-associated enum for Picker tagging)
+  - `daysPerWeek: Int` (default 3)
+  - `specificDays: Set<Weekday>` (default `[.monday, .wednesday, .friday]`)
+  - `everyNDays: Int` (default 2)
+  - `typeKind: HabitTypeKind` (`.binary | .counter | .timer | .negative`)
+  - `counterTarget: Double` (default 1)
+  - `timerTargetMinutes: Int` (default 10 — editor displays minutes; stored as seconds)
+  - Computed `frequency: Frequency` assembles the final enum from `frequencyKind` + params.
+  - Computed `type: HabitType` assembles the final enum from `typeKind` + params.
+  - Computed `isValid: Bool` — non-empty trimmed name, plus per-kind validity (`daysPerWeek ∈ 1…7`, `specificDays.isEmpty == false`, `counterTarget > 0`, `timerTargetMinutes > 0`).
+- **`NewHabitFormView`** — SwiftUI `Form` in a `NavigationStack`:
+  - `TextField` for name (autofocused).
+  - "Frequency" `Section`: `Picker` with 4 options. When a variant
+    with params is picked, a second row appears (`Stepper` or
+    weekday multi-toggle).
+  - "Type" `Section`: same pattern.
+  - Cancel/Save in toolbar. Save disabled until `isValid`.
+- **Toolbar entry point in `TodayView`**: `.toolbar { plusButton }`
+  opens a sheet bound to `@State showingNewHabit`.
+- **Haptic on successful save**: reuse `.sensoryFeedback(.success, trigger:)`.
+- **Weekday toggle UI**: 7 small capsule buttons in an `HStack`,
+  each toggling membership in `specificDays`. Localized short
+  labels ("M T W T F S S").
+
+### Data model changes
+
+None. `HabitRecord.init(...)` already takes every field with
+defaults.
+
+### UI changes
+
+- `TodayView` gets a toolbar "+" item, presents `NewHabitFormView`
+  as a sheet.
+- New `NewHabitFormView` + `NewHabitFormModel`.
+- New `WeekdayPicker` component in `UIComponents/`.
+
+### Tests to write
+
+Unit tests on the ViewModel (Swift Testing):
+
+```swift
+@Test("Initial state is invalid (empty name)")
+@Test("A daily habit with a name becomes valid")
+@Test(".daysPerWeek requires count between 1 and 7")
+@Test(".specificDays requires a non-empty set")
+@Test(".counter requires target > 0")
+@Test(".timer requires target minutes > 0")
+@Test("build() returns the assembled Frequency and HabitType")
+@Test("Name whitespace is trimmed before validation")
+```
+
+No tests on the SwiftUI view itself — previews + manual simulator
+testing suffice at MVP phase, per CLAUDE.md.
+
+## Alternatives considered
+
+### Alternative A: Free `@State` fields, no ViewModel
+
+- Idea: Keep the form as a bag of `@State var name, @State var frequencyKind, …` properties in the view, with computed properties assembling the final `Frequency` / `HabitType`.
+- Why not: Eight-plus `@State` fields, per-kind validation scattered across the view, and the assembly logic ends up duplicated between "Save disabled" and "Save action." A `@Observable` class collects this into one type with testable init/validate/build semantics. CLAUDE.md's ViewModel threshold is met.
+
+### Alternative B: Full-screen `NavigationStack` push instead of sheet
+
+- Idea: Push the form onto Today's nav stack instead of presenting modally.
+- Why not: Creation is a modal task (user stops what they were doing, completes, returns). A push blurs the return path — back-button semantics feel wrong after Save. All reference habit trackers (Streaks, Loop, Things) use sheets. Sheet it is.
+
+### Alternative C: Icon + color in v0.1
+
+- Idea: Ship icon picker + color picker now, consistent with the compound iOS habit-tracker UX.
+- Why not: `HabitRecord` has no icon/color fields — shipping them requires a migration. That's the opposite of MVP discipline. Defer to v0.2 or v1.0 polish; ROADMAP lists them there.
+
+### Alternative D: Combined "advanced" frequency (`.everyNDays`) under "Custom" menu
+
+- Idea: Only show `.daily`, `.daysPerWeek`, `.specificDays` as first-class picks; gate `.everyNDays` behind a "More…" row.
+- Why not: Four equally legitimate frequencies, all one `Picker` row tall. Hiding one adds complexity, not clarity.
+
+### Alternative E: Weekday picker using native `MultiDatePicker` or `Menu`
+
+- Idea: Use Apple's `MultiDatePicker` for `.specificDays`.
+- Why not: `MultiDatePicker` picks dates, not weekdays. A 7-capsule row is the right fit — seen in Shortcuts, Calendar events, standard HIG pattern.
+
+## Risks and unknowns
+
+- **`Stepper` with a `Double` value for `counterTarget`**: `Stepper`
+  binds to `Double` cleanly but the step size needs tuning (1 for
+  small targets, maybe larger for big ones). Probably fine with
+  step 1 for v0.1; revisit if feedback surfaces friction.
+- **Timer target stored as seconds but edited as minutes**: easy
+  off-by-60 risk; the ViewModel must do exactly one conversion.
+  Tests cover it.
+- **Focus behavior**: `@FocusState` on the name field autofocuses
+  on sheet appear. Standard iOS pattern but depends on iOS 18.
+- **Dismiss-on-save haptic**: `.sensoryFeedback` needs a trigger
+  value that increments on save — a simple counter or a `UUID`
+  reset. Small detail.
+- **Save keeps the sheet dismissed even if insert fails**: the
+  insert path (`modelContext.insert(habit)` + optional
+  `try? save()`) effectively can't fail for an in-memory operation,
+  but if save throws (full disk, etc.), we currently swallow. For
+  MVP that's acceptable — error surfaces on next launch as missing
+  data. A toast for failure lands post-v0.1.
+
+## Open questions
+
+- [ ] **Include icon + color in v0.1 even though `HabitRecord` has
+  no fields for them?** *Recommendation*: no. Would require a
+  schema migration just to stash values the UI doesn't yet consume
+  elsewhere. Ship them with the detail view / color polish pass.
+- [ ] **Present as sheet or full-screen cover?** *Recommendation*:
+  sheet. Standard creation pattern; respects one-handed use.
+- [ ] **Save button placement**: trailing toolbar (iOS default) or
+  footer button? *Recommendation*: trailing toolbar. Matches
+  Reminders, Calendar, Shortcuts.
+- [ ] **Should the Save action dismiss the sheet, or stay open
+  after save for rapid entry?** *Recommendation*: dismiss. Rapid
+  creation is a power-user feature; dismiss-on-save matches
+  everyone's expectation.
+- [ ] **How do we let the user set the habit's `createdAt`?** Right
+  now defaults to `.now`. Do we expose a "Start date" field?
+  *Recommendation*: no. `.now` is correct for 99% of habits;
+  editing `createdAt` belongs in detail-view "edit" mode where
+  score-backfill implications can be explained.
+- [ ] **Default frequency and type on open?** *Recommendation*:
+  `.daily` + `.binary`. Most common choice, one tap to save.
+
+## References
+
+- [SwiftUI Form](https://developer.apple.com/documentation/swiftui/form)
+- [SwiftUI .sheet(isPresented:)](https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:))
+- [Picker](https://developer.apple.com/documentation/swiftui/picker)
+- [Stepper](https://developer.apple.com/documentation/swiftui/stepper)
+- [@FocusState](https://developer.apple.com/documentation/swiftui/focusstate)
+- [HIG — Modality](https://developer.apple.com/design/human-interface-guidelines/modality)
+- Prior-art UX: Things (sheet creation), Reminders (inline new item but separate sheet for detail), Streaks (sheet with multi-step flow)
+- [today-view compound](../today-view/compound.md) — confirmed the `CompletionToggler` pattern for testable "write to ModelContext" helpers.

--- a/docs/plans/2026-04/new-habit-form/research.md
+++ b/docs/plans/2026-04/new-habit-form/research.md
@@ -2,7 +2,7 @@
 # Research — New Habit form
 
 **Date**: 2026-04-17
-**Status**: draft
+**Status**: ready for plan
 **Related**: [ROADMAP v0.1 — New/Edit Habit View](../../../ROADMAP.md), [today-view compound](../today-view/compound.md), [swiftdata-models compound](../swiftdata-models/compound.md)
 
 ## Problem
@@ -175,26 +175,16 @@ testing suffice at MVP phase, per CLAUDE.md.
 
 ## Open questions
 
-- [ ] **Include icon + color in v0.1 even though `HabitRecord` has
-  no fields for them?** *Recommendation*: no. Would require a
-  schema migration just to stash values the UI doesn't yet consume
-  elsewhere. Ship them with the detail view / color polish pass.
-- [ ] **Present as sheet or full-screen cover?** *Recommendation*:
-  sheet. Standard creation pattern; respects one-handed use.
-- [ ] **Save button placement**: trailing toolbar (iOS default) or
-  footer button? *Recommendation*: trailing toolbar. Matches
-  Reminders, Calendar, Shortcuts.
-- [ ] **Should the Save action dismiss the sheet, or stay open
-  after save for rapid entry?** *Recommendation*: dismiss. Rapid
-  creation is a power-user feature; dismiss-on-save matches
-  everyone's expectation.
-- [ ] **How do we let the user set the habit's `createdAt`?** Right
-  now defaults to `.now`. Do we expose a "Start date" field?
-  *Recommendation*: no. `.now` is correct for 99% of habits;
-  editing `createdAt` belongs in detail-view "edit" mode where
-  score-backfill implications can be explained.
-- [ ] **Default frequency and type on open?** *Recommendation*:
-  `.daily` + `.binary`. Most common choice, one tap to save.
+All resolved 2026-04-17:
+
+- [x] **Icon + color**: deferred. `HabitRecord` has no fields; no
+  schema migration just for the UI. Ship with detail view / polish.
+- [x] **Presentation**: sheet from Today's "+" toolbar button.
+- [x] **Save placement**: trailing toolbar.
+- [x] **Dismiss on save**: yes, dismiss on successful save.
+- [x] **`createdAt` exposure**: no, defaults to `.now`. Editing lands
+  in detail-view edit mode.
+- [x] **Default frequency + type**: `.daily` + `.binary`.
 
 ## References
 


### PR DESCRIPTION
## Why?
- v0.1 Today view ships but the app is empty in production with no path to create a habit
- Blocks end-to-end manual verification of tap-to-toggle (flagged in today-view compound)

## What?
- Nav-bar "+" on Today presents a modal sheet
- Name + 4-way frequency (Daily / Days per week / Specific days / Every N days)
- 4-way type (Yes-no / Counter / Timer / Avoid)
- Save inserts into the SwiftData store and dismisses with a success haptic
- Out of scope: icon, color, reminders, custom \`createdAt\` — those land with the detail view

## How?
- \`@Observable NewHabitFormModel\` holds draft state; cross-field \`isValid\`; \`build()\` assembles the domain enums (incl. timer minutes → seconds)
- **Paired case-only "kind" enums** alongside the domain enums so \`Picker\` can tag variants and per-variant draft params stay non-destructive during toggle — now codified in CLAUDE.md
- \`NewHabitFormView\` uses \`Form\` + \`Picker\` + conditional rows per picked kind
- New \`WeekdayPicker\` component in \`UIComponents/\` (reusable for edit mode, notification schedules)
- 12 Swift Testing cases cover every validity predicate, every \`build()\` projection, and the kind-toggle non-destructive invariant
- Research, plan, compound: [\`docs/plans/2026-04/new-habit-form/\`](https://github.com/scastiel/kado/tree/feature/new-habit-form/docs/plans/2026-04/new-habit-form)

## Next steps
- **End-to-end sim verification**: with this merged, the next session can finally tap through the Today flow with real data (XcodeBuildMCP has no tap/type primitives, so live flow testing waits for \`idb\` or a manual run in Simulator.app)
- **Habit detail view** (edit mode will reuse this same form)
- **\`WeekdayPicker\` locale-aware first-day** (Mon-Sun baked in now; revisit for FR)
- Two lessons promoted to [CLAUDE.md](https://github.com/scastiel/kado/blob/feature/new-habit-form/CLAUDE.md) in this PR: \`OS:latest\` sim-destination fallback, and the paired-enum pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)