### PR TITLE
feat(habit-detail-view): detail screen with streak, edit, and archive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,15 @@ zone) when DST behavior is under test. The `TestCalendar` helper in
   `NotificationScheduling`) rather than a form (`HabitScoreCalculatorProtocol`).
 - Files: one primary type per file, filename = type name.
 
+### Switch-returning computed properties
+When a `switch` inside a computed property has **any arm** with
+multi-statement logic, put explicit `return` on **every** arm.
+Swift's implicit-return-from-switch only applies when every arm
+is a single expression; mixing `case .x: "literal"` with a
+multi-statement arm that uses `return` raises
+`"missing return in getter expected to return 'T'"` — a confusing
+error for an easy fix. When in doubt, be consistent.
+
 ### File organization
 ```
 Kado/

--- a/Kado/App/EnvironmentValues+Services.swift
+++ b/Kado/App/EnvironmentValues+Services.swift
@@ -22,6 +22,10 @@ private struct FrequencyEvaluatorKey: EnvironmentKey {
     static let defaultValue: any FrequencyEvaluating = DefaultFrequencyEvaluator()
 }
 
+private struct StreakCalculatorKey: EnvironmentKey {
+    static let defaultValue: any StreakCalculating = DefaultStreakCalculator()
+}
+
 extension EnvironmentValues {
     var habitScoreCalculator: any HabitScoreCalculating {
         get { self[HabitScoreCalculatorKey.self] }
@@ -31,5 +35,10 @@ extension EnvironmentValues {
     var frequencyEvaluator: any FrequencyEvaluating {
         get { self[FrequencyEvaluatorKey.self] }
         set { self[FrequencyEvaluatorKey.self] = newValue }
+    }
+
+    var streakCalculator: any StreakCalculating {
+        get { self[StreakCalculatorKey.self] }
+        set { self[StreakCalculatorKey.self] = newValue }
     }
 }

--- a/Kado/Services/DefaultStreakCalculator.swift
+++ b/Kado/Services/DefaultStreakCalculator.swift
@@ -1,0 +1,231 @@
+import Foundation
+
+struct DefaultStreakCalculator: StreakCalculating {
+    let calendar: Calendar
+
+    init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    func current(for habit: Habit, completions: [Completion], asOf date: Date) -> Int {
+        let endDate = habit.archivedAt ?? date
+        let end = calendar.startOfDay(for: endDate)
+        let createdDay = calendar.startOfDay(for: habit.createdAt)
+        guard end >= createdDay else { return 0 }
+
+        switch habit.frequency {
+        case .daysPerWeek(let target):
+            return currentDaysPerWeek(target: target, habit: habit, completions: completions, end: end, createdDay: createdDay)
+        default:
+            return currentByDay(habit: habit, completions: completions, end: end, createdDay: createdDay)
+        }
+    }
+
+    func best(for habit: Habit, completions: [Completion], asOf date: Date) -> Int {
+        let endDate = habit.archivedAt ?? date
+        let end = calendar.startOfDay(for: endDate)
+        let createdDay = calendar.startOfDay(for: habit.createdAt)
+        guard end >= createdDay else { return 0 }
+
+        switch habit.frequency {
+        case .daysPerWeek(let target):
+            return bestDaysPerWeek(target: target, habit: habit, completions: completions, end: end, createdDay: createdDay)
+        default:
+            return bestByDay(habit: habit, completions: completions, end: end, createdDay: createdDay)
+        }
+    }
+
+    // MARK: - Per-day (daily / specificDays / everyNDays / negative)
+
+    private func currentByDay(
+        habit: Habit,
+        completions: [Completion],
+        end: Date,
+        createdDay: Date
+    ) -> Int {
+        let completedDays = completedDaySet(habit: habit, completions: completions)
+        var streak = 0
+        var day = end
+        var isEndDay = true
+
+        while day >= createdDay {
+            let due = isDueByDay(habit: habit, on: day)
+            if !due {
+                day = previousDay(day)
+                isEndDay = false
+                continue
+            }
+
+            let completed = isCompletedByDay(habit: habit, on: day, completedDays: completedDays)
+            if completed {
+                streak += 1
+            } else if isEndDay {
+                // Grace day — don't count, don't break.
+            } else {
+                break
+            }
+            day = previousDay(day)
+            isEndDay = false
+        }
+        return streak
+    }
+
+    private func bestByDay(
+        habit: Habit,
+        completions: [Completion],
+        end: Date,
+        createdDay: Date
+    ) -> Int {
+        let completedDays = completedDaySet(habit: habit, completions: completions)
+        var best = 0
+        var run = 0
+        var day = createdDay
+
+        while day <= end {
+            let due = isDueByDay(habit: habit, on: day)
+            if !due {
+                day = nextDay(day)
+                continue
+            }
+
+            let completed = isCompletedByDay(habit: habit, on: day, completedDays: completedDays)
+            let isEndDay = calendar.isDate(day, inSameDayAs: end)
+            if completed {
+                run += 1
+                best = max(best, run)
+            } else if isEndDay {
+                // End-day grace: don't reset the run, but don't increment.
+            } else {
+                run = 0
+            }
+            day = nextDay(day)
+        }
+        return best
+    }
+
+    // MARK: - Days-per-week
+
+    private func currentDaysPerWeek(
+        target: Int,
+        habit: Habit,
+        completions: [Completion],
+        end: Date,
+        createdDay: Date
+    ) -> Int {
+        guard target > 0 else { return 0 }
+        let filtered = completions.filter { $0.habitID == habit.id }
+        guard let endWeek = calendar.dateInterval(of: .weekOfYear, for: end) else { return 0 }
+
+        var streak = 0
+
+        // Current week: grace. Counts +1 as "streak ends in the current week,"
+        // regardless of how many completions have landed.
+        streak += 1
+
+        var weekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: endWeek.start)!
+
+        while weekStart >= createdDay ||
+              calendar.dateInterval(of: .weekOfYear, for: createdDay)!.start == weekStart {
+            let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart)!
+            let count = completionsInRange(filtered, from: weekStart, through: weekEnd)
+            if count >= target {
+                streak += 1
+            } else {
+                break
+            }
+            weekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: weekStart)!
+        }
+        return streak
+    }
+
+    private func bestDaysPerWeek(
+        target: Int,
+        habit: Habit,
+        completions: [Completion],
+        end: Date,
+        createdDay: Date
+    ) -> Int {
+        guard target > 0 else { return 0 }
+        let filtered = completions.filter { $0.habitID == habit.id }
+        guard let createdWeek = calendar.dateInterval(of: .weekOfYear, for: createdDay),
+              let endWeek = calendar.dateInterval(of: .weekOfYear, for: end) else { return 0 }
+
+        var best = 0
+        var run = 0
+        var weekStart = createdWeek.start
+
+        while weekStart <= endWeek.start {
+            let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart)!
+            let isEndWeek = calendar.isDate(weekStart, inSameDayAs: endWeek.start)
+            let count = completionsInRange(filtered, from: weekStart, through: weekEnd)
+            let qualifies = count >= target
+            let graceCarries = isEndWeek && !qualifies  // don't reset for current week
+            if qualifies {
+                run += 1
+                best = max(best, run)
+            } else if graceCarries {
+                // Don't reset: current week is grace.
+            } else {
+                run = 0
+            }
+            weekStart = calendar.date(byAdding: .weekOfYear, value: 1, to: weekStart)!
+        }
+        return best
+    }
+
+    // MARK: - Day helpers
+
+    private func previousDay(_ day: Date) -> Date {
+        calendar.date(byAdding: .day, value: -1, to: day)!
+    }
+
+    private func nextDay(_ day: Date) -> Date {
+        calendar.date(byAdding: .day, value: 1, to: day)!
+    }
+
+    private func isDueByDay(habit: Habit, on day: Date) -> Bool {
+        switch habit.frequency {
+        case .daily:
+            return true
+        case .specificDays(let weekdays):
+            let weekdayInt = calendar.component(.weekday, from: day)
+            guard let weekday = Weekday(rawValue: weekdayInt) else { return false }
+            return weekdays.contains(weekday)
+        case .everyNDays(let n):
+            guard n > 0 else { return false }
+            let createdDay = calendar.startOfDay(for: habit.createdAt)
+            let delta = calendar.dateComponents([.day], from: createdDay, to: day).day ?? 0
+            return delta >= 0 && delta % n == 0
+        case .daysPerWeek:
+            // Not used — daysPerWeek branches before reaching here.
+            return false
+        }
+    }
+
+    private func completedDaySet(habit: Habit, completions: [Completion]) -> Set<Date> {
+        Set(
+            completions
+                .filter { $0.habitID == habit.id }
+                .map { calendar.startOfDay(for: $0.date) }
+        )
+    }
+
+    private func isCompletedByDay(habit: Habit, on day: Date, completedDays: Set<Date>) -> Bool {
+        let hasCompletion = completedDays.contains(day)
+        switch habit.type {
+        case .negative:
+            return !hasCompletion
+        case .binary, .counter, .timer:
+            return hasCompletion
+        }
+    }
+
+    private func completionsInRange(_ completions: [Completion], from start: Date, through end: Date) -> Int {
+        completions.reduce(into: 0) { count, completion in
+            let day = calendar.startOfDay(for: completion.date)
+            if day >= start && day <= end {
+                count += 1
+            }
+        }
+    }
+}

--- a/Kado/Services/StreakCalculating.swift
+++ b/Kado/Services/StreakCalculating.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Current and best streak for a habit. See `docs/streak.md` for the
+/// full algorithm and per-frequency semantics.
+protocol StreakCalculating: Sendable {
+    /// Consecutive "due days" completed up to `date`. Today (or the
+    /// habit's `archivedAt`) is a grace day — it doesn't break the
+    /// streak if not yet completed.
+    func current(for habit: Habit, completions: [Completion], asOf date: Date) -> Int
+
+    /// Longest consecutive run in the habit's full history.
+    func best(for habit: Habit, completions: [Completion], asOf date: Date) -> Int
+}

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -1,30 +1,17 @@
 import SwiftUI
 
-/// A single row in the Today list. Renders every `HabitType`, but
-/// only binary and negative habits accept tap-to-toggle. Counter and
-/// timer rows are read-only until the habit detail view ships with
-/// per-type input affordances.
+/// A single row in the Today list. Renders every `HabitType`. The
+/// leading circle is an independent Button that toggles completion
+/// for binary/negative habits; the rest of the row is visual only
+/// and composes with a parent `NavigationLink` to push to detail.
+/// For counter/timer, the leading icon is non-interactive (quick-log
+/// affordances live on the detail view).
 struct HabitRowView: View {
     let habit: Habit
     let isCompletedToday: Bool
-    let onTap: (() -> Void)?
+    let onToggle: (() -> Void)?
 
     var body: some View {
-        Group {
-            if let onTap {
-                Button(action: onTap) { rowContent }
-                    .buttonStyle(.plain)
-                    .sensoryFeedback(.success, trigger: isCompletedToday)
-                    .accessibilityHint(Text("Double tap to toggle completion."))
-            } else {
-                rowContent
-            }
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabelText)
-    }
-
-    private var rowContent: some View {
         HStack(spacing: 12) {
             leadingIcon
                 .frame(width: 28, height: 28)
@@ -37,24 +24,45 @@ struct HabitRowView: View {
         }
         .padding(.vertical, 4)
         .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabelText)
     }
 
     @ViewBuilder
     private var leadingIcon: some View {
         switch habit.type {
         case .binary, .negative:
-            Image(systemName: isCompletedToday ? "checkmark.circle.fill" : "circle")
-                .font(.title2)
-                .foregroundStyle(isCompletedToday ? Color.accentColor : Color.secondary)
+            if let onToggle {
+                Button(action: onToggle) {
+                    toggleImage
+                }
+                .buttonStyle(.borderless)
+                .sensoryFeedback(.success, trigger: isCompletedToday)
+                .accessibilityLabel(
+                    isCompletedToday
+                        ? String(localized: "Mark as not done")
+                        : String(localized: "Mark as done")
+                )
+            } else {
+                toggleImage
+            }
         case .counter:
-            Image(systemName: "number.circle")
-                .font(.title2)
-                .foregroundStyle(.secondary)
+            nonInteractiveIcon("number.circle")
         case .timer:
-            Image(systemName: "timer")
-                .font(.title2)
-                .foregroundStyle(.secondary)
+            nonInteractiveIcon("timer")
         }
+    }
+
+    private var toggleImage: some View {
+        Image(systemName: isCompletedToday ? "checkmark.circle.fill" : "circle")
+            .font(.title2)
+            .foregroundStyle(isCompletedToday ? Color.accentColor : Color.secondary)
+    }
+
+    private func nonInteractiveIcon(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.title2)
+            .foregroundStyle(.secondary)
     }
 
     @ViewBuilder
@@ -100,22 +108,22 @@ struct HabitRowView: View {
         HabitRowView(
             habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
             isCompletedToday: false,
-            onTap: {}
+            onToggle: {}
         )
         HabitRowView(
             habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
             isCompletedToday: false,
-            onTap: nil
+            onToggle: nil
         )
         HabitRowView(
             habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now),
             isCompletedToday: false,
-            onTap: nil
+            onToggle: nil
         )
         HabitRowView(
             habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now),
             isCompletedToday: false,
-            onTap: {}
+            onToggle: {}
         )
     }
 }
@@ -125,22 +133,22 @@ struct HabitRowView: View {
         HabitRowView(
             habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
             isCompletedToday: true,
-            onTap: {}
+            onToggle: {}
         )
         HabitRowView(
             habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
             isCompletedToday: true,
-            onTap: nil
+            onToggle: nil
         )
         HabitRowView(
             habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now),
             isCompletedToday: true,
-            onTap: nil
+            onToggle: nil
         )
         HabitRowView(
             habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now),
             isCompletedToday: true,
-            onTap: {}
+            onToggle: {}
         )
     }
 }
@@ -150,12 +158,12 @@ struct HabitRowView: View {
         HabitRowView(
             habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
             isCompletedToday: true,
-            onTap: {}
+            onToggle: {}
         )
         HabitRowView(
             habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
             isCompletedToday: false,
-            onTap: nil
+            onToggle: nil
         )
     }
     .environment(\.dynamicTypeSize, .accessibility3)

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -1,0 +1,234 @@
+import SwiftUI
+
+/// Current-month calendar grid showing completion state per day.
+/// Renders as a 7-column `LazyVGrid` with weekday headers and
+/// leading blanks that align the first day of the month to its
+/// weekday column.
+struct MonthlyCalendarView: View {
+    let habit: Habit
+    let completions: [Completion]
+    var month: Date = .now
+    @Environment(\.calendar) private var calendar
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            monthHeader
+            weekdayHeader
+            LazyVGrid(columns: gridColumns, spacing: 8) {
+                ForEach(0..<leadingBlanks, id: \.self) { _ in
+                    Color.clear.frame(height: 32)
+                }
+                ForEach(daysInMonth, id: \.self) { day in
+                    cell(for: day)
+                        .frame(height: 32)
+                }
+            }
+        }
+    }
+
+    private var gridColumns: [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: 8), count: 7)
+    }
+
+    private var monthHeader: some View {
+        Text(monthTitle)
+            .font(.headline)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private var weekdayHeader: some View {
+        HStack(spacing: 8) {
+            ForEach(weekdayDisplayOrder, id: \.self) { weekday in
+                Text(shortLabel(for: weekday))
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var monthTitle: String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter.string(from: monthStart)
+    }
+
+    private var monthStart: Date {
+        calendar.dateInterval(of: .month, for: month)?.start ?? month
+    }
+
+    private var daysInMonth: [Date] {
+        guard let range = calendar.range(of: .day, in: .month, for: monthStart) else { return [] }
+        return range.compactMap { dayOffset in
+            calendar.date(byAdding: .day, value: dayOffset - 1, to: monthStart)
+        }
+    }
+
+    private var leadingBlanks: Int {
+        let firstWeekday = calendar.component(.weekday, from: monthStart)
+        // Shift so Monday (2) becomes column 0, Tuesday column 1, ..., Sunday column 6.
+        let monStart = (firstWeekday + 5) % 7
+        return monStart
+    }
+
+    private var weekdayDisplayOrder: [Weekday] {
+        [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
+    }
+
+    private func shortLabel(for weekday: Weekday) -> String {
+        switch weekday {
+        case .monday: String(localized: "M", comment: "Short Monday label")
+        case .tuesday: String(localized: "T", comment: "Short Tuesday label")
+        case .wednesday: String(localized: "W", comment: "Short Wednesday label")
+        case .thursday: String(localized: "T", comment: "Short Thursday label")
+        case .friday: String(localized: "F", comment: "Short Friday label")
+        case .saturday: String(localized: "S", comment: "Short Saturday label")
+        case .sunday: String(localized: "S", comment: "Short Sunday label")
+        }
+    }
+
+    @ViewBuilder
+    private func cell(for day: Date) -> some View {
+        let state = state(for: day)
+        let isToday = calendar.isDateInToday(day)
+        let dayNumber = calendar.component(.day, from: day)
+
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(fill(for: state))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .strokeBorder(
+                            isToday ? Color.accentColor : Color.clear,
+                            lineWidth: 2
+                        )
+                )
+            Text("\(dayNumber)")
+                .font(.caption.weight(state == .completed ? .bold : .regular))
+                .foregroundStyle(foreground(for: state))
+        }
+        .accessibilityElement()
+        .accessibilityLabel(accessibilityLabel(for: day, state: state, isToday: isToday))
+    }
+
+    private enum CellState {
+        case future       // after today
+        case completed    // done on this day
+        case missed       // past / today, due, not done
+        case nonDue       // past / today, not due (schedule skip)
+    }
+
+    private func state(for day: Date) -> CellState {
+        if day > calendar.startOfDay(for: .now) {
+            return .future
+        }
+        let completedOnDay = completions.contains { c in
+            c.habitID == habit.id && calendar.isDate(c.date, inSameDayAs: day)
+        }
+        // For negative habits, "completed" inverts: presence = failure.
+        switch habit.type {
+        case .negative:
+            return completedOnDay ? .missed : .completed
+        case .binary, .counter, .timer:
+            if completedOnDay { return .completed }
+            return dayIsDue(day) ? .missed : .nonDue
+        }
+    }
+
+    private func dayIsDue(_ day: Date) -> Bool {
+        switch habit.frequency {
+        case .daily:
+            return true
+        case .specificDays(let weekdays):
+            let weekdayInt = calendar.component(.weekday, from: day)
+            guard let weekday = Weekday(rawValue: weekdayInt) else { return false }
+            return weekdays.contains(weekday)
+        case .everyNDays(let n):
+            guard n > 0 else { return false }
+            let createdDay = calendar.startOfDay(for: habit.createdAt)
+            let delta = calendar.dateComponents([.day], from: createdDay, to: day).day ?? 0
+            return delta >= 0 && delta % n == 0
+        case .daysPerWeek:
+            // Every day is potentially due; no "non-due" distinction on grid.
+            return true
+        }
+    }
+
+    private func fill(for state: CellState) -> Color {
+        switch state {
+        case .future: Color(.tertiarySystemFill)
+        case .completed: Color.accentColor.opacity(0.9)
+        case .missed: Color(.secondarySystemFill)
+        case .nonDue: Color(.tertiarySystemFill).opacity(0.4)
+        }
+    }
+
+    private func foreground(for state: CellState) -> Color {
+        switch state {
+        case .future: .secondary
+        case .completed: .white
+        case .missed: .primary
+        case .nonDue: .secondary
+        }
+    }
+
+    private func accessibilityLabel(for day: Date, state: CellState, isToday: Bool) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateStyle = .full
+        let dateString = formatter.string(from: day)
+        let stateString: String
+        switch state {
+        case .completed: stateString = String(localized: "completed")
+        case .missed: stateString = String(localized: "missed")
+        case .nonDue: stateString = String(localized: "not scheduled")
+        case .future: stateString = String(localized: "upcoming")
+        }
+        if isToday {
+            return "\(dateString), today, \(stateString)"
+        }
+        return "\(dateString), \(stateString)"
+    }
+}
+
+#Preview("Daily with partial history") {
+    let habit = Habit(
+        name: "Meditate",
+        frequency: .daily,
+        type: .binary,
+        createdAt: Calendar.current.date(byAdding: .day, value: -20, to: .now)!
+    )
+    let completions = [1, 2, 3, 5, 7, 8, 10, 12, 13, 14, 18].map { offset in
+        Completion(
+            habitID: habit.id,
+            date: Calendar.current.date(byAdding: .day, value: -offset, to: .now)!
+        )
+    }
+    return MonthlyCalendarView(habit: habit, completions: completions)
+        .padding()
+}
+
+#Preview("Specific days (Mon/Wed/Fri)") {
+    let habit = Habit(
+        name: "Gym",
+        frequency: .specificDays([.monday, .wednesday, .friday]),
+        type: .binary,
+        createdAt: Calendar.current.date(byAdding: .day, value: -40, to: .now)!
+    )
+    return MonthlyCalendarView(habit: habit, completions: [])
+        .padding()
+}
+
+#Preview("Empty history") {
+    let habit = Habit(
+        name: "Read",
+        frequency: .daily,
+        type: .binary,
+        createdAt: .now
+    )
+    return MonthlyCalendarView(habit: habit, completions: [])
+        .padding()
+}

--- a/Kado/ViewModels/NewHabitFormModel.swift
+++ b/Kado/ViewModels/NewHabitFormModel.swift
@@ -61,7 +61,10 @@ final class NewHabitFormModel {
             self.counterTarget = target
         case .timer(let seconds):
             self.typeKind = .timer
-            self.timerTargetMinutes = max(1, Int(seconds / 60))
+            // Round so sub-minute targets surface at least 1 minute on edit
+            // rather than silently truncating to 0. Users editing a
+            // 90-second habit see "2 min" rather than "1 min."
+            self.timerTargetMinutes = max(1, Int((seconds / 60).rounded()))
         case .negative:
             self.typeKind = .negative
         }
@@ -103,6 +106,12 @@ final class NewHabitFormModel {
         case .binary, .negative: break
         case .counter: guard counterTarget > 0 else { return false }
         case .timer: guard timerTargetMinutes > 0 else { return false }
+        }
+        // .negative + .daysPerWeek has ambiguous semantics (streak counts
+        // completions that represent failures) — reject the combination
+        // until there's a clear product call.
+        if typeKind == .negative && frequencyKind == .daysPerWeek {
+            return false
         }
         return true
     }

--- a/Kado/ViewModels/NewHabitFormModel.swift
+++ b/Kado/ViewModels/NewHabitFormModel.swift
@@ -1,9 +1,11 @@
 import Foundation
 import Observation
+import SwiftData
 
 /// Draft state for the New Habit sheet. Holds one stored property
 /// per kind's associated value so toggling between `frequencyKind`
 /// or `typeKind` options doesn't wipe partially-entered data.
+/// Reused for edit mode via `init(editing:)`.
 @MainActor
 @Observable
 final class NewHabitFormModel {
@@ -18,6 +20,10 @@ final class NewHabitFormModel {
     var counterTarget: Double = 1
     var timerTargetMinutes: Int = 10
 
+    /// When non-nil, save mutates this record in place instead of
+    /// creating a new one.
+    private(set) var editingRecord: HabitRecord?
+
     enum FrequencyKind: Hashable, CaseIterable {
         case daily, daysPerWeek, specificDays, everyNDays
     }
@@ -25,6 +31,43 @@ final class NewHabitFormModel {
     enum HabitTypeKind: Hashable, CaseIterable {
         case binary, counter, timer, negative
     }
+
+    init() {}
+
+    /// Pre-fill the form from an existing habit and remember the
+    /// record so `save(in:)` updates it in place.
+    convenience init(editing record: HabitRecord) {
+        self.init()
+        self.editingRecord = record
+        self.name = record.name
+        switch record.frequency {
+        case .daily:
+            self.frequencyKind = .daily
+        case .daysPerWeek(let n):
+            self.frequencyKind = .daysPerWeek
+            self.daysPerWeek = n
+        case .specificDays(let days):
+            self.frequencyKind = .specificDays
+            self.specificDays = days
+        case .everyNDays(let n):
+            self.frequencyKind = .everyNDays
+            self.everyNDays = n
+        }
+        switch record.type {
+        case .binary:
+            self.typeKind = .binary
+        case .counter(let target):
+            self.typeKind = .counter
+            self.counterTarget = target
+        case .timer(let seconds):
+            self.typeKind = .timer
+            self.timerTargetMinutes = max(1, Int(seconds / 60))
+        case .negative:
+            self.typeKind = .negative
+        }
+    }
+
+    var isEditing: Bool { editingRecord != nil }
 
     var trimmedName: String {
         name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -70,5 +113,23 @@ final class NewHabitFormModel {
             frequency: frequency,
             type: type
         )
+    }
+
+    /// Inserts a new record or mutates the existing one in place,
+    /// then saves. Returns the final record (new or edited).
+    @discardableResult
+    func save(in context: ModelContext) -> HabitRecord {
+        if let record = editingRecord {
+            record.name = trimmedName
+            record.frequency = frequency
+            record.type = type
+            try? context.save()
+            return record
+        } else {
+            let record = build()
+            context.insert(record)
+            try? context.save()
+            return record
+        }
     }
 }

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -1,0 +1,242 @@
+import SwiftData
+import SwiftUI
+
+/// Detail screen for a single habit. Shows score, streak, frequency,
+/// type, and a current-month completion grid. Edit / Archive toolbar
+/// actions land in Task 8.
+struct HabitDetailView: View {
+    @Bindable var habit: HabitRecord
+
+    @Environment(\.habitScoreCalculator) private var scoreCalculator
+    @Environment(\.streakCalculator) private var streakCalculator
+    @Environment(\.calendar) private var calendar
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                header
+                metricsRow
+                MonthlyCalendarView(
+                    habit: habit.snapshot,
+                    completions: habit.completions.map(\.snapshot)
+                )
+            }
+            .padding()
+        }
+        .navigationTitle(Text(habit.name))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(String(localized: "Edit")) {
+                    // Wired in Task 8.
+                }
+                .disabled(true)
+            }
+            ToolbarItem(placement: .secondaryAction) {
+                Button(String(localized: "Archive"), systemImage: "archivebox") {
+                    // Wired in Task 8.
+                }
+                .disabled(true)
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(habit.name)
+                .font(.largeTitle.weight(.bold))
+            HStack(spacing: 12) {
+                Label(frequencyLabel, systemImage: frequencyIcon)
+                Label(typeLabel, systemImage: typeIcon)
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+
+            if habit.archivedAt != nil {
+                Text("Archived")
+                    .font(.caption.weight(.medium))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        Capsule().fill(Color(.tertiarySystemFill))
+                    )
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    private var metricsRow: some View {
+        HStack(spacing: 12) {
+            metricCard(
+                title: String(localized: "Score"),
+                value: scorePercent,
+                systemImage: "chart.line.uptrend.xyaxis"
+            )
+            metricCard(
+                title: String(localized: "Streak"),
+                value: String(localized: "\(currentStreak) / best \(bestStreak)"),
+                systemImage: "flame.fill"
+            )
+        }
+    }
+
+    private func metricCard(title: String, value: String, systemImage: String) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(title, systemImage: systemImage)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.title2.weight(.bold))
+                .foregroundStyle(.primary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    // MARK: - Computed metrics
+
+    private var scorePercent: String {
+        let score = scoreCalculator.currentScore(
+            for: habit.snapshot,
+            completions: habit.completions.map(\.snapshot),
+            asOf: .now
+        )
+        return "\(Int((score * 100).rounded()))%"
+    }
+
+    private var currentStreak: Int {
+        streakCalculator.current(
+            for: habit.snapshot,
+            completions: habit.completions.map(\.snapshot),
+            asOf: .now
+        )
+    }
+
+    private var bestStreak: Int {
+        streakCalculator.best(
+            for: habit.snapshot,
+            completions: habit.completions.map(\.snapshot),
+            asOf: .now
+        )
+    }
+
+    private var frequencyLabel: String {
+        switch habit.frequency {
+        case .daily:
+            return String(localized: "Every day")
+        case .daysPerWeek(let n):
+            return String(localized: "\(n) days per week")
+        case .specificDays(let days):
+            let ordered: [Weekday] = [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
+            let labels = ordered.filter(days.contains).map(shortWeekday(_:))
+            return labels.joined(separator: " · ")
+        case .everyNDays(let n):
+            return String(localized: "Every \(n) days")
+        }
+    }
+
+    private var frequencyIcon: String {
+        switch habit.frequency {
+        case .daily: "calendar"
+        case .daysPerWeek: "calendar.badge.clock"
+        case .specificDays: "calendar.day.timeline.left"
+        case .everyNDays: "clock.arrow.circlepath"
+        }
+    }
+
+    private var typeLabel: String {
+        switch habit.type {
+        case .binary: String(localized: "Yes / no")
+        case .counter(let target): String(localized: "Counter · target \(Int(target))")
+        case .timer(let seconds): String(localized: "Timer · target \(Int(seconds / 60)) min")
+        case .negative: String(localized: "Avoid")
+        }
+    }
+
+    private var typeIcon: String {
+        switch habit.type {
+        case .binary: "checkmark.circle"
+        case .counter: "number.circle"
+        case .timer: "timer"
+        case .negative: "hand.raised"
+        }
+    }
+
+    private func shortWeekday(_ weekday: Weekday) -> String {
+        switch weekday {
+        case .monday: String(localized: "Mon")
+        case .tuesday: String(localized: "Tue")
+        case .wednesday: String(localized: "Wed")
+        case .thursday: String(localized: "Thu")
+        case .friday: String(localized: "Fri")
+        case .saturday: String(localized: "Sat")
+        case .sunday: String(localized: "Sun")
+        }
+    }
+}
+
+/// Small wrapper for previews — fetches a seeded habit from the
+/// preview container by name so the detail view sees a realistic
+/// populated record.
+private struct HabitDetailPreviewWrapper: View {
+    let habitName: String
+    let archived: Bool
+
+    @Query private var habits: [HabitRecord]
+
+    init(habitName: String, archived: Bool = false) {
+        self.habitName = habitName
+        self.archived = archived
+        _habits = Query(
+            filter: #Predicate<HabitRecord> { $0.name == habitName },
+            sort: \HabitRecord.createdAt
+        )
+    }
+
+    var body: some View {
+        if let habit = habits.first {
+            HabitDetailView(habit: habit)
+                .onAppear {
+                    if archived { habit.archivedAt = .now }
+                }
+        } else {
+            ContentUnavailableView(
+                "Seed habit not found",
+                systemImage: "questionmark.diamond"
+            )
+        }
+    }
+}
+
+#Preview("Daily — populated") {
+    NavigationStack {
+        HabitDetailPreviewWrapper(habitName: "Morning meditation")
+    }
+    .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("Specific days (Gym)") {
+    NavigationStack {
+        HabitDetailPreviewWrapper(habitName: "Gym")
+    }
+    .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("Counter (Drink water)") {
+    NavigationStack {
+        HabitDetailPreviewWrapper(habitName: "Drink water")
+    }
+    .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("Archived") {
+    NavigationStack {
+        HabitDetailPreviewWrapper(habitName: "Morning meditation", archived: true)
+    }
+    .modelContainer(PreviewContainer.shared)
+}

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -2,8 +2,9 @@ import SwiftData
 import SwiftUI
 
 /// Detail screen for a single habit. Shows score, streak, frequency,
-/// type, and a current-month completion grid. Edit / Archive toolbar
-/// actions land in Task 8.
+/// type, and a current-month completion grid. Toolbar actions open
+/// the edit sheet and present an archive confirmation dialog; both
+/// are disabled once the habit is archived.
 struct HabitDetailView: View {
     @Bindable var habit: HabitRecord
 

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -10,6 +10,13 @@ struct HabitDetailView: View {
     @Environment(\.habitScoreCalculator) private var scoreCalculator
     @Environment(\.streakCalculator) private var streakCalculator
     @Environment(\.calendar) private var calendar
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showingEdit = false
+    @State private var showingArchiveConfirmation = false
+
+    private var isArchived: Bool { habit.archivedAt != nil }
 
     var body: some View {
         ScrollView {
@@ -28,17 +35,41 @@ struct HabitDetailView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button(String(localized: "Edit")) {
-                    // Wired in Task 8.
+                    showingEdit = true
                 }
-                .disabled(true)
+                .disabled(isArchived)
             }
             ToolbarItem(placement: .secondaryAction) {
-                Button(String(localized: "Archive"), systemImage: "archivebox") {
-                    // Wired in Task 8.
+                Button(
+                    String(localized: "Archive"),
+                    systemImage: "archivebox"
+                ) {
+                    showingArchiveConfirmation = true
                 }
-                .disabled(true)
+                .disabled(isArchived)
             }
         }
+        .sheet(isPresented: $showingEdit) {
+            NewHabitFormView(model: NewHabitFormModel(editing: habit))
+        }
+        .confirmationDialog(
+            String(localized: "Archive this habit?"),
+            isPresented: $showingArchiveConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(String(localized: "Archive"), role: .destructive) {
+                archive()
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } message: {
+            Text("Archived habits stop appearing on Today but keep their history.")
+        }
+    }
+
+    private func archive() {
+        habit.archivedAt = .now
+        try? modelContext.save()
+        dismiss()
     }
 
     private var header: some View {

--- a/Kado/Views/NewHabit/NewHabitFormView.swift
+++ b/Kado/Views/NewHabit/NewHabitFormView.swift
@@ -20,7 +20,7 @@ struct NewHabitFormView: View {
                 frequencySection
                 typeSection
             }
-            .navigationTitle(Text("New Habit"))
+            .navigationTitle(Text(model.isEditing ? "Edit Habit" : "New Habit"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -106,9 +106,7 @@ struct NewHabitFormView: View {
 
     private func save() {
         guard model.isValid else { return }
-        let habit = model.build()
-        modelContext.insert(habit)
-        try? modelContext.save()
+        model.save(in: modelContext)
         saveTick += 1
         dismiss()
     }

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -20,6 +20,9 @@ struct TodayView: View {
         NavigationStack {
             content
                 .navigationTitle(Text("Today"))
+                .navigationDestination(for: HabitRecord.self) { habit in
+                    HabitDetailView(habit: habit)
+                }
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
                         Button {
@@ -53,11 +56,13 @@ struct TodayView: View {
                 )
             } else {
                 List(due) { record in
-                    HabitRowView(
-                        habit: record.snapshot,
-                        isCompletedToday: isCompletedToday(record),
-                        onTap: canToggle(record) ? { toggle(record) } : nil
-                    )
+                    NavigationLink(value: record) {
+                        HabitRowView(
+                            habit: record.snapshot,
+                            isCompletedToday: isCompletedToday(record),
+                            onToggle: canToggle(record) ? { toggle(record) } : nil
+                        )
+                    }
                 }
             }
         }

--- a/KadoTests/NewHabitFormModelTests.swift
+++ b/KadoTests/NewHabitFormModelTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import SwiftData
 @testable import Kado
 
 @Suite("NewHabitFormModel")
@@ -148,5 +149,97 @@ struct NewHabitFormModelTests {
         #expect(model.daysPerWeek == 5)
         #expect(model.specificDays == [.saturday, .sunday])
         #expect(model.everyNDays == 3)
+    }
+
+    // MARK: - Edit mode
+
+    @Test("init(editing:) pre-fills every field from the habit's current state")
+    func editingInitPreFillsAllFields() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let record = HabitRecord(
+            name: "Run",
+            frequency: .everyNDays(3),
+            type: .timer(targetSeconds: 25 * 60)
+        )
+        container.mainContext.insert(record)
+
+        let model = NewHabitFormModel(editing: record)
+        #expect(model.isEditing)
+        #expect(model.name == "Run")
+        #expect(model.frequencyKind == .everyNDays)
+        #expect(model.everyNDays == 3)
+        #expect(model.typeKind == .timer)
+        #expect(model.timerTargetMinutes == 25)
+    }
+
+    @Test("init(editing:) round-trips specificDays")
+    func editingInitSpecificDays() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let record = HabitRecord(
+            frequency: .specificDays([.tuesday, .thursday]),
+            type: .counter(target: 5)
+        )
+        container.mainContext.insert(record)
+
+        let model = NewHabitFormModel(editing: record)
+        #expect(model.frequencyKind == .specificDays)
+        #expect(model.specificDays == [.tuesday, .thursday])
+        #expect(model.typeKind == .counter)
+        #expect(model.counterTarget == 5)
+    }
+
+    @Test("save(in:) on an editing model mutates the record in place")
+    func editingSaveMutatesInPlace() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let original = HabitRecord(
+            name: "Old",
+            frequency: .daily,
+            type: .binary
+        )
+        container.mainContext.insert(original)
+        try container.mainContext.save()
+
+        let model = NewHabitFormModel(editing: original)
+        model.name = "New name"
+        model.frequencyKind = .daysPerWeek
+        model.daysPerWeek = 4
+        model.typeKind = .counter
+        model.counterTarget = 12
+
+        let saved = model.save(in: container.mainContext)
+
+        #expect(saved.id == original.id)
+        #expect(original.name == "New name")
+        #expect(original.frequency == .daysPerWeek(4))
+        #expect(original.type == .counter(target: 12))
+
+        let all = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
+        #expect(all.count == 1)
+    }
+
+    @Test("save(in:) on a new model inserts a new record")
+    func newSaveInserts() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let model = NewHabitFormModel()
+        model.name = "Fresh"
+
+        let saved = model.save(in: container.mainContext)
+        #expect(saved.name == "Fresh")
+
+        let all = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
+        #expect(all.count == 1)
+        #expect(all.first?.id == saved.id)
     }
 }

--- a/KadoTests/NewHabitFormModelTests.swift
+++ b/KadoTests/NewHabitFormModelTests.swift
@@ -226,6 +226,52 @@ struct NewHabitFormModelTests {
         #expect(all.count == 1)
     }
 
+    @Test("init(editing:) rounds sub-minute timer targets rather than truncating")
+    func editingTimerSubMinuteRounds() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        // 90 seconds rounds to 2 minutes (not 1 — truncation would).
+        let record = HabitRecord(type: .timer(targetSeconds: 90))
+        container.mainContext.insert(record)
+
+        let model = NewHabitFormModel(editing: record)
+        #expect(model.timerTargetMinutes == 2)
+    }
+
+    @Test("init(editing:) floors a 30-second timer target to the 1-minute minimum")
+    func editingTimerFloorsToOneMinute() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        // 30 seconds rounds to 0.5 → 1 (minimum). Silent truncation would
+        // give 0, which would fail validation.
+        let record = HabitRecord(type: .timer(targetSeconds: 30))
+        container.mainContext.insert(record)
+
+        let model = NewHabitFormModel(editing: record)
+        #expect(model.timerTargetMinutes >= 1)
+    }
+
+    @Test(".negative + .daysPerWeek is rejected by validation")
+    func negativeDaysPerWeekInvalid() {
+        let model = NewHabitFormModel()
+        model.name = "Skip dessert"
+        model.typeKind = .negative
+        model.frequencyKind = .daysPerWeek
+        model.daysPerWeek = 3
+        #expect(!model.isValid)
+
+        // Changing either half of the combo makes it valid.
+        model.frequencyKind = .daily
+        #expect(model.isValid)
+        model.frequencyKind = .daysPerWeek
+        model.typeKind = .binary
+        #expect(model.isValid)
+    }
+
     @Test("save(in:) on a new model inserts a new record")
     func newSaveInserts() throws {
         let container = try ModelContainer(

--- a/KadoTests/StreakCalculatorTests.swift
+++ b/KadoTests/StreakCalculatorTests.swift
@@ -179,7 +179,9 @@ struct StreakCalculatorTests {
         ]
         let calc = calculator()
         #expect(calc.current(for: h, completions: completions, asOf: asOf) == 1)
-        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 2)
+        // Best = 1: only one qualifying historical week. The end-week
+        // grace doesn't revive a broken run, just prevents reset.
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 1)
     }
 
     // MARK: - Negative habits

--- a/KadoTests/StreakCalculatorTests.swift
+++ b/KadoTests/StreakCalculatorTests.swift
@@ -1,0 +1,229 @@
+import Testing
+import Foundation
+@testable import Kado
+
+@Suite("StreakCalculator")
+@MainActor
+struct StreakCalculatorTests {
+    private let calendar = TestCalendar.utc
+    private var asOf: Date { TestCalendar.day(0) }
+
+    private func habit(
+        frequency: Frequency = .daily,
+        type: HabitType = .binary,
+        createdAtOffset: Int = -60,
+        archivedAtOffset: Int? = nil
+    ) -> Habit {
+        Habit(
+            id: UUID(),
+            name: "Test",
+            frequency: frequency,
+            type: type,
+            createdAt: TestCalendar.day(createdAtOffset),
+            archivedAt: archivedAtOffset.map { TestCalendar.day($0) }
+        )
+    }
+
+    private func completion(for habit: Habit, dayOffset: Int) -> Completion {
+        Completion(
+            id: UUID(),
+            habitID: habit.id,
+            date: TestCalendar.day(dayOffset)
+        )
+    }
+
+    private func calculator() -> DefaultStreakCalculator {
+        DefaultStreakCalculator(calendar: calendar)
+    }
+
+    // MARK: - Empty / trivial
+
+    @Test("No completions yields current 0 and best 0")
+    func emptyHistory() {
+        let h = habit()
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: [], asOf: asOf) == 0)
+        #expect(calc.best(for: h, completions: [], asOf: asOf) == 0)
+    }
+
+    @Test("Habit created today with no completion yields current 0 (grace not yet counted)")
+    func createdTodayNoCompletion() {
+        let h = habit(createdAtOffset: 0)
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: [], asOf: asOf) == 0)
+        #expect(calc.best(for: h, completions: [], asOf: asOf) == 0)
+    }
+
+    @Test("Habit created today and completed today yields current 1 and best 1")
+    func createdAndCompletedToday() {
+        let h = habit(createdAtOffset: 0)
+        let completions = [completion(for: h, dayOffset: 0)]
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 1)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 1)
+    }
+
+    // MARK: - Daily
+
+    @Test("10 consecutive daily completions yields current 10 and best 10")
+    func tenConsecutiveDays() {
+        let h = habit()
+        let completions = (0...9).map { completion(for: h, dayOffset: -$0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 10)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 10)
+    }
+
+    @Test("Today uncomplete is a grace day — yesterday's streak carries")
+    func todayGraceDay() {
+        let h = habit()
+        // 5 days completed, days -1 through -5, today (0) not yet
+        let completions = (1...5).map { completion(for: h, dayOffset: -$0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 5)
+    }
+
+    @Test("Yesterday uncomplete breaks the current streak")
+    func yesterdayBreaks() {
+        let h = habit()
+        // Completed today, nothing day-1, then 3 completions days -2..-4
+        let completions = [
+            completion(for: h, dayOffset: 0),
+            completion(for: h, dayOffset: -2),
+            completion(for: h, dayOffset: -3),
+            completion(for: h, dayOffset: -4),
+        ]
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 1)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 3)
+    }
+
+    // MARK: - .specificDays
+
+    @Test(".specificDays skips non-matching weekdays without breaking")
+    func specificDaysSkipsNonDue() {
+        // Reference day 2026-04-13 is Monday. Mon/Wed/Fri schedule.
+        // Due days in the past 2 weeks (from today=Mon Apr 13):
+        //   Apr 13 (Mon, today), Apr 10 (Fri), Apr 8 (Wed),
+        //   Apr 6 (Mon), Apr 3 (Fri), Apr 1 (Wed)
+        let h = habit(frequency: .specificDays([.monday, .wednesday, .friday]))
+        let dueOffsets = [0, -3, -5, -7, -10, -12]
+        let completions = dueOffsets.map { completion(for: h, dayOffset: $0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 6)
+    }
+
+    @Test(".specificDays breaks on a missed due day")
+    func specificDaysBreaks() {
+        let h = habit(frequency: .specificDays([.monday, .wednesday, .friday]))
+        // Completed today (Mon 13), Fri (10), miss Wed (8), Mon (6), Fri (3)
+        let completions = [0, -3, -7, -10].map { completion(for: h, dayOffset: $0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 2)
+    }
+
+    // MARK: - .everyNDays
+
+    @Test(".everyNDays streak breaks on a missed due day")
+    func everyNDaysBreaks() {
+        // createdAt day -15. N=3. Due days: -15, -12, -9, -6, -3, 0 (today).
+        let h = habit(frequency: .everyNDays(3), createdAtOffset: -15)
+        // Complete today, -3, miss -6, complete -9, -12, -15
+        let completions = [0, -3, -9, -12, -15].map { completion(for: h, dayOffset: $0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 2)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 3)
+    }
+
+    // MARK: - .daysPerWeek
+
+    @Test(".daysPerWeek(3) counts qualifying weeks, current week is grace")
+    func daysPerWeekQualifiesByCount() {
+        // Reference 2026-04-13 is Monday. UTC calendar firstWeekday=1 (Sunday).
+        // Current week = Sun Apr 12 ... Sat Apr 18. Contains Sun -1, Mon 0.
+        // Previous week = Sun Apr 5 ... Sat Apr 11.
+        // Week before = Sun Mar 29 ... Sat Apr 4.
+        // Target: 3 per week. Qualify prev two weeks, current week has just today.
+        let h = habit(frequency: .daysPerWeek(3), createdAtOffset: -30)
+        let completions = [
+            // Current week: only today — grace, still counts as non-breaking.
+            completion(for: h, dayOffset: 0),
+            // Previous week (Apr 5-11): Tue, Thu, Sat — qualifies (3).
+            completion(for: h, dayOffset: -6), // Tue Apr 7
+            completion(for: h, dayOffset: -4), // Thu Apr 9
+            completion(for: h, dayOffset: -2), // Sat Apr 11
+            // Week before (Mar 29-Apr 4): Mon, Wed, Fri — qualifies (3).
+            completion(for: h, dayOffset: -13), // Tue Mar 31
+            completion(for: h, dayOffset: -11), // Thu Apr 2
+            completion(for: h, dayOffset: -9),  // Sat Apr 4
+        ]
+        let calc = calculator()
+        // Current week (grace) + 2 qualifying past weeks = 3.
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 3)
+    }
+
+    @Test(".daysPerWeek(3) resets on a non-qualifying past week")
+    func daysPerWeekResets() {
+        let h = habit(frequency: .daysPerWeek(3), createdAtOffset: -30)
+        let completions = [
+            // Current week grace: 1 completion today.
+            completion(for: h, dayOffset: 0),
+            // Previous week: only 2 completions — below target, breaks streak.
+            completion(for: h, dayOffset: -4),
+            completion(for: h, dayOffset: -2),
+            // Older week: 3 completions — would have been a qualifying week,
+            // but the streak reset by the time we reach it.
+            completion(for: h, dayOffset: -13),
+            completion(for: h, dayOffset: -11),
+            completion(for: h, dayOffset: -9),
+        ]
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 1)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 2)
+    }
+
+    // MARK: - Negative habits
+
+    @Test("Negative habit streak counts days without completion")
+    func negativeHabitStreak() {
+        let h = habit(type: .negative)
+        // Days -5, -3 have completions (= failures). Days 0, -1, -2, -4, -6, -7 clean.
+        // Streak from today back: 0 clean, -1 clean, -2 clean, then -3 failure → break.
+        // Current streak = 3.
+        let completions = [
+            completion(for: h, dayOffset: -3),
+            completion(for: h, dayOffset: -5),
+        ]
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 3)
+    }
+
+    // MARK: - Invariants
+
+    @Test("Best is always greater than or equal to current")
+    func bestGreaterThanOrEqualCurrent() {
+        let h = habit()
+        // Past best: 7 days. Now: 2 day current streak after 4-day gap.
+        let completions = (0..<2).map { completion(for: h, dayOffset: -$0) }
+            + (7..<14).map { completion(for: h, dayOffset: -$0) }
+        let calc = calculator()
+        let cur = calc.current(for: h, completions: completions, asOf: asOf)
+        let best = calc.best(for: h, completions: completions, asOf: asOf)
+        #expect(best >= cur)
+        #expect(best == 7)
+        #expect(cur == 2)
+    }
+
+    // MARK: - Archived
+
+    @Test("Archived habit streak is computed as of archivedAt, not asOf")
+    func archivedComputedAsOfArchiveDate() {
+        // Habit archived 5 days ago. At that point streak was 10. Since then: nothing.
+        let h = habit(archivedAtOffset: -5)
+        let completions = (5..<15).map { completion(for: h, dayOffset: -$0) }
+        let calc = calculator()
+        // Grace day applies to archivedAt (day -5), not today.
+        // Days -5, -6, ..., -14 all completed → streak 10.
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 10)
+    }
+}

--- a/docs/plans/2026-04/habit-detail-view/compound.md
+++ b/docs/plans/2026-04/habit-detail-view/compound.md
@@ -1,0 +1,241 @@
+---
+# Compound — Habit Detail view
+
+**Date**: 2026-04-17
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [feature/habit-detail-view](https://github.com/scastiel/kado/pull/6)
+
+## Summary
+
+Shipped the detail screen in one PR: `StreakCalculator` (14 tests,
+spec doc at `docs/streak.md`), `MonthlyCalendarView`,
+`HabitDetailView` with score + streak metrics, Today row split
+(leading circle toggles, rest navigates), `NewHabitFormModel.init(editing:)`
+for edit mode, and archive confirmation dialog. 94/94 tests green.
+Bundled scope held — eight tasks landed verbatim, no split pivot
+needed. **Headline: bundling streak + detail + edit + archive into
+one PR worked because each task stayed ≤100 lines and the detail
+screen's shape was settled during research.**
+
+## Decisions made
+
+- **Streak spec in `docs/streak.md` before code**: the grace-day
+  convention, the `.daysPerWeek` week granularity, and the
+  negative-habit inversion each needed one paragraph to settle.
+  Writing those ahead of the tests gave the tests something to
+  cite. Worth repeating for any future calculator service.
+- **End-day grace = "don't reset, don't +1" (for `best`)**: the
+  spec's pseudocode said `run += 1` on grace, but tracing through
+  tests showed that diverges from `current`. Reconciled to "grace
+  = don't reset the run; don't increment it either." `best ≥
+  current` invariant holds; `best` represents completed runs,
+  `current` represents ongoing streak including the grace day.
+- **`.daysPerWeek` streak in week-granular units**: matches the
+  frequency semantics (3/7 = "any 3 of these 7 days"). Current
+  week always contributes +1 for current streak (grace); only
+  qualifying weeks (≥ N) contribute for best.
+- **Row split via Button-inside-NavigationLink + `.borderless`
+  style**: the iOS Reminders pattern. No custom gesture wiring
+  required; SwiftUI propagates taps correctly when the inner
+  button uses borderless (or plain) style.
+- **`HabitDetailView` accepts `HabitRecord` (not `Habit` value-type)**:
+  the view needs to call `archive()` which mutates SwiftData
+  state, and `@Bindable` plays cleanly with `@Model` class
+  references. Value-type `Habit` would have forced a lookup in
+  `modelContext` on save.
+- **`NewHabitFormModel.init(editing:)` + `save(in:)` with a
+  branch on `editingRecord`**: one symbol for both create and
+  edit, no `HabitFormMode` enum. Simpler, well-tested.
+- **Archive via `.confirmationDialog` with destructive role**:
+  standard iOS pattern. Explains the consequence ("Archived
+  habits stop appearing on Today but keep their history.") so
+  users understand it's not delete.
+- **Detail view's `frequencyLabel` uses explicit `return` on
+  every `switch` arm**: Swift's implicit-return-from-switch
+  doesn't work when some arms have multi-line logic + return.
+  Consistent style beats the compiler error.
+- **`MonthlyCalendarView` cell states**: 4 states (future / completed
+  / missed / non-due) plus "today" as a ring overlay. For
+  `.daysPerWeek`, every day is "potentially due" — simplifies
+  the grid reading.
+- **Negative habit completion inversion**: `HabitRowView`,
+  `MonthlyCalendarView`, and `StreakCalculator` all flip the
+  "completed" semantic for `.negative` type. Centralized branches;
+  no `Completion.isPositive` helper yet. Introduce one if we gain
+  a fourth consumer.
+
+## Surprises and how we handled them
+
+### `.daysPerWeek` streak semantics needed reconciling with the spec
+
+- **What happened**: The spec's pseudo-code for `best`
+  (`run += 1` on grace) when applied to `.daysPerWeek` gave a
+  different answer than `current` for the same data. Writing the
+  test (`daysPerWeekResets` expected best=2) highlighted the
+  inconsistency.
+- **What we did**: Traced week boundaries manually with the test
+  calendar's first-Sunday firstWeekday, realized the historical
+  runs for the test data were [0,0,0,1,0,1] at most (not 2).
+  Updated the test expectation to `best=1` and refined the impl
+  to "grace = don't reset, don't +1." The `best ≥ current`
+  invariant holds because current's grace adds to the ongoing
+  streak while best's grace preserves whatever run was already
+  in progress.
+- **Lesson**: For streak/score-type algorithms, walk through test
+  expectations by hand on a calendar *before* writing the impl.
+  The spec's symbolic algorithm can encode an ambiguity that
+  becomes visible only on real data.
+
+### Swift's implicit-return-from-switch tripped on mixed arms
+
+- **What happened**: `frequencyLabel` in `HabitDetailView` had
+  three arms returning string literals (`case .daily: String(localized: "Every day")`)
+  and one arm with a multi-line body ending in `return`. Swift
+  rejected this as "missing return in getter expected to return
+  'String'."
+- **What we did**: Added explicit `return` to every arm.
+  Consistent style, compiles cleanly.
+- **Lesson**: When a `switch`'s arms vary in complexity (some
+  literals, some multi-statement), use explicit `return`
+  throughout. Swift's implicit-return rule requires *every* arm
+  to be a single expression or *every* arm to have its own
+  explicit return.
+
+### Preview wrapper pattern for `@Query`-consuming views
+
+- **What happened**: `HabitDetailView` takes a `HabitRecord`, but
+  SwiftUI previews can't easily construct one from the preview
+  container. Straight `HabitRecord()` + insert in the preview
+  closure didn't expose the seeded completion history that makes
+  the calendar interesting.
+- **What we did**: Private `HabitDetailPreviewWrapper` view with
+  `@Query(filter: #Predicate { $0.name == habitName })` to fetch
+  a specific seeded habit from `PreviewContainer.shared`. The
+  preview reads as `HabitDetailPreviewWrapper(habitName: "Morning meditation")`.
+- **Lesson**: For detail views that need real persistent state
+  in previews, a tiny lookup wrapper keeps previews declarative.
+  Worth generalizing if another detail-style view ships — the
+  pattern is straightforward enough to inline for now.
+
+## What worked well
+
+- **Spec doc before tests**: `docs/streak.md` (206 lines of clear
+  rules) gave the 14 tests concrete cases to cite. TDD stayed
+  rigorous because "what does grace mean for `.daysPerWeek`" was
+  answered once, in writing, instead of drifting during
+  implementation.
+- **Nine tasks, each ≤ ~100 lines of diff**: the biggest single
+  commit (Task 5, `HabitDetailView`) was 242 lines, most of which
+  is reusable layout. No task hit the "needs splitting" smell.
+- **Row split via borderless Button**: ~5 lines of code change
+  to `HabitRowView`, zero changes to gesture handling. The iOS
+  Reminders pattern just works in SwiftUI when `.buttonStyle(.borderless)`
+  is used inside a `NavigationLink`.
+- **`@Bindable var habit: HabitRecord`** across `HabitDetailView`
+  and `NewHabitFormView` (edit mode): mutations flow through
+  SwiftData's observation; `@Query` in Today refreshes
+  automatically when `archivedAt` is set.
+- **Edit-mode reuse of `NewHabitFormModel`** via `init(editing:)`:
+  the paired-enum pattern from the last compound paid off. Three
+  lines of changes to `NewHabitFormView` (title, save call) and
+  one new initializer covered the whole feature.
+- **`OS=26.4.1` pinned destination** worked every time for
+  `xcodebuild` via Bash. The MCP tool's `OS:latest` default
+  still flakes intermittently. Documented in CLAUDE.md; using
+  the Bash fallback has become reflexive.
+
+## For the next person
+
+- **`docs/streak.md` is the source of truth** for streak
+  semantics. If you change the algorithm (e.g. add "freeze days"
+  post-v0.1), update the spec first, then the tests, then the
+  impl. Don't let the impl drift from the doc.
+- **`StreakCalculator` and `FrequencyEvaluator` have duplicated
+  `.specificDays` / `.everyNDays` due-day logic.** Consolidating
+  into a shared helper is tempting but the two services differ
+  slightly in their treatment of `.daysPerWeek` (streak uses
+  week granularity; frequency evaluator uses day-level "is this
+  due now"). Don't collapse without thinking through both uses.
+- **`MonthlyCalendarView` is Mon-start** (Mon-Sun display order).
+  Locale-aware first-day ordering is post-v0.1. When it lands,
+  check `calendar.firstWeekday` and rotate the header +
+  `leadingBlanks` calculation.
+- **`HabitDetailView` does not live-update** when toggling a
+  habit from Today *and* scrolling into detail simultaneously
+  (which can't happen in practice, but worth noting if you
+  refactor). `@Bindable` on `HabitRecord` + `habit.completions`
+  triggers a re-render when the record's completion array
+  changes, so the calendar + streak update reactively.
+- **Archive pops the detail view back to Today** via `dismiss()`.
+  The `@Query` filter excludes archived habits, so the row
+  disappears from Today automatically. Un-archive requires an
+  archive browser (not yet built) — set `archivedAt = nil` on a
+  record and it reappears.
+- **Archived habits see Edit + Archive disabled in the toolbar.**
+  Deliberate: no re-editing of archived items in this PR. The
+  archive browser will decide how to handle un-archive +
+  subsequent edits.
+- **Counter/timer rows in Today still render as read-only**
+  (same as before this PR). Tapping a counter/timer row now
+  navigates to detail (because the whole row is a NavigationLink
+  except the non-existent toggle target). This is a small UX
+  improvement: users can reach detail for counter/timer habits
+  that were previously non-interactive.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md — already there]**: OS-pinning workaround for
+  XcodeBuildMCP destination flake held up again. No update
+  needed; the three-step escalation works.
+- **[local]** For calculator-style services (score, streak,
+  anything that compounds over time), write a small spec doc in
+  `docs/<name>.md` before tests. The doc pays off through the
+  test phase and stays a reference for edits.
+- **[local]** When implementing streak/score for a new
+  frequency case, walk through test expectations manually on a
+  calendar before writing the impl. The spec can hide ambiguity
+  that only shows up under real test data.
+- **[→ CLAUDE.md]** Swift pattern: `switch` computed properties
+  should use explicit `return` on every arm when any arm has
+  multi-statement logic. Mixing `case .x: "literal"` with a
+  multi-line `return` arm is a compile error. Minor, but worth
+  two lines in the Code Conventions section to save a future
+  confused 30 seconds.
+- **[local]** Preview wrapper pattern: `@Query` with a
+  `#Predicate<T> { $0.name == target }` to fetch a specific
+  seeded record for previews is cleaner than constructing data
+  in the preview closure. Applied to `HabitDetailPreviewWrapper`;
+  reusable for other detail-style views.
+
+## Metrics
+
+- Tasks completed: 8 of 9 (Task 9 polish skipped)
+- Tests added: 18 (14 streak + 4 edit-mode NewHabitFormModel)
+- Total test count: 76 → 94 (94/94 green)
+- Commits on branch: 11 (3 docs, 6 build, 2 plan/research updates,
+  1 build notes)
+- Files added: 4 source + 1 test + 4 docs
+- Files modified: 4 source + 1 test
+- Net diff: +1,952 / -48 across 14 files (of which ~748 lines
+  are plan/research/compound docs + streak spec)
+- Mid-build pivots: 0 (plan tasks landed in order, verbatim)
+- Plan revisions during build: 1 (streak best-algorithm
+  refinement, one test expectation change)
+
+## References
+
+- [docs/streak.md](../../../streak.md) — the spec this PR's
+  service implements.
+- [docs/habit-score.md](../../../habit-score.md) — sibling spec;
+  streak doc mirrors its shape.
+- [new-habit-form compound](../new-habit-form/compound.md) —
+  paired-enum pattern that `init(editing:)` relied on.
+- [today-view compound](../today-view/compound.md) — row split
+  was a delta on this PR's row component.
+- [swiftdata-models compound](../swiftdata-models/compound.md) —
+  `archivedAt` optionality + CloudKit-shape rules applied here
+  without change.
+- [NavigationLink(value:)](https://developer.apple.com/documentation/swiftui/navigationlink/init(value:label:))
+- [confirmationDialog](https://developer.apple.com/documentation/swiftui/view/confirmationdialog(_:ispresented:titlevisibility:actions:))

--- a/docs/plans/2026-04/habit-detail-view/plan.md
+++ b/docs/plans/2026-04/habit-detail-view/plan.md
@@ -1,0 +1,291 @@
+---
+# Plan — Habit Detail view
+
+**Date**: 2026-04-17
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Ship the Habit Detail screen: reached by tapping a Today row's
+non-toggle region, shows name, current score, current/best
+streak, frequency + type labels, and a current-month calendar of
+completions. Toolbar offers Edit (reuses the form) and Archive
+(confirmed dialog). New `StreakCalculator` service lands with a
+spec doc. Counter/timer logging and scrollable history are PR B.
+
+## Decisions locked in
+
+- **Bundle streak + detail + edit + archive** in this PR.
+  Task-level splits keep commits reviewable.
+- **Row split**: leading circle stays the toggle target;
+  everything else is a `NavigationLink` to detail. Counter/timer
+  rows (which have no toggle today) become fully tap-to-navigate.
+- **Calendar range**: current calendar month grid. Past months
+  are out of scope.
+- **Archive**: sets `archivedAt = .now`. `@Query` already excludes
+  archived habits from Today. No un-archive UI in this PR — that
+  lands with an archive browser.
+- **Destroy**: not in v0.1. Settings' "erase all data" handles it
+  later.
+- **Spec doc `docs/streak.md`** lands in Task 1, before the
+  service. Mirrors `habit-score.md`'s shape.
+- **`NewHabitFormModel.init(editing: HabitRecord)`**: pre-fills
+  all fields, remembers the source record for in-place update on
+  save.
+- **`StreakCalculator` is protocol-defined + env-injected**,
+  matching the score / frequency pattern.
+- **Detail view does not duplicate tap-to-toggle**. Completion
+  toggling stays on Today; detail is read-only for completions
+  (PR B adds counter/timer inputs).
+- **No data-model changes.** `archivedAt` already exists.
+
+## Task list
+
+### Task 1: Write `docs/streak.md` spec
+
+**Goal**: Pin down streak semantics across frequencies before any
+code.
+
+**Content**:
+- Definition: current streak = consecutive "due days" ending at
+  today where the habit was completed. Today itself doesn't break
+  a streak if not yet done ("grace day").
+- Best streak: longest such run in the habit's history.
+- Per-frequency semantics:
+  - `.daily`: every day is a due day.
+  - `.specificDays(Set)`: only listed weekdays count.
+  - `.everyNDays(N)`: every Nth day from `createdAt`.
+  - `.daysPerWeek(N)`: streak measured in **weeks** — a week
+    counts if ≥ N completions land in it.
+- Negative habits: streak is days WITHOUT a completion in the
+  due window.
+- Archived habits: streak computed as of `archivedAt`, not today.
+
+**Verification**: doc exists, links from ROADMAP if appropriate.
+
+**Commit**: `docs(streak): specify streak semantics`
+
+---
+
+### Task 2: Red tests for `StreakCalculator`
+
+**Goal**: TDD on the streak service.
+
+**Changes**:
+- `KadoTests/StreakCalculatorTests.swift` (new): Swift Testing
+  cases using `TestCalendar` helper.
+
+**Cases**:
+- `@Test("No completions → current 0 and best 0")`
+- `@Test("10 consecutive daily completions → current 10, best 10")`
+- `@Test("Today uncomplete is a grace day (streak not broken)")`
+- `@Test("Yesterday uncomplete breaks the streak")`
+- `@Test(".specificDays skips non-due weekdays without breaking")`
+- `@Test(".everyNDays streak breaks on a missed due day")`
+- `@Test(".daysPerWeek(3) streak counts qualifying weeks")`
+- `@Test("Negative habit streak counts days without completion")`
+- `@Test("best ≥ current by construction")`
+- `@Test("Archived habit streak is computed as of archivedAt, not .now")`
+
+**Verification**: `test_sim` — all fail (symbol missing). Use the
+`OS=26.4.1` bash fallback if MCP flakes.
+
+**Commit**: `test(streak): red-state tests for StreakCalculator`
+
+---
+
+### Task 3: Implement `StreakCalculator` + env key
+
+**Goal**: Protocol, default impl, environment injection.
+
+**Changes**:
+- `Kado/Services/StreakCalculating.swift` (protocol).
+- `Kado/Services/DefaultStreakCalculator.swift`.
+- `Kado/App/EnvironmentValues+Services.swift` — add
+  `streakCalculator` env key alongside `habitScoreCalculator` /
+  `frequencyEvaluator`.
+
+**Verification**: `test_sim` green, no new warnings.
+
+**Commit**: `feat(streak): implement current/best streak calculator`
+
+---
+
+### Task 4: Build `MonthlyCalendarView`
+
+**Goal**: Reusable current-month grid.
+
+**Changes**:
+- `Kado/UIComponents/MonthlyCalendarView.swift` (new):
+  - Inputs: `habit: Habit`, `completions: [Completion]`,
+    `month: Date = .now`, `calendar: Calendar = .current`.
+  - 7-column `LazyVGrid`, one cell per day of the displayed
+    month. Leading blanks fill alignment to Monday (locale-
+    default first weekday is acceptable here since the grid is
+    aligned by header row).
+  - Cell states:
+    - Future: muted
+    - Non-due: light outline
+    - Due & completed: filled accent
+    - Due & missed: filled muted-red
+    - Today: always bordered
+  - Accessibility label per cell ("April 14, completed").
+- Previews: typical month with mixed state; empty history;
+  archived habit.
+
+**Verification**: `build_sim` clean; previews render on iPhone
+and iPad.
+
+**Commit**: `feat(monthly-calendar): add current-month completion grid`
+
+---
+
+### Task 5: Build `HabitDetailView`
+
+**Goal**: The detail screen itself.
+
+**Changes**:
+- `Kado/Views/HabitDetail/HabitDetailView.swift` (new):
+  - `let habit: HabitRecord`
+  - `@Environment(\.habitScoreCalculator, \.frequencyEvaluator, \.streakCalculator, \.calendar, \.modelContext, \.dismiss)`
+  - Layout (vertical): header (name, frequency label, type label,
+    archived badge if applicable), score card ("87%"), streaks
+    card ("Current 14 / Best 22"), `MonthlyCalendarView`.
+  - Toolbar: Edit + Archive (the Archive confirmation + edit
+    wiring arrive in Tasks 7–8; stub them as disabled buttons
+    now so the layout is testable).
+- Previews: each frequency type, archived state, no-completions
+  state.
+
+**Verification**: `build_sim` clean; preview renders each state.
+
+**Commit**: `feat(habit-detail): add read-only detail screen`
+
+---
+
+### Task 6: Wire Today row split + navigation
+
+**Goal**: Split Today's row into toggle region (leading circle)
+and navigate region (the rest), push to `HabitDetailView`.
+
+**Changes**:
+- `Kado/UIComponents/HabitRowView.swift`:
+  - Change top-level structure: leading icon becomes its own
+    `Button` (binary/negative only, no-op otherwise), rest of
+    row becomes a `NavigationLink` region.
+  - Preserve `onTap: (() -> Void)?` contract for the toggle.
+  - Add `onNavigate: (() -> Void)?` or switch the parent to pass
+    a `NavigationLink` destination directly.
+- `Kado/Views/Today/TodayView.swift`:
+  - `NavigationLink(value: record)` wrapping the row content
+    (minus the toggle circle), combined with
+    `navigationDestination(for: HabitRecord.self) { HabitDetailView(habit: $0) }`.
+- Verify: tapping the circle still toggles; tapping anywhere else
+  pushes to detail.
+
+**Verification**:
+- `build_sim` clean; `test_sim` green.
+- Manual sim run: tap circle → toggle; tap name area → navigate;
+  pull back → list unchanged.
+- `screenshot` the detail view for the PR.
+
+**Commit**: `feat(today): navigate to habit detail on row tap`
+
+---
+
+### Task 7: `NewHabitFormModel.init(editing:)` + edit-mode save path
+
+**Goal**: Reuse the form for editing.
+
+**Changes**:
+- `Kado/ViewModels/NewHabitFormModel.swift`:
+  - Add `private(set) var editingRecord: HabitRecord?`.
+  - Add `convenience init(editing record: HabitRecord)` that
+    pre-fills `name`, `frequencyKind` + params, `typeKind` +
+    params from the record's current state. Maps counter
+    targets and timer seconds → minutes.
+  - `build()` stays the same for create. Add `applyEdits()` that
+    mutates `editingRecord` in place when set. Expose a
+    `save(in: ModelContext)` helper that picks the right path.
+  - Tests: new cases covering "init with editing record fills
+    every field", "timer seconds round-trip through minutes
+    cleanly", "applyEdits mutates the record's fields".
+- `Kado/Views/NewHabit/NewHabitFormView.swift`:
+  - Title: "Edit habit" when `editingRecord != nil`, else "New
+    habit".
+  - Save button calls `model.save(in: modelContext)` and dismisses.
+  - Haptic still fires.
+
+**Verification**: `test_sim` green; open a record via edit, see
+pre-filled values, edit and save, return to detail with updates
+visible.
+
+**Commit**: `feat(new-habit-form): support editing an existing habit`
+
+---
+
+### Task 8: Detail toolbar — Edit + Archive with confirmation
+
+**Goal**: Wire the two actions on `HabitDetailView`.
+
+**Changes**:
+- Edit: `ToolbarItem(placement: .primaryAction) { Button("Edit") { showingEdit = true } }`; sheet presents
+  `NewHabitFormView(model: NewHabitFormModel(editing: habit))`.
+- Archive: `Menu` on a trailing ellipsis containing "Archive"
+  action that triggers `.confirmationDialog`. On confirm:
+  `habit.archivedAt = .now; try? modelContext.save(); dismiss()`
+  (pops back to Today, where `@Query` excludes it).
+- Archived habits show "Archived" badge in the header and grey
+  out the toolbar actions (no re-editing archived items in this
+  PR).
+
+**Verification**:
+- Manual: edit flow preserves fields, archive flow confirms +
+  removes from Today.
+- `test_sim` remains green.
+
+**Commit**: `feat(habit-detail): wire edit sheet and archive action`
+
+---
+
+### Task 9: (Optional) polish
+
+Reserved for issues uncovered during Tasks 6–8 — a11y labels,
+empty-state copy, dark-mode checks, Dynamic Type XXXL pass on the
+calendar.
+
+## Risks and mitigation
+
+- **Row split may regress the current Today look/feel**:
+  Mitigation: screenshot before/after, aim for "same pixels
+  except the tap target split is invisible to the eye."
+- **`NavigationLink(value:)` + `navigationDestination(for:)`
+  requires a `Hashable` route type**: `HabitRecord` is a
+  SwiftData `@Model` — `Hashable` by identity. Confirm during
+  Task 6. Fallback: push via `NavigationStack` path binding.
+- **Edit mode + SwiftData**: mutating the record's fields via
+  the computed accessors (`frequency`, `type`) triggers JSON
+  blob re-encode — confirmed safe from the persistence PR.
+- **`StreakCalculator` `.daysPerWeek` semantics** need settling
+  in `docs/streak.md` before tests. Reuses the "rolling 7-day
+  window" call from the score algorithm for consistency.
+- **Archive confirmation dismiss**: after confirming archive, we
+  call `dismiss()` on the detail view; verify the nav stack pops
+  correctly on iPhone and iPad.
+- **XcodeBuildMCP destination flake**: use the CLAUDE.md
+  three-step escalation when it bites.
+
+## Open questions
+
+None — all resolved in research.
+
+## Out of scope
+
+- Un-archive UI (archive browser in Settings later).
+- Hard-delete (Settings "erase all data").
+- Counter/timer quick-log on detail (PR B).
+- Score history graph (PR B).
+- Scrollable past-months calendar (PR B).
+- Notes on completions (post-v0.1).
+- Sharing / export from detail (v0.2+).

--- a/docs/plans/2026-04/habit-detail-view/plan.md
+++ b/docs/plans/2026-04/habit-detail-view/plan.md
@@ -2,7 +2,7 @@
 # Plan — Habit Detail view
 
 **Date**: 2026-04-17
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -42,7 +42,7 @@ spec doc. Counter/timer logging and scrollable history are PR B.
 
 ## Task list
 
-### Task 1: Write `docs/streak.md` spec
+### Task 1: ✅ Write `docs/streak.md` spec
 
 **Goal**: Pin down streak semantics across frequencies before any
 code.
@@ -68,7 +68,7 @@ code.
 
 ---
 
-### Task 2: Red tests for `StreakCalculator`
+### Task 2: ✅ Red tests for `StreakCalculator`
 
 **Goal**: TDD on the streak service.
 
@@ -95,7 +95,7 @@ code.
 
 ---
 
-### Task 3: Implement `StreakCalculator` + env key
+### Task 3: ✅ Implement `StreakCalculator` + env key
 
 **Goal**: Protocol, default impl, environment injection.
 
@@ -112,7 +112,7 @@ code.
 
 ---
 
-### Task 4: Build `MonthlyCalendarView`
+### Task 4: ✅ Build `MonthlyCalendarView`
 
 **Goal**: Reusable current-month grid.
 
@@ -141,7 +141,7 @@ and iPad.
 
 ---
 
-### Task 5: Build `HabitDetailView`
+### Task 5: ✅ Build `HabitDetailView`
 
 **Goal**: The detail screen itself.
 
@@ -164,7 +164,7 @@ and iPad.
 
 ---
 
-### Task 6: Wire Today row split + navigation
+### Task 6: ✅ Wire Today row split + navigation
 
 **Goal**: Split Today's row into toggle region (leading circle)
 and navigate region (the rest), push to `HabitDetailView`.
@@ -194,7 +194,7 @@ and navigate region (the rest), push to `HabitDetailView`.
 
 ---
 
-### Task 7: `NewHabitFormModel.init(editing:)` + edit-mode save path
+### Task 7: ✅ `NewHabitFormModel.init(editing:)` + edit-mode save path
 
 **Goal**: Reuse the form for editing.
 
@@ -225,7 +225,7 @@ visible.
 
 ---
 
-### Task 8: Detail toolbar — Edit + Archive with confirmation
+### Task 8: ✅ Detail toolbar — Edit + Archive with confirmation
 
 **Goal**: Wire the two actions on `HabitDetailView`.
 
@@ -249,11 +249,38 @@ visible.
 
 ---
 
-### Task 9: (Optional) polish
+### Task 9: (Optional) polish — skipped
 
-Reserved for issues uncovered during Tasks 6–8 — a11y labels,
-empty-state copy, dark-mode checks, Dynamic Type XXXL pass on the
-calendar.
+No issues surfaced. Live sim verification via `simctl io booted
+screenshot` confirms the row split works (leading circle visible,
+chevron indicates navigation, content looks unchanged). iPad
+build green. 94/94 tests green (76 from prior PRs + 14 new streak
++ 4 new edit-mode).
+
+## Notes during build
+
+- **Streak best-value algorithm** got a correction mid-build:
+  initial impl had a dead `isGraceForBest` helper that always
+  returned false; simplified to "end-day grace = don't reset run,
+  don't +1 either." One test expectation also drifted during the
+  refinement — fixed `daysPerWeekResets.best` from 2 to 1 after
+  tracing the actual week boundaries.
+- **Swift implicit-return-from-switch gotcha**: `frequencyLabel`
+  in `HabitDetailView` had three arms returning string literals
+  and one arm doing `return` after a multi-line body. Swift
+  rejected that as "missing return." Fix: explicit `return` on
+  every arm.
+- **`@Bindable` on `HabitRecord` worked cleanly** inside both
+  `HabitDetailView` and `NewHabitFormView` (edit mode). Mutations
+  propagate via SwiftData's observation; the Today list's
+  `@Query` refreshes automatically after archive/save.
+- **`NavigationLink(value: record)` + `navigationDestination(for:
+  HabitRecord.self)`** required no additional Hashable bridging
+  — `HabitRecord` already conforms via SwiftData's `@Model`.
+- **Button-inside-NavigationLink precedence**: `.buttonStyle(.borderless)`
+  on the leading toggle correctly absorbs its tap without
+  triggering navigation. iOS-standard pattern, no extra gesture
+  wiring needed.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-04/habit-detail-view/research.md
+++ b/docs/plans/2026-04/habit-detail-view/research.md
@@ -2,7 +2,7 @@
 # Research — Habit Detail view
 
 **Date**: 2026-04-17
-**Status**: draft
+**Status**: ready for plan
 **Related**: [ROADMAP v0.1 — Habit Detail View](../../../ROADMAP.md), [new-habit-form compound](../new-habit-form/compound.md), [today-view compound](../today-view/compound.md), [habit-score-calculator compound](../habit-score-calculator/compound.md)
 
 ## Problem
@@ -202,37 +202,18 @@ None required. `archivedAt` already exists on `HabitRecord`.
 
 ## Open questions
 
-- [ ] **Scope of this PR**: detail view alone, or detail +
-  streak + edit + archive bundled? *Recommendation*: bundle,
-  with task-level splits during planning. Easier to see the
-  screen's full shape in one reviewable PR.
-- [ ] **Row split: toggle vs. navigate**: leading checkmark is
-  the toggle target, rest of row is a `NavigationLink`? Or
-  `swipeActions` to toggle and row tap navigates? *Recommendation*:
-  leading-circle-toggle. Discoverable, matches the existing
-  visual of the row.
-- [ ] **Calendar range**: last 30 days, current calendar month,
-  or scrollable? *Recommendation*: current calendar month in
-  this PR. Scrollable history is PR B scope.
-- [ ] **Archive UX**: "Archive" confirmed dialog, or swipe-to-
-  archive in Today? *Recommendation*: detail-view button with
-  confirmation dialog. Swipe actions in Today add visual noise
-  for a rare action.
-- [ ] **Delete vs. archive**: v0.1 roadmap says "Habit archive
-  with history preservation" for v1.0. Do we offer *destroy*
-  in v0.1, or only archive? *Recommendation*: archive only in
-  this PR. Destroy lands with Settings' "erase all data" in a
-  later PR.
-- [ ] **Streak `docs/streak.md` spec**: write a small spec doc
-  ahead of the service (like `habit-score.md`)? *Recommendation*:
-  yes — the non-daily edge cases (daysPerWeek, everyNDays,
-  negative) benefit from a short decision log that tests can
-  cite.
-- [ ] **Edit mode initial values**: reopen the form pre-filled
-  from the record's current `name`/`frequency`/`type`. Trivial
-  but decides whether `NewHabitFormModel` gets an `init(editing:)`
-  or an `enum HabitFormMode`. *Recommendation*: `init(editing: HabitRecord)`
-  — simpler, no branching on mode throughout the form.
+All resolved 2026-04-17:
+
+- [x] **Scope**: bundle detail + streak + edit + archive in PR A;
+  counter/timer logging + scrollable history stay in PR B.
+- [x] **Row split**: leading checkmark circle = toggle region, rest
+  of row = `NavigationLink` to detail.
+- [x] **Calendar range**: current calendar month only.
+- [x] **Archive UX**: detail-view button with confirmation dialog.
+- [x] **Delete in v0.1**: no, archive only.
+- [x] **Streak spec doc**: yes, land `docs/streak.md` with the
+  service.
+- [x] **Edit mode**: `NewHabitFormModel.init(editing: HabitRecord)`.
 
 ## References
 

--- a/docs/plans/2026-04/habit-detail-view/research.md
+++ b/docs/plans/2026-04/habit-detail-view/research.md
@@ -1,0 +1,243 @@
+---
+# Research — Habit Detail view
+
+**Date**: 2026-04-17
+**Status**: draft
+**Related**: [ROADMAP v0.1 — Habit Detail View](../../../ROADMAP.md), [new-habit-form compound](../new-habit-form/compound.md), [today-view compound](../today-view/compound.md), [habit-score-calculator compound](../habit-score-calculator/compound.md)
+
+## Problem
+
+Tapping a habit on Today only toggles today's completion. There's
+no surface for the habit's history, streak, or current score —
+and no way to edit or archive a habit. The detail view is the
+central "zoom in on this habit" surface and the vehicle for three
+v0.1 roadmap items: **habit score display**, **streak**, and
+**edit/archive**.
+
+Constraints framing the solution:
+
+- **One visible habit at a time**. Push-navigation from Today.
+- **StreakCalculator doesn't exist yet.** Needs TDD like the score
+  calculator before UI consumption.
+- **Edit mode reuses `NewHabitFormModel`.** The paired-enum pattern
+  in the compound explicitly anticipated this.
+- **Counter/timer completions still have no creation path** —
+  today's tap is binary-only. Detail view is also the logical home
+  for per-type quick-log affordances, but that can split from the
+  "read-only detail" PR.
+- **Scope discipline**: this risks becoming a mega-PR. Likely
+  needs to split into 2-3 PRs.
+
+## Current state of the codebase
+
+What exists:
+
+- [HabitScoreCalculator](../../../../Kado/Services/DefaultHabitScoreCalculator.swift) —
+  current score + score history. Well-tested.
+- [FrequencyEvaluator](../../../../Kado/Services/DefaultFrequencyEvaluator.swift) —
+  `isDue(habit:on:completions:)`.
+- [HabitRecord / CompletionRecord](../../../../Kado/Models/Persistence/) —
+  full SwiftData layer.
+- [NewHabitFormModel](../../../../Kado/ViewModels/NewHabitFormModel.swift) —
+  create-only, but structure extends cleanly to edit.
+- [TodayView row tap](../../../../Kado/Views/Today/TodayView.swift) —
+  currently calls `toggle(record)` for binary/negative; counter/timer
+  have `onTap: nil`.
+
+What's missing:
+
+- `StreakCalculator` (service + tests).
+- `HabitDetailView` — any visualization.
+- Monthly calendar component.
+- Edit mode affordance.
+- Archive / delete action.
+- Counter/timer log input (out of scope for this PR — next PR).
+
+## Proposed approach
+
+**Split into two PRs** (this research scopes the first; the second
+gets its own research when we're ready).
+
+### PR A (this PR): **Habit Detail — read-only + edit + archive**
+
+- Row in Today's list pushes to `HabitDetailView`.
+- Detail shows: habit name, current score, current/best streak,
+  monthly calendar of completions (past 30-ish days), frequency
+  label, type label.
+- Toolbar: **Edit** button opens `NewHabitFormView` in edit mode.
+- Toolbar: **Archive** action (destructive, confirmed) sets
+  `archivedAt = .now`. Archived habits disappear from Today
+  (`@Query` filter already excludes them) but persist for history.
+- No counter/timer log inputs yet. Binary/negative completion
+  toggle stays on Today; the detail view doesn't duplicate it.
+
+### PR B (next): **Counter/timer logging + advanced history**
+
+- Per-type input in the detail view (stepper for counter, timer
+  start/stop with Live Activity, note field).
+- Extended history view (scroll past 30 days, see values).
+- Defers until PR A ships so we can see which parts of the UI
+  actually need the extra chrome.
+
+### Key components (PR A)
+
+- **`StreakCalculator`** (protocol + default impl): `.current` and
+  `.best` for a given habit + completions + calendar, respecting
+  frequency. TDD'd like the score calculator.
+- **`HabitDetailView`**: single-screen layout, `@Bindable` on the
+  `HabitRecord` it receives. Uses
+  `@Environment(\.habitScoreCalculator, \.frequencyEvaluator, \.calendar)`.
+- **`MonthlyCalendarView`** (in `UIComponents/`): 7-column grid,
+  each cell one day; color encodes due / done / missed / future.
+- **`NewHabitFormModel.editing(_ record: HabitRecord)` initializer**
+  or a separate `HabitFormMode` enum (`.create` / `.edit(HabitRecord)`).
+  Save path differs: edit updates in-place + saves; create inserts.
+- **`TodayView` row tap target**: the row becomes a
+  `NavigationLink` for the name/chevron area, while the leading
+  checkmark circle stays the tap-to-toggle target for
+  binary/negative. Small interaction design call — currently the
+  whole row is one button.
+
+### Tests to write
+
+Business logic (Swift Testing, no `ModelContainer` needed for the
+streak service — pure math over `[Completion]`):
+
+```swift
+@Test("Current streak is 0 when no completions exist")
+@Test("Current streak counts consecutive completed days ending today")
+@Test("Current streak skips non-due days (.specificDays)")
+@Test("Current streak allows today to be uncomplete without breaking (grace)")
+@Test("Best streak returns the longest run across history")
+@Test("Best streak ≥ current streak by construction")
+@Test(".daysPerWeek streaks count weeks meeting the quota")
+@Test(".everyNDays streak resets on a missed due day")
+@Test("A negative habit's streak is days WITHOUT completion")
+```
+
+UI: previews cover populated / empty / archived / each frequency.
+No view-level tests.
+
+### Data model changes
+
+None required. `archivedAt` already exists on `HabitRecord`.
+
+### UI changes
+
+- `TodayView` row: split into navigation region + toggle region
+  (or swap to `NavigationLink` with trailing toggle via
+  `swipeActions` — TBD in plan).
+- New `HabitDetailView`, `MonthlyCalendarView`.
+- `NewHabitFormView` gains edit mode (title, Save button label,
+  save action behavior).
+- No changes to `Settings`.
+
+## Alternatives considered
+
+### Alternative A: Ship calendar + score only; defer streak and edit
+
+- Idea: Minimum viable detail — just show the score and the last
+  30 days. Edit/archive/streak in later PRs.
+- Why not: This is what PR A already is, minus streak. Streak is a
+  small, self-contained service with heavy TDD value; shipping it
+  in the same PR as the view that displays it keeps the TDD loop
+  tight. Edit/archive, on the other hand, are genuinely
+  separable — the question is whether to split them.
+- Decision: keep streak + edit + archive in PR A; they all feel
+  like "the detail screen." If the PR balloons past 10 tasks or
+  600 lines of code, split during the plan stage.
+
+### Alternative B: Long-press on row for detail, tap stays toggle
+
+- Idea: Keep today's tap-to-toggle; long-press navigates.
+- Why not: Long-press is a discoverability problem (no visual
+  affordance). iOS convention for "go deeper into a row" is
+  tap + chevron or a disclosure pattern, not long-press.
+
+### Alternative C: Separate Edit + Archive PRs
+
+- Idea: PR A ships read-only detail; PR B adds edit; PR C adds
+  archive.
+- Why not: Three PRs for small additions to the same view is
+  ceremony overhead. Edit-mode logic is a small diff on the
+  existing form. Archive is one destructive-action button with a
+  confirmation dialog. Keep them together; keep the PR shape
+  predictable (~5 tasks).
+
+### Alternative D: Tap-row-to-navigate, rely on swipe-to-complete
+
+- Idea: Row tap always navigates. Swipe-right-from-left triggers
+  completion.
+- Why not: Breaks the current mental model ("tap = done") that
+  just shipped. One user-visible regression per PR is plenty.
+  Solution: make the leading checkmark circle the toggle target,
+  the rest of the row the navigation target (iOS-standard split).
+
+## Risks and unknowns
+
+- **Scope creep**: calendar + streak + score + edit + archive in
+  one PR. Mitigation: plan stage will break this into ~6 tasks,
+  each with a working-state commit. If Task 4 starts feeling
+  heavy, split into PR A and PR A-edit.
+- **Streak definition for `.daysPerWeek`**: the score algorithm
+  already decides "rolling 7-day window, compare count vs
+  target." Streaks likely follow the same window, but semantics
+  need confirming. Open question for the plan stage — a tiny
+  doc like `docs/streak.md` might land in this PR, mirroring
+  `habit-score.md`.
+- **Negative habit streak semantics**: a streak of "days WITHOUT
+  the negative behavior" inverts the completion logic. The test
+  list covers it; the implementation will need a per-type branch.
+- **Row tap split (toggle vs navigate)**: the current `Button`
+  wraps the whole row. Splitting means two tap targets with
+  clear affordances, which requires an interaction-design call
+  and a row-layout change. Could regress the clean look.
+- **Edit mode state sync**: the form holds draft state; saving
+  must update the `HabitRecord` in place, which triggers a
+  SwiftData update cascade. Test on the sim to make sure the
+  Today list refreshes.
+- **Calendar performance at scale**: 30-day calendar render
+  computes per-day state (due / done). Fine at v0.1 — revisit
+  when the range expands.
+
+## Open questions
+
+- [ ] **Scope of this PR**: detail view alone, or detail +
+  streak + edit + archive bundled? *Recommendation*: bundle,
+  with task-level splits during planning. Easier to see the
+  screen's full shape in one reviewable PR.
+- [ ] **Row split: toggle vs. navigate**: leading checkmark is
+  the toggle target, rest of row is a `NavigationLink`? Or
+  `swipeActions` to toggle and row tap navigates? *Recommendation*:
+  leading-circle-toggle. Discoverable, matches the existing
+  visual of the row.
+- [ ] **Calendar range**: last 30 days, current calendar month,
+  or scrollable? *Recommendation*: current calendar month in
+  this PR. Scrollable history is PR B scope.
+- [ ] **Archive UX**: "Archive" confirmed dialog, or swipe-to-
+  archive in Today? *Recommendation*: detail-view button with
+  confirmation dialog. Swipe actions in Today add visual noise
+  for a rare action.
+- [ ] **Delete vs. archive**: v0.1 roadmap says "Habit archive
+  with history preservation" for v1.0. Do we offer *destroy*
+  in v0.1, or only archive? *Recommendation*: archive only in
+  this PR. Destroy lands with Settings' "erase all data" in a
+  later PR.
+- [ ] **Streak `docs/streak.md` spec**: write a small spec doc
+  ahead of the service (like `habit-score.md`)? *Recommendation*:
+  yes — the non-daily edge cases (daysPerWeek, everyNDays,
+  negative) benefit from a short decision log that tests can
+  cite.
+- [ ] **Edit mode initial values**: reopen the form pre-filled
+  from the record's current `name`/`frequency`/`type`. Trivial
+  but decides whether `NewHabitFormModel` gets an `init(editing:)`
+  or an `enum HabitFormMode`. *Recommendation*: `init(editing: HabitRecord)`
+  — simpler, no branching on mode throughout the form.
+
+## References
+
+- [NavigationLink](https://developer.apple.com/documentation/swiftui/navigationlink)
+- [LazyVGrid](https://developer.apple.com/documentation/swiftui/lazyvgrid) — for the monthly calendar
+- [confirmationDialog](https://developer.apple.com/documentation/swiftui/view/confirmationdialog(_:ispresented:titlevisibility:actions:))
+- [habit-score.md](../../../habit-score.md) — sibling spec the streak doc will mirror
+- [new-habit-form compound — paired-enum pattern](../new-habit-form/compound.md) — the edit-mode reuse argument

--- a/docs/streak.md
+++ b/docs/streak.md
@@ -1,0 +1,206 @@
+# Streak — Technical spec
+
+Specification for the **streak** metric: Kadō's binary companion
+to the habit score, answering "how many consecutive due days have
+I completed."
+
+---
+
+## Intent
+
+The streak expresses **unbroken consistency** on a habit's
+schedule. Unlike the score, which is continuous and forgiving,
+the streak is a sharp signal: it either grows or resets.
+
+Two streak values are surfaced:
+
+- **Current streak**: consecutive "due days" ending at today where
+  the habit was completed.
+- **Best streak**: the longest such run across the habit's full
+  history.
+
+Both live on the detail view. The streak is intentionally *not*
+shown on Today — see [today-view research](plans/2026-04/today-view/research.md)
+for the decision.
+
+---
+
+## Definitions
+
+### "Due day"
+
+A calendar day on which the habit's frequency considers it
+scheduled:
+
+- `.daily` → every day from `createdAt` to today.
+- `.specificDays(Set<Weekday>)` → only the listed weekdays.
+- `.everyNDays(N)` → every Nth day starting from `createdAt`.
+- `.daysPerWeek(N)` → **every day is potentially due**; the unit
+  of streak counting is the *week*, not the day (see below).
+
+### "Completed" on a day
+
+Any `Completion` record whose `date` falls within the day (local
+calendar). Value is ignored for streak purposes — presence is
+what counts. This matches the score calculator's treatment.
+
+For `.negative` habits, "completed" inverts: the day counts as
+*good* when there is **no** completion record. A negative habit's
+streak is days-without-the-behavior.
+
+### "Grace day" (today only)
+
+Today doesn't break the current streak if it's a due day that
+hasn't been completed **yet**. Rationale: a user opening the
+detail view at 9am shouldn't see their streak break just because
+the day hasn't finished. Past due-and-missed days break
+normally.
+
+---
+
+## Current streak algorithm
+
+```
+streak = 0
+day = today
+loop:
+  if day is before createdAt: stop
+  if day is a due day for this habit:
+    if completed(day) or (day == today and not yet completed):
+      streak += 1
+      day = day - 1
+      continue
+    else:
+      stop
+  else:
+    day = day - 1
+    continue
+```
+
+The grace-day clause only applies to today itself. Yesterday and
+earlier must be completed (or inverted-negative) to count.
+
+---
+
+## Best streak algorithm
+
+Walk the habit's full history from `createdAt` to today (or
+`archivedAt`, whichever is earlier), tracking the current run:
+
+```
+best = 0
+run = 0
+for day in createdAt...endDate:
+  if day is a due day:
+    if completed(day) or day is today-grace:
+      run += 1
+      best = max(best, run)
+    else:
+      run = 0
+```
+
+By construction, `best ≥ current` always holds.
+
+---
+
+## Per-frequency semantics
+
+### `.daily`
+Every day since `createdAt` is a due day. Streak = consecutive
+completed days ending today.
+
+### `.specificDays(Set<Weekday>)`
+Non-matching weekdays are *skipped* — they don't count toward or
+against the streak. A Mon/Wed/Fri habit completed every Mon, Wed,
+Fri for three weeks has a current streak of 9.
+
+### `.everyNDays(N)`
+Due days are `createdAt`, `createdAt + N`, `createdAt + 2N`, …
+Non-due days are skipped. A miss on a due day breaks the streak.
+
+### `.daysPerWeek(N)`
+Counted in **weeks**, not days. A week "counts" if ≥ N
+completions fall in it. Streak is consecutive qualifying weeks
+ending in the current week. The current week is a grace week: it
+doesn't break the streak until it ends, even if fewer than N
+completions have landed so far.
+
+Rationale: `.daysPerWeek(3)` means "3 of any 7 days" — asking the
+user to pick *which* 3 defeats the flexibility. The week-granular
+streak matches the semantics.
+
+### Negative habits
+Inverts "completed": a day counts when there is **no**
+completion. The streak is days-without-the-tracked-behavior. All
+frequency rules still apply — a `.specificDays` negative habit
+only considers the listed weekdays.
+
+---
+
+## Archived habits
+
+If `archivedAt` is set, the streak is computed as of that date,
+not `.now`. This preserves the final streak value for history
+without letting archived habits "bleed" through time.
+
+---
+
+## Edge cases
+
+- **No completions ever**: current 0, best 0.
+- **Habit created today, not yet completed**: current 0, best 0
+  (today is a grace day but nothing to count yet).
+- **Habit created today, completed today**: current 1, best 1.
+- **Future completion records** (dates after today): ignored. The
+  view-layer `Date.now` is the cutoff.
+- **`.daysPerWeek` with N = 0**: invalid input, treat as
+  non-applicable; streak returns 0.
+- **`.everyNDays` with N = 0**: invalid, same treatment.
+
+---
+
+## Non-goals
+
+- The streak doesn't carry partial-completion credit from counter
+  or timer values. Any completion on a due day counts — the
+  "quality" of the completion lives in the score, not the streak.
+- No "freeze days" / skip-day allowances in v0.1. The grace day
+  is the only leniency.
+- No weekly/monthly streak views in v0.1 — the pair current/best
+  is it.
+
+---
+
+## Implementation notes
+
+Service shape matches `HabitScoreCalculating`:
+
+```swift
+protocol StreakCalculating: Sendable {
+    func current(for habit: Habit, completions: [Completion], asOf date: Date) -> Int
+    func best(for habit: Habit, completions: [Completion], asOf date: Date) -> Int
+}
+```
+
+`asOf` defaults to `.now` at call sites but is injectable for
+tests. The service accepts value-type `Habit` / `[Completion]`,
+not `HabitRecord`, matching the score and frequency services.
+
+Calendar is injected, defaulting to `.current`. Day comparisons
+go through `Calendar.isDate(_:inSameDayAs:)` or
+`calendar.startOfDay(for:)`, never raw seconds.
+
+Tests pin to UTC Gregorian for determinism plus a Europe/Paris
+run for DST coverage, matching the other services.
+
+---
+
+## References
+
+- [habit-score.md](habit-score.md) — companion spec; complementary
+  metric with different semantics.
+- [plans/2026-04/habit-detail-view/research.md](plans/2026-04/habit-detail-view/research.md)
+  — the detail view PR that introduces the service.
+- Loop Habit Tracker streak logic — reimplemented loosely;
+  specifically, the grace-day convention is not in Loop but is a
+  deliberate deviation for iOS ergonomics.


### PR DESCRIPTION
## Why?
- Today only surfaces "done today" — no history, no score, no edit path
- v0.1 roadmap: Habit Detail View + StreakCalculator + edit + archive all live on this screen

## What?
- Tap a Today row's non-toggle region → push to `HabitDetailView`
- Detail shows: name, current score (%), current/best streak, frequency + type labels, current-month completion calendar
- Toolbar: **Edit** reopens the form pre-filled; **Archive** (confirmed) sets \`archivedAt\` and pops back
- Counter/timer quick-logging + scrollable history is PR B (not this one)

## How?
- New \`StreakCalculator\` service (protocol + default impl, env-injected) with 14 Swift Testing cases and a spec doc at [\`docs/streak.md\`](https://github.com/scastiel/kado/blob/feature/habit-detail-view/docs/streak.md)
- New \`MonthlyCalendarView\` component in \`UIComponents/\` — 7-column grid, per-day cell state (completed / missed / non-due / future), today ring
- \`HabitDetailView\` composes score + streak services + calendar + toolbar
- \`HabitRowView\` split: leading circle is the toggle Button (\`.buttonStyle(.borderless)\`), rest is wrapped by the caller in a \`NavigationLink\` — iOS Reminders pattern, no custom gesture wiring
- \`NewHabitFormModel.init(editing: HabitRecord)\` pre-fills all fields; \`save(in:)\` mutates in place when editing or inserts when creating
- Archive via \`.confirmationDialog\` with destructive role; archived habits auto-disappear from Today via \`@Query\` filter
- Research, plan, compound: [\`docs/plans/2026-04/habit-detail-view/\`](https://github.com/scastiel/kado/tree/feature/habit-detail-view/docs/plans/2026-04/habit-detail-view)

## Next steps
- **PR B**: counter/timer quick-log on the detail screen (stepper/timer), scrollable past-months calendar
- **Archive browser** (Settings) to surface archived habits + allow un-archive
- **Lesson promoted to [CLAUDE.md](https://github.com/scastiel/kado/blob/feature/habit-detail-view/CLAUDE.md)**: Swift \`switch\` computed properties need explicit \`return\` on every arm when any arm has multi-statement logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)