### PR TITLE
feat(detail-quick-log): counter/timer logging and completion history

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,19 @@ KadoUITests/                # UI tests (XCTest)
 - Use `ViewThatFits`, `ContainerRelativeShape`, `Layout` protocol
   rather than manual size calculations when possible.
 - Systematic previews for every non-trivial view, with multiple states.
+- **`@State` defaults that depend on `@Environment` must initialize
+  in `.onAppear`, not `init`.** `@State` is seeded before the env is
+  injected, so `Calendar.current` (or any fallback) will leak into
+  `init` instead of the overridden env value. Pattern:
+  ```swift
+  @State private var value: T? = nil
+  var body: some View {
+      ContentView(value: value ?? fallback)
+          .onAppear { if value == nil { value = computeDefault() } }
+  }
+  ```
+  Applied in `TimerLogSheet` so the env calendar drives today-
+  completion prefill, matching the save path.
 
 ### SwiftData
 - One `@Model` per persistent type, explicit relationships with
@@ -235,6 +248,14 @@ Tests where they add value, not everywhere. **Mandatory** for:
 ### Framework
 **Swift Testing** (`@Test`, `#expect`) by default. XCTest only for UI
 tests.
+
+**Match numeric types on both sides of `#expect`.** Swift's permissive
+binding lets `#expect(value == 25 * 60)` compile when `value` is
+`Double?` and `25 * 60` is `Int`, but the runtime comparison returns
+`false` for the same logical value — the failure message reads
+`"1500.0 == 1500"` with no hint that the types differ. Always use
+an explicit `Double(...)` or `1500.0` literal when asserting against
+a `Double` value. Same rule applies to `#require`.
 
 ### Workflow
 For any calculation function (score, streak, frequency), **write the

--- a/Kado/Services/CompletionLogger.swift
+++ b/Kado/Services/CompletionLogger.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftData
+
+/// Counter/timer completion operations for the detail view's
+/// quick-log surface. Mirrors `CompletionToggler`'s shape but
+/// handles value-carrying mutations rather than presence toggles.
+@MainActor
+struct CompletionLogger {
+    let calendar: Calendar
+
+    init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
+
+    /// Adds `delta` to today's completion value, creating a record
+    /// if none exists.
+    func incrementCounter(
+        for habit: HabitRecord,
+        on date: Date = .now,
+        by delta: Double = 1,
+        in context: ModelContext
+    ) {
+        if let existing = todayCompletion(for: habit, on: date) {
+            existing.value += delta
+        } else {
+            let completion = CompletionRecord(date: date, value: delta, habit: habit)
+            context.insert(completion)
+        }
+    }
+
+    /// Subtracts 1 from today's completion value. When the value
+    /// drops below 1, the record is deleted so "no completion" ↔
+    /// "not done today" stays a bijection.
+    func decrementCounter(
+        for habit: HabitRecord,
+        on date: Date = .now,
+        in context: ModelContext
+    ) {
+        guard let existing = todayCompletion(for: habit, on: date) else { return }
+        if existing.value <= 1 {
+            context.delete(existing)
+        } else {
+            existing.value -= 1
+        }
+    }
+
+    /// Replaces today's completion with one recording the given
+    /// session duration. Single-record-per-day invariant holds.
+    func logTimerSession(
+        for habit: HabitRecord,
+        seconds: TimeInterval,
+        on date: Date = .now,
+        in context: ModelContext
+    ) {
+        if let existing = todayCompletion(for: habit, on: date) {
+            context.delete(existing)
+        }
+        let completion = CompletionRecord(date: date, value: seconds, habit: habit)
+        context.insert(completion)
+    }
+
+    /// Removes a specific completion (used by history-list swipes).
+    func delete(_ completion: CompletionRecord, in context: ModelContext) {
+        context.delete(completion)
+    }
+
+    private func todayCompletion(for habit: HabitRecord, on date: Date) -> CompletionRecord? {
+        habit.completions.first {
+            calendar.isDate($0.date, inSameDayAs: date)
+        }
+    }
+}

--- a/Kado/UIComponents/CounterQuickLogView.swift
+++ b/Kado/UIComponents/CounterQuickLogView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+/// Quick-log control for counter habits on the detail view.
+/// Shows today's value next to the target, with `−` and `+`
+/// buttons on either side. Minus is disabled at zero. A success
+/// haptic fires once when `todayValue` first meets `target`.
+struct CounterQuickLogView: View {
+    let target: Double
+    let todayValue: Double
+    let onIncrement: () -> Void
+    let onDecrement: () -> Void
+
+    private var targetReached: Bool { todayValue >= target }
+    private var canDecrement: Bool { todayValue > 0 }
+
+    var body: some View {
+        HStack(spacing: 20) {
+            Button(action: onDecrement) {
+                Image(systemName: "minus")
+                    .font(.title2.weight(.semibold))
+                    .frame(width: 44, height: 44)
+                    .background(
+                        Circle().fill(Color(.secondarySystemFill))
+                    )
+                    .foregroundStyle(canDecrement ? Color.primary : Color.secondary)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canDecrement)
+            .accessibilityLabel(String(localized: "Decrement"))
+
+            VStack(spacing: 2) {
+                Text("\(Int(todayValue))")
+                    .font(.system(size: 36, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(targetReached ? Color.accentColor : Color.primary)
+                Text(String(localized: "of \(Int(target))"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+
+            Button(action: onIncrement) {
+                Image(systemName: "plus")
+                    .font(.title2.weight(.semibold))
+                    .frame(width: 44, height: 44)
+                    .background(
+                        Circle().fill(Color.accentColor.opacity(0.15))
+                    )
+                    .foregroundStyle(Color.accentColor)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(localized: "Increment"))
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .sensoryFeedback(.success, trigger: targetReached) { old, new in
+            !old && new
+        }
+    }
+}
+
+#Preview("Under target") {
+    CounterQuickLogView(target: 8, todayValue: 3, onIncrement: {}, onDecrement: {})
+        .padding()
+}
+
+#Preview("At target") {
+    CounterQuickLogView(target: 8, todayValue: 8, onIncrement: {}, onDecrement: {})
+        .padding()
+}
+
+#Preview("Over target") {
+    CounterQuickLogView(target: 8, todayValue: 12, onIncrement: {}, onDecrement: {})
+        .padding()
+}
+
+#Preview("At zero (minus disabled)") {
+    CounterQuickLogView(target: 8, todayValue: 0, onIncrement: {}, onDecrement: {})
+        .padding()
+}

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -10,6 +10,9 @@ struct HabitRowView: View {
     let habit: Habit
     let isCompletedToday: Bool
     let onToggle: (() -> Void)?
+    /// Today's completion value, if any. Counter and timer rows
+    /// surface this in the trailing label (e.g. `3/8`, `12:34/30:00`).
+    var todayValue: Double? = nil
 
     var body: some View {
         HStack(spacing: 12) {
@@ -69,16 +72,30 @@ struct HabitRowView: View {
     private var trailingState: some View {
         switch habit.type {
         case .counter(let target):
-            Text("–/\(Int(target))")
+            Text(counterLabel(target: target))
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(.secondary)
         case .timer(let targetSeconds):
-            Text(formatSeconds(targetSeconds))
+            Text(timerLabel(target: targetSeconds))
                 .font(.callout.monospacedDigit())
                 .foregroundStyle(.secondary)
         case .binary, .negative:
             EmptyView()
         }
+    }
+
+    private func counterLabel(target: Double) -> String {
+        if let todayValue {
+            return "\(Int(todayValue))/\(Int(target))"
+        }
+        return "–/\(Int(target))"
+    }
+
+    private func timerLabel(target: TimeInterval) -> String {
+        if let todayValue {
+            return "\(formatSeconds(todayValue)) / \(formatSeconds(target))"
+        }
+        return formatSeconds(target)
     }
 
     private var accessibilityLabelText: String {
@@ -149,6 +166,29 @@ struct HabitRowView: View {
             habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now),
             isCompletedToday: true,
             onToggle: {}
+        )
+    }
+}
+
+#Preview("Counter / timer in progress") {
+    List {
+        HabitRowView(
+            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
+            isCompletedToday: false,
+            onToggle: nil,
+            todayValue: 3
+        )
+        HabitRowView(
+            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
+            isCompletedToday: true,
+            onToggle: nil,
+            todayValue: 8
+        )
+        HabitRowView(
+            habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now),
+            isCompletedToday: false,
+            onToggle: nil,
+            todayValue: 750
         )
     }
 }

--- a/Kado/Views/HabitDetail/CompletionHistoryList.swift
+++ b/Kado/Views/HabitDetail/CompletionHistoryList.swift
@@ -31,7 +31,7 @@ struct CompletionHistoryList: View {
                             .fill(Color(.secondarySystemBackground))
                     )
             } else {
-                VStack(spacing: 0) {
+                LazyVStack(spacing: 0) {
                     ForEach(sortedCompletions) { completion in
                         row(for: completion)
                         if completion.id != sortedCompletions.last?.id {

--- a/Kado/Views/HabitDetail/CompletionHistoryList.swift
+++ b/Kado/Views/HabitDetail/CompletionHistoryList.swift
@@ -1,0 +1,175 @@
+import SwiftData
+import SwiftUI
+
+/// Scrollable list of completions for a habit, sorted newest first.
+/// Swipe-to-delete removes a completion. Empty state shows a neutral
+/// "No history yet" row.
+struct CompletionHistoryList: View {
+    @Bindable var habit: HabitRecord
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.calendar) private var calendar
+
+    private var sortedCompletions: [CompletionRecord] {
+        habit.completions.sorted { $0.date > $1.date }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("History")
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+
+            if sortedCompletions.isEmpty {
+                Text("No history yet.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color(.secondarySystemBackground))
+                    )
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(sortedCompletions) { completion in
+                        row(for: completion)
+                        if completion.id != sortedCompletions.last?.id {
+                            Divider().padding(.leading, 16)
+                        }
+                    }
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color(.secondarySystemBackground))
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func row(for completion: CompletionRecord) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(relativeDate(for: completion.date))
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                Text(absoluteDate(for: completion.date))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text(valueLabel(for: completion))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .contentShape(Rectangle())
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                delete(completion)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+
+    private func delete(_ completion: CompletionRecord) {
+        CompletionLogger(calendar: calendar).delete(completion, in: modelContext)
+        try? modelContext.save()
+    }
+
+    private func relativeDate(for date: Date) -> String {
+        let now = Date.now
+        if calendar.isDateInToday(date) { return String(localized: "Today") }
+        if calendar.isDateInYesterday(date) { return String(localized: "Yesterday") }
+        let days = calendar.dateComponents([.day], from: calendar.startOfDay(for: date), to: calendar.startOfDay(for: now)).day ?? 0
+        if days > 0 && days < 7 {
+            return String(localized: "\(days) days ago")
+        }
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+
+    private func absoluteDate(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateFormat = "EEE MMM d"
+        return formatter.string(from: date)
+    }
+
+    private func valueLabel(for completion: CompletionRecord) -> String {
+        switch habit.type {
+        case .binary:
+            return String(localized: "Done")
+        case .negative:
+            return String(localized: "Slipped")
+        case .counter(let target):
+            return "\(Int(completion.value))/\(Int(target))"
+        case .timer(let targetSeconds):
+            return "\(formatMinutes(completion.value)) / \(formatMinutes(targetSeconds))"
+        }
+    }
+
+    private func formatMinutes(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let minutes = total / 60
+        let remaining = total % 60
+        return String(format: "%d:%02d", minutes, remaining)
+    }
+}
+
+#Preview("Populated daily") {
+    CompletionHistoryListPreviewWrapper(habitName: "Morning meditation")
+        .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("Counter") {
+    CompletionHistoryListPreviewWrapper(habitName: "Drink water")
+        .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("Empty") {
+    CompletionHistoryListPreviewWrapperEmpty()
+        .modelContainer(PreviewContainer.emptyContainer())
+}
+
+private struct CompletionHistoryListPreviewWrapper: View {
+    let habitName: String
+
+    @Query private var habits: [HabitRecord]
+
+    init(habitName: String) {
+        self.habitName = habitName
+        _habits = Query(filter: #Predicate<HabitRecord> { $0.name == habitName })
+    }
+
+    var body: some View {
+        ScrollView {
+            if let habit = habits.first {
+                CompletionHistoryList(habit: habit)
+                    .padding()
+            } else {
+                Text("Seed habit not found")
+            }
+        }
+    }
+}
+
+private struct CompletionHistoryListPreviewWrapperEmpty: View {
+    @Environment(\.modelContext) private var context
+    @State private var habit = HabitRecord(name: "Fresh")
+
+    var body: some View {
+        ScrollView {
+            CompletionHistoryList(habit: habit)
+                .padding()
+        }
+        .onAppear { context.insert(habit) }
+    }
+}

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -16,6 +16,7 @@ struct HabitDetailView: View {
 
     @State private var showingEdit = false
     @State private var showingArchiveConfirmation = false
+    @State private var showingTimerSheet = false
 
     private var isArchived: Bool { habit.archivedAt != nil }
 
@@ -24,10 +25,12 @@ struct HabitDetailView: View {
             VStack(alignment: .leading, spacing: 20) {
                 header
                 metricsRow
+                quickLogSection
                 MonthlyCalendarView(
                     habit: habit.snapshot,
                     completions: habit.completions.map(\.snapshot)
                 )
+                CompletionHistoryList(habit: habit)
             }
             .padding()
         }
@@ -53,6 +56,9 @@ struct HabitDetailView: View {
         .sheet(isPresented: $showingEdit) {
             NewHabitFormView(model: NewHabitFormModel(editing: habit))
         }
+        .sheet(isPresented: $showingTimerSheet) {
+            TimerLogSheet(habit: habit)
+        }
         .confirmationDialog(
             String(localized: "Archive this habit?"),
             isPresented: $showingArchiveConfirmation,
@@ -71,6 +77,56 @@ struct HabitDetailView: View {
         habit.archivedAt = .now
         try? modelContext.save()
         dismiss()
+    }
+
+    // MARK: - Quick-log
+
+    @ViewBuilder
+    private var quickLogSection: some View {
+        switch habit.type {
+        case .counter(let target):
+            CounterQuickLogView(
+                target: target,
+                todayValue: todayCounterValue,
+                onIncrement: incrementCounter,
+                onDecrement: decrementCounter
+            )
+            .disabled(isArchived)
+        case .timer:
+            Button {
+                showingTimerSheet = true
+            } label: {
+                Label("Log a session", systemImage: "timer")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color.accentColor.opacity(0.15))
+                    )
+                    .foregroundStyle(Color.accentColor)
+            }
+            .buttonStyle(.plain)
+            .disabled(isArchived)
+        case .binary, .negative:
+            EmptyView()
+        }
+    }
+
+    private var todayCounterValue: Double {
+        habit.completions
+            .first { calendar.isDate($0.date, inSameDayAs: .now) }?
+            .value ?? 0
+    }
+
+    private func incrementCounter() {
+        CompletionLogger(calendar: calendar).incrementCounter(for: habit, in: modelContext)
+        try? modelContext.save()
+    }
+
+    private func decrementCounter() {
+        CompletionLogger(calendar: calendar).decrementCounter(for: habit, in: modelContext)
+        try? modelContext.save()
     }
 
     private var header: some View {

--- a/Kado/Views/HabitDetail/TimerLogSheet.swift
+++ b/Kado/Views/HabitDetail/TimerLogSheet.swift
@@ -11,35 +11,22 @@ struct TimerLogSheet: View {
     @Environment(\.calendar) private var calendar
     @Environment(\.dismiss) private var dismiss
 
-    @State private var minutes: Int
+    /// Prefilled lazily in `.onAppear` so the env calendar (not the
+    /// unrelated `.current`) drives today-completion lookup. `nil`
+    /// before first render.
+    @State private var minutes: Int?
     @State private var saveTick = 0
-
-    init(habit: HabitRecord) {
-        self.habit = habit
-        // Prefill with today's existing value (minutes) or the habit's target.
-        let cal = Calendar.current
-        let existing = habit.completions.first {
-            cal.isDate($0.date, inSameDayAs: .now)
-        }
-        let defaultMinutes: Int = {
-            if let existing {
-                return max(1, Int((existing.value / 60).rounded()))
-            }
-            switch habit.type {
-            case .timer(let seconds): return max(1, Int((seconds / 60).rounded()))
-            default: return 10
-            }
-        }()
-        _minutes = State(initialValue: defaultMinutes)
-    }
 
     var body: some View {
         NavigationStack {
             Form {
                 Section {
                     Stepper(
-                        String(localized: "\(minutes) min"),
-                        value: $minutes,
+                        String(localized: "\(minutes ?? 1) min"),
+                        value: Binding(
+                            get: { minutes ?? 1 },
+                            set: { minutes = $0 }
+                        ),
                         in: 1...480
                     )
                 } header: {
@@ -59,13 +46,32 @@ struct TimerLogSheet: View {
                 }
             }
             .sensoryFeedback(.success, trigger: saveTick)
+            .onAppear {
+                if minutes == nil {
+                    minutes = defaultMinutes()
+                }
+            }
+        }
+    }
+
+    private func defaultMinutes() -> Int {
+        let existing = habit.completions.first {
+            calendar.isDate($0.date, inSameDayAs: .now)
+        }
+        if let existing {
+            return max(1, Int((existing.value / 60).rounded()))
+        }
+        switch habit.type {
+        case .timer(let seconds): return max(1, Int((seconds / 60).rounded()))
+        default: return 10
         }
     }
 
     private func save() {
+        let m = minutes ?? defaultMinutes()
         CompletionLogger(calendar: calendar).logTimerSession(
             for: habit,
-            seconds: TimeInterval(minutes) * 60,
+            seconds: TimeInterval(m) * 60,
             in: modelContext
         )
         try? modelContext.save()

--- a/Kado/Views/HabitDetail/TimerLogSheet.swift
+++ b/Kado/Views/HabitDetail/TimerLogSheet.swift
@@ -1,0 +1,86 @@
+import SwiftData
+import SwiftUI
+
+/// Modal sheet for logging a timer habit's session duration in
+/// minutes. Replaces today's completion on save (single-record-
+/// per-day invariant).
+struct TimerLogSheet: View {
+    let habit: HabitRecord
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.calendar) private var calendar
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var minutes: Int
+    @State private var saveTick = 0
+
+    init(habit: HabitRecord) {
+        self.habit = habit
+        // Prefill with today's existing value (minutes) or the habit's target.
+        let cal = Calendar.current
+        let existing = habit.completions.first {
+            cal.isDate($0.date, inSameDayAs: .now)
+        }
+        let defaultMinutes: Int = {
+            if let existing {
+                return max(1, Int((existing.value / 60).rounded()))
+            }
+            switch habit.type {
+            case .timer(let seconds): return max(1, Int((seconds / 60).rounded()))
+            default: return 10
+            }
+        }()
+        _minutes = State(initialValue: defaultMinutes)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Stepper(
+                        String(localized: "\(minutes) min"),
+                        value: $minutes,
+                        in: 1...480
+                    )
+                } header: {
+                    Text("Session length")
+                } footer: {
+                    Text("Saves as today's completion. If you already logged a session today, it will be replaced.")
+                }
+            }
+            .navigationTitle(Text("Log session"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") { save() }
+                }
+            }
+            .sensoryFeedback(.success, trigger: saveTick)
+        }
+    }
+
+    private func save() {
+        CompletionLogger(calendar: calendar).logTimerSession(
+            for: habit,
+            seconds: TimeInterval(minutes) * 60,
+            in: modelContext
+        )
+        try? modelContext.save()
+        saveTick += 1
+        dismiss()
+    }
+}
+
+#Preview {
+    TimerLogSheet(
+        habit: HabitRecord(
+            name: "Read",
+            frequency: .daily,
+            type: .timer(targetSeconds: 30 * 60)
+        )
+    )
+    .modelContainer(PreviewContainer.emptyContainer())
+}

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -60,7 +60,8 @@ struct TodayView: View {
                         HabitRowView(
                             habit: record.snapshot,
                             isCompletedToday: isCompletedToday(record),
-                            onToggle: canToggle(record) ? { toggle(record) } : nil
+                            onToggle: canToggle(record) ? { toggle(record) } : nil,
+                            todayValue: todayValue(for: record)
                         )
                     }
                 }
@@ -82,6 +83,13 @@ struct TodayView: View {
     private func isCompletedToday(_ record: HabitRecord) -> Bool {
         let now = Date.now
         return record.completions.contains { calendar.isDate($0.date, inSameDayAs: now) }
+    }
+
+    private func todayValue(for record: HabitRecord) -> Double? {
+        let now = Date.now
+        return record.completions
+            .first { calendar.isDate($0.date, inSameDayAs: now) }?
+            .value
     }
 
     private func canToggle(_ record: HabitRecord) -> Bool {

--- a/KadoTests/CompletionLoggerTests.swift
+++ b/KadoTests/CompletionLoggerTests.swift
@@ -1,0 +1,150 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import Kado
+
+@Suite("CompletionLogger")
+@MainActor
+struct CompletionLoggerTests {
+    let container: ModelContainer
+
+    init() throws {
+        container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("incrementCounter creates a completion with value 1 when none exists today")
+    func incrementCreatesWhenAbsent() throws {
+        let habit = HabitRecord(name: "Water", frequency: .daily, type: .counter(target: 8))
+        container.mainContext.insert(habit)
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.incrementCounter(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 1)
+        #expect(habit.completions.first?.value == 1)
+    }
+
+    @Test("incrementCounter adds to existing today's value")
+    func incrementAddsToExisting() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        let existing = CompletionRecord(date: TestCalendar.day(0), value: 3, habit: habit)
+        container.mainContext.insert(existing)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.incrementCounter(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 1)
+        #expect(habit.completions.first?.value == 4)
+    }
+
+    @Test("decrementCounter reduces value by 1")
+    func decrementReducesValue() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        let existing = CompletionRecord(date: TestCalendar.day(0), value: 5, habit: habit)
+        container.mainContext.insert(existing)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.decrementCounter(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.first?.value == 4)
+    }
+
+    @Test("decrementCounter below 1 deletes the completion")
+    func decrementDeletesWhenZero() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        let existing = CompletionRecord(date: TestCalendar.day(0), value: 1, habit: habit)
+        container.mainContext.insert(existing)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.decrementCounter(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.isEmpty)
+    }
+
+    @Test("decrementCounter with no completion is a no-op")
+    func decrementWithoutCompletionIsNoOp() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.decrementCounter(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.isEmpty)
+    }
+
+    @Test("logTimerSession creates a completion with value = seconds")
+    func timerSessionCreates() throws {
+        let habit = HabitRecord(type: .timer(targetSeconds: 30 * 60))
+        container.mainContext.insert(habit)
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.logTimerSession(for: habit, seconds: 25 * 60, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 1)
+        #expect(habit.completions.first?.value == 25 * 60)
+    }
+
+    @Test("logTimerSession replaces today's existing completion")
+    func timerSessionReplaces() throws {
+        let habit = HabitRecord(type: .timer(targetSeconds: 30 * 60))
+        container.mainContext.insert(habit)
+        let existing = CompletionRecord(date: TestCalendar.day(0), value: 10 * 60, habit: habit)
+        container.mainContext.insert(existing)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.logTimerSession(for: habit, seconds: 40 * 60, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 1)
+        #expect(habit.completions.first?.value == 40 * 60)
+    }
+
+    @Test("delete removes the given completion without touching others")
+    func deleteRemovesOnly() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        let c1 = CompletionRecord(date: TestCalendar.day(0), value: 3, habit: habit)
+        let c2 = CompletionRecord(date: TestCalendar.day(-1), value: 4, habit: habit)
+        container.mainContext.insert(c1)
+        container.mainContext.insert(c2)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.delete(c1, in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 1)
+        #expect(habit.completions.first?.id == c2.id)
+    }
+
+    @Test("Incrementing on two consecutive days creates two records")
+    func incrementSpanningDays() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.incrementCounter(for: habit, on: TestCalendar.day(-1), in: container.mainContext)
+        logger.incrementCounter(for: habit, on: TestCalendar.day(0), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions.count == 2)
+    }
+}

--- a/KadoTests/CompletionLoggerTests.swift
+++ b/KadoTests/CompletionLoggerTests.swift
@@ -97,7 +97,7 @@ struct CompletionLoggerTests {
         try container.mainContext.save()
 
         #expect(habit.completions.count == 1)
-        #expect(habit.completions.first?.value == 25 * 60)
+        #expect(habit.completions.first?.value == Double(25 * 60))
     }
 
     @Test("logTimerSession replaces today's existing completion")
@@ -113,7 +113,7 @@ struct CompletionLoggerTests {
         try container.mainContext.save()
 
         #expect(habit.completions.count == 1)
-        #expect(habit.completions.first?.value == 40 * 60)
+        #expect(habit.completions.first?.value == Double(40 * 60))
     }
 
     @Test("delete removes the given completion without touching others")

--- a/docs/plans/2026-04/detail-quick-log/compound.md
+++ b/docs/plans/2026-04/detail-quick-log/compound.md
@@ -1,0 +1,211 @@
+---
+# Compound — Detail view quick-log + history
+
+**Date**: 2026-04-17
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [feature/detail-quick-log](https://github.com/scastiel/kado/pull/7)
+
+## Summary
+
+Shipped counter `+/−` controls, a timer "Log session" modal sheet,
+and a scrollable completion history list on `HabitDetailView`. New
+`CompletionLogger` service handles the value-carrying mutations
+(mirrors `CompletionToggler`'s shape). `HabitRowView` now surfaces
+today's value for counter/timer rows (`3/8` instead of `–/8`). 7
+tasks shipped verbatim from the plan. **Headline: the "sub-minute
+timer edit" issue that bit the previous PR reappeared as a
+Double-vs-Int `#expect` failure — same family of bug, different
+surface.**
+
+## Decisions made
+
+- **`CompletionLogger` as a concrete struct mirroring
+  `CompletionToggler`**: no protocol, `Calendar` injection, inline
+  instantiation at call sites. The pattern is clearly the right
+  fit for "mutate a habit's completions from UI" — third time it
+  recurs, worth codifying.
+- **Single-record-per-day invariant holds across all types**:
+  counter increments add to today's record; timer replaces it
+  (delete-then-insert); decrement-to-zero deletes. "No record" ↔
+  "not done today" bijection preserved.
+- **Counter target-reached haptic fires only on below→at
+  transition**: `.sensoryFeedback(.success, trigger:) { old, new in !old && new }`.
+  Not on every re-render, not on the reverse direction.
+- **Timer logging via modal sheet with minute stepper**: defers
+  the real start/stop timer (ActivityKit, v0.3). Manual minute
+  logging covers the MVP use case — 2 taps to log a 25-min
+  session.
+- **History list empty state is a neutral "No history yet" row**
+  (not a `ContentUnavailableView` — the calendar above already
+  signals "nothing here").
+- **Swipe-to-delete with no confirmation**: iOS-convention. Undo
+  lives in the row (tap +/-, delete, re-log).
+- **Counter `+` always enabled**; `−` disabled only when value is
+  0. Users can overshoot targets intentionally.
+- **`HabitRowView.todayValue: Double? = nil`**: optional with a
+  default to preserve every existing call site. `TodayView`
+  computes it; detail-view consumers don't need it.
+- **History list uses `LazyVStack`** (fixed during review): long
+  histories render lazily, not eagerly.
+- **Timer prefill via `.onAppear` + env calendar** (also a review
+  fix): init-time `Calendar.current` was subtly inconsistent with
+  the save path's env calendar.
+
+## Surprises and how we handled them
+
+### Double vs Int equality in `#expect` fails silently at compile time
+
+- **What happened**: Two timer-session tests failed with
+  `(habit.completions.first?.value → 1500.0) == (25 * 60 → 1500)`.
+  `value` is `Double?`; `25 * 60` is `Int`. Swift's type system
+  compiles the expression via permissive coercion but runtime
+  equality returns false — the Double and Int have different
+  bitwise representations, and `#expect`'s macro captures both
+  values honestly.
+- **What we did**: Explicit `Double(25 * 60)` on the RHS. Tests
+  went green immediately. No impl change.
+- **Lesson**: In Swift Testing with numeric types, always match
+  sides explicitly. `Double(...)` or `1500.0` literal on the RHS
+  of a `Double?` comparison. The compiler's silent coercion is a
+  landmine for `#expect`. Worth a CLAUDE.md note under Testing.
+
+### `CompletionHistoryList` was a `VStack`, not a `LazyVStack`
+
+- **What happened**: The plan explicitly called for `LazyVStack`.
+  The initial implementation used plain `VStack`, which eagerly
+  builds every row on first render. Review caught it.
+- **What we did**: One-line swap: `VStack` → `LazyVStack`. No
+  other changes.
+- **Lesson**: When the plan specifies `LazyVStack` for a
+  potentially-large list, double-check at build time. Easy to
+  drift from the plan's perf assumptions.
+
+### Timer prefill used `Calendar.current`, not env
+
+- **What happened**: `TimerLogSheet.init` read today's completion
+  via `Calendar.current` because `@Environment` isn't accessible
+  in `init`. The save path later used the env calendar — subtle
+  inconsistency in tests/previews with overridden calendars.
+- **What we did**: Moved prefill to `.onAppear`, where the env
+  calendar is bound. Added a small `Optional<Int>` dance for the
+  `@State` to reflect "not prefilled yet." No user-facing
+  change.
+- **Lesson**: `@Environment` values can't drive `@State`
+  initializers directly. For env-dependent defaults, use
+  `.onAppear` to perform the first assignment. Generalizable
+  pattern worth calling out in CLAUDE.md alongside the existing
+  `@Observable ViewModel` note.
+
+## What worked well
+
+- **Third time using the "service struct with Calendar injection"
+  pattern** (after `CompletionToggler`, `StreakCalculator`,
+  `HabitScoreCalculator`): the `CompletionLogger` landed in under
+  an hour. Shape is familiar, tests are familiar, instantiation
+  is familiar. Pattern is now load-bearing across the codebase.
+- **TDD caught the Double/Int issue at first run**: red tests
+  failed on the value comparison, not on scaffolding or build
+  errors. Tight loop.
+- **Plan tasks 3-7 each landed as their own commit** with no
+  cross-task refactors — row update, counter view, timer sheet,
+  history list, wiring. The bundling held.
+- **Plan's "Out of scope" section** kept the PR from bloating.
+  Live Activities, notes on completions, scrollable past months
+  stayed deferred.
+- **`@Bindable var habit: HabitRecord`** continues to carry
+  SwiftData mutations cleanly across child components
+  (`CompletionHistoryList`, `CounterQuickLogView` callbacks,
+  `TimerLogSheet`). No explicit propagation needed; the detail
+  view's `@Bindable` root cascades updates to every consumer.
+- **Pre-merge review catching two real issues** that unit tests
+  wouldn't have (LazyVStack perf, env-calendar consistency). The
+  review stage is earning its time.
+
+## For the next person
+
+- **`CompletionLogger.delete` is a passthrough to
+  `modelContext.delete`**. It exists for API symmetry with the
+  other mutations. If you add centralized logging/telemetry
+  later, the hook is there. Otherwise, `modelContext.delete`
+  directly is equally correct.
+- **Counter decrement below 1 deletes the record.** If a user
+  edits `value` to a fractional number (via a hypothetical future
+  API or data import), the deletion threshold (`<= 1`) might
+  surprise — 0.5 decrements to deletion, not 0. Current UI uses
+  integer steps so it can't happen today.
+- **Timer sessions replace, not accumulate.** If a user logs two
+  25-minute sessions in the same day, the second replaces the
+  first. If product feedback wants sum-in-day semantics, revisit
+  `logTimerSession` to add instead of replace — but note that
+  the score algorithm currently expects one record per day.
+- **`HabitDetailView.quickLogSection` is `.disabled(isArchived)`**
+  — archived habits can't be logged against. But
+  `CompletionHistoryList` swipe-to-delete stays enabled on
+  archived habits intentionally: history editing remains
+  possible after archive. Revisit if users treat archive as
+  "read-only vault."
+- **`CompletionHistoryList.valueLabel` for counter rows compares
+  the completion's value against the habit's CURRENT target**,
+  not the target at the time of the completion. If target
+  changes (8→10), old "6/8" entries retroactively render as
+  "6/10." To fix properly, store `targetAtTime` on
+  `CompletionRecord` — a data-model change that belongs with the
+  score-history spec work.
+- **`absoluteDate` in the history list uses fixed format
+  `"EEE MMM d"`** — English abbreviations baked in. Swap to a
+  locale-aware formatter when FR lands.
+- **Today row's `todayValue` threads through from `@Query`'s
+  reactive result**: no explicit observation plumbing. If you
+  add another per-row reactive field (score? streak?), follow
+  the same pattern: compute in `TodayView`, pass via optional
+  parameter with default `nil` to preserve call-site
+  compatibility.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md — Testing]** In Swift Testing, numeric
+  comparisons in `#expect` must have matching types on both
+  sides. `Double? == Int` compiles (via the expression macro's
+  permissive binding) but evaluates to `false` at runtime even
+  for the same logical value. Always use explicit `Double(...)`
+  or a `1500.0` literal when asserting against a `Double` value.
+  Applies to `#require` too.
+- **[→ CLAUDE.md — SwiftUI]** For `@State` defaults that depend
+  on `@Environment` values (calendar, locale, dismiss action),
+  initialize in `.onAppear`, not `init`. `@State` is seeded
+  before env injection happens. Pattern: declare as
+  `@State var value: T? = nil`, then `.onAppear { if value == nil { value = computeDefault() } }`.
+  Applied to `TimerLogSheet`'s minute prefill.
+- **[local]** The "service struct + Calendar injection + inline
+  instantiation" pattern (`CompletionToggler`, `CompletionLogger`,
+  `DefaultStreakCalculator`, `DefaultFrequencyEvaluator`) is now
+  the default for "write or read completion-adjacent data." Don't
+  reach for a protocol until there's a real substitution need.
+
+## Metrics
+
+- Tasks completed: 7 of 8 (Task 8 polish skipped; addressed
+  two review items instead)
+- Tests added: 9 (`CompletionLoggerTests`)
+- Total test count: 97 → 106 (106/106 green)
+- Commits on branch: 11 (3 docs, 6 build, 1 plan notes, 1 review
+  fix)
+- Files added: 4 source + 1 test + 3 docs
+- Files modified: 2 source (HabitRowView, TodayView)
+- Net diff: +1,145 / -3 across 10 files (of which ~707 lines are
+  plan/research/compound docs)
+- Mid-build pivots: 0
+- Pre-merge review fixes: 2 (LazyVStack, env-calendar prefill)
+
+## References
+
+- [habit-detail-view compound](../habit-detail-view/compound.md)
+  — the parent PR that deferred this scope as "PR B."
+- [CompletionToggler](../../../../Kado/Services/CompletionToggler.swift)
+  — the pattern this PR's logger mirrors.
+- [Stepper](https://developer.apple.com/documentation/swiftui/stepper)
+- [swipeActions](https://developer.apple.com/documentation/swiftui/view/swipeactions(edge:allowsfullswipe:content:))
+- [LazyVStack](https://developer.apple.com/documentation/swiftui/lazyvstack)
+- [Swift Testing — #expect](https://developer.apple.com/documentation/testing/expect(_:_:sourcelocation:))

--- a/docs/plans/2026-04/detail-quick-log/plan.md
+++ b/docs/plans/2026-04/detail-quick-log/plan.md
@@ -1,0 +1,217 @@
+---
+# Plan — Detail view quick-log + history
+
+**Date**: 2026-04-17
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Detail view gains counter `+/−` controls, a timer "Log session"
+sheet, and a scrollable completion history list with
+swipe-to-delete. `HabitRowView` updates to show today's value for
+counter/timer rows. New `CompletionLogger` service handles the
+writes. No data-model changes.
+
+## Decisions locked in
+
+- **`CompletionLogger` mirrors `CompletionToggler`**: concrete
+  `@MainActor struct` with injected `Calendar`, no protocol, no
+  env injection. Instantiated inline at call sites.
+- **Single record per day invariant** holds for counter and
+  timer (same as binary). Increment adds to the existing record's
+  value; timer replaces.
+- **Counter decrement to zero deletes** the record. Keeps "no
+  record" ↔ "not completed" bijection.
+- **History list**: `LazyVStack` over all completions, sorted
+  descending, swipe-to-delete without confirmation.
+- **Counter target-reached haptic**: `.success` on the below→at
+  transition only.
+- **Timer logging**: modal sheet with minute stepper, default
+  prefilled from habit's target minutes.
+- **No data-model change.** `CompletionRecord.value: Double`
+  accommodates both.
+
+## Task list
+
+### Task 1: Red tests for `CompletionLogger`
+
+**Goal**: TDD the new counter/timer/delete operations.
+
+**Changes**:
+- `KadoTests/CompletionLoggerTests.swift` (new).
+
+**Cases**:
+- `@Test("incrementCounter creates a completion with value 1 when none exists today")`
+- `@Test("incrementCounter adds to existing today's value")`
+- `@Test("decrementCounter reduces value by 1")`
+- `@Test("decrementCounter below 1 deletes the completion")`
+- `@Test("decrementCounter when no completion is a no-op")`
+- `@Test("logTimerSession creates a completion with value = seconds")`
+- `@Test("logTimerSession replaces today's existing completion")`
+- `@Test("delete removes the given completion without touching others")`
+- `@Test("Day-boundary: incrementing on two consecutive days creates two records")`
+
+**Verification**: `test_sim` fails (symbol missing).
+
+**Commit**: `test(completion-logger): red-state tests for counter/timer logging`
+
+---
+
+### Task 2: Implement `CompletionLogger`
+
+**Goal**: Struct with `Calendar` injection, four methods.
+
+**Changes**:
+- `Kado/Services/CompletionLogger.swift` (new):
+  ```swift
+  @MainActor
+  struct CompletionLogger {
+      let calendar: Calendar
+      init(calendar: Calendar = .current)
+
+      func incrementCounter(for habit: HabitRecord, on date: Date = .now, by delta: Double = 1, in context: ModelContext)
+      func decrementCounter(for habit: HabitRecord, on date: Date = .now, in context: ModelContext)
+      func logTimerSession(for habit: HabitRecord, seconds: TimeInterval, on date: Date = .now, in context: ModelContext)
+      func delete(_ completion: CompletionRecord, in context: ModelContext)
+  }
+  ```
+
+**Verification**: `test_sim` green.
+
+**Commit**: `feat(completion-logger): support counter/timer logging operations`
+
+---
+
+### Task 3: Update `HabitRowView` to show today's value
+
+**Goal**: Replace `–/8` placeholder with actual today value when
+present.
+
+**Changes**:
+- `Kado/UIComponents/HabitRowView.swift`:
+  - Add `todayValue: Double?` parameter.
+  - Counter trailing label: `"\(Int(todayValue ?? 0))/\(Int(target))"`
+    when `todayValue != nil`, else `"–/\(Int(target))"`.
+  - Timer trailing label: "HH:MM / target" formatted when present.
+- `Kado/Views/Today/TodayView.swift`: compute `todayValue` from
+  today's completion and pass through.
+- Previews: add "counter with today's progress" and "timer with
+  today's progress" permutations.
+
+**Verification**: `build_sim` clean; previews render.
+
+**Commit**: `feat(today-row): show today's value for counter and timer habits`
+
+---
+
+### Task 4: Build `CounterQuickLogView`
+
+**Goal**: `−` / value / `+` trio with target-reached haptic.
+
+**Changes**:
+- `Kado/UIComponents/CounterQuickLogView.swift` (new):
+  - Inputs: `habit: HabitRecord`, `todayValue: Double`,
+    `onIncrement`, `onDecrement`.
+  - Layout: large Label("\(value)/\(target)") between two circular
+    buttons. `−` disabled when `todayValue == 0`.
+  - `.sensoryFeedback(.success, trigger: targetReached)` where
+    `targetReached` flips to true when `todayValue >= target`.
+- Previews: under target / at target / over target / at zero.
+
+**Verification**: `build_sim` clean; previews render.
+
+**Commit**: `feat(counter-quick-log): add counter +/- control with target haptic`
+
+---
+
+### Task 5: Build `TimerLogSheet`
+
+**Goal**: Modal sheet for logging a timer session's minutes.
+
+**Changes**:
+- `Kado/Views/HabitDetail/TimerLogSheet.swift` (new):
+  - `@Bindable` habit + `@State var minutes: Int` prefilled from
+    target.
+  - `Form` with a `Stepper("Minutes: \(minutes)", value: $minutes, in: 1...480)`.
+  - Toolbar: Cancel / Save (Save calls `CompletionLogger.logTimerSession`).
+  - `@Environment(\.dismiss)` + `@Environment(\.modelContext)`.
+
+**Verification**: `build_sim` clean.
+
+**Commit**: `feat(timer-log-sheet): add minute-based timer session logging`
+
+---
+
+### Task 6: Build `CompletionHistoryList`
+
+**Goal**: Scrollable list of completions below the calendar.
+
+**Changes**:
+- `Kado/Views/HabitDetail/CompletionHistoryList.swift` (new):
+  - Input: `habit: HabitRecord`.
+  - Computes sorted-desc completions.
+  - `LazyVStack` — each row shows relative date
+    (`Today`/`Yesterday`/`N days ago`/formatted), formatted value
+    per habit type, swipe-to-delete.
+  - Empty state row when history is empty.
+
+**Verification**: `build_sim` clean.
+
+**Commit**: `feat(completion-history): add scrollable completion list for detail view`
+
+---
+
+### Task 7: Wire quick-log + history into `HabitDetailView`
+
+**Goal**: Compose the new components on the detail screen.
+
+**Changes**:
+- `HabitDetailView.swift`:
+  - Add `CounterQuickLogView` conditionally when
+    `habit.type == .counter`.
+  - Add "Log a session" button conditionally when
+    `habit.type == .timer`, opening `TimerLogSheet` as a sheet.
+  - Add `CompletionHistoryList` section at the bottom of the
+    scroll.
+
+**Verification**:
+- `build_sim` clean; `test_sim` green.
+- Manual sim run: create a counter habit → detail → `+` thrice
+  → row reflects `3/target`. Create a timer habit → detail →
+  "Log session" → saves. Swipe-delete history row → value
+  updates.
+- `screenshot` the populated detail view.
+
+**Commit**: `feat(habit-detail): wire counter, timer, and history sections`
+
+---
+
+### Task 8: (Optional) polish
+
+Reserved for issues during Tasks 3–7.
+
+## Risks and mitigation
+
+- **`HabitRowView` API change** breaks TodayView's call site:
+  Mitigation: Task 3 updates both in one commit.
+- **`@Bindable` on `HabitRecord` across multiple components**:
+  mutations propagate via SwiftData observation. No explicit
+  re-fetch needed.
+- **Swipe-to-delete races with optimistic UI**: deleting a
+  completion removes it from the list reactively (via the
+  `habit.completions` relationship). Should just work.
+- **XcodeBuildMCP flake**: OS-pinned `xcodebuild` fallback is
+  documented.
+
+## Open questions
+
+None — all resolved in research.
+
+## Out of scope
+
+- Live Activities / real timer start-stop (v0.3).
+- Notes / photos on completions (post-v1.0).
+- Scrollable past-months calendar (later PR).
+- Multi-session timer logging in a single day.
+- Editable value on history rows (only delete).

--- a/docs/plans/2026-04/detail-quick-log/plan.md
+++ b/docs/plans/2026-04/detail-quick-log/plan.md
@@ -2,7 +2,7 @@
 # Plan — Detail view quick-log + history
 
 **Date**: 2026-04-17
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -34,7 +34,7 @@ writes. No data-model changes.
 
 ## Task list
 
-### Task 1: Red tests for `CompletionLogger`
+### Task 1: ✅ Red tests for `CompletionLogger`
 
 **Goal**: TDD the new counter/timer/delete operations.
 
@@ -58,7 +58,7 @@ writes. No data-model changes.
 
 ---
 
-### Task 2: Implement `CompletionLogger`
+### Task 2: ✅ Implement `CompletionLogger`
 
 **Goal**: Struct with `Calendar` injection, four methods.
 
@@ -83,7 +83,7 @@ writes. No data-model changes.
 
 ---
 
-### Task 3: Update `HabitRowView` to show today's value
+### Task 3: ✅ Update `HabitRowView` to show today's value
 
 **Goal**: Replace `–/8` placeholder with actual today value when
 present.
@@ -105,7 +105,7 @@ present.
 
 ---
 
-### Task 4: Build `CounterQuickLogView`
+### Task 4: ✅ Build `CounterQuickLogView`
 
 **Goal**: `−` / value / `+` trio with target-reached haptic.
 
@@ -125,7 +125,7 @@ present.
 
 ---
 
-### Task 5: Build `TimerLogSheet`
+### Task 5: ✅ Build `TimerLogSheet`
 
 **Goal**: Modal sheet for logging a timer session's minutes.
 
@@ -143,7 +143,7 @@ present.
 
 ---
 
-### Task 6: Build `CompletionHistoryList`
+### Task 6: ✅ Build `CompletionHistoryList`
 
 **Goal**: Scrollable list of completions below the calendar.
 
@@ -162,7 +162,7 @@ present.
 
 ---
 
-### Task 7: Wire quick-log + history into `HabitDetailView`
+### Task 7: ✅ Wire quick-log + history into `HabitDetailView`
 
 **Goal**: Compose the new components on the detail screen.
 
@@ -187,9 +187,31 @@ present.
 
 ---
 
-### Task 8: (Optional) polish
+### Task 8: (Optional) polish — skipped
 
-Reserved for issues during Tasks 3–7.
+No issues surfaced during Tasks 3–7. 106/106 tests green on
+iPhone; iPad Air build clean. Screenshot confirms Today row
+layout unchanged for existing binary habits.
+
+## Notes during build
+
+- **Double vs Int comparison in `#expect`**: the timer-session
+  tests initially failed with `"1500.0 == 1500"` on the same
+  logical value because LHS was `Double?` and RHS was `Int`
+  (from `25 * 60`). Swift compiled the expression via permissive
+  coercion but runtime equality returned false. Fix: explicit
+  `Double(25 * 60)` on the RHS. Worth a CLAUDE.md note under
+  Testing: always match numeric types in `#expect` to avoid
+  silent compile-time coercion.
+- **`@Bindable` across components** continues to propagate
+  SwiftData mutations cleanly — `CompletionHistoryList`,
+  `CounterQuickLogView` callbacks, and `TimerLogSheet` all
+  trigger `habit.completions` updates that the detail view's
+  `HabitRowView`-computed properties pick up on re-render.
+- **`CompletionLogger` mirrors `CompletionToggler`** in shape and
+  test discipline — no protocol, concrete struct, `Calendar`
+  injection. The pattern is clearly a good fit for "mutate a
+  habit's completions from UI" operations.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-04/detail-quick-log/research.md
+++ b/docs/plans/2026-04/detail-quick-log/research.md
@@ -2,7 +2,7 @@
 # Research — Detail view quick-log + completion history
 
 **Date**: 2026-04-17
-**Status**: draft
+**Status**: ready for plan
 **Related**: [ROADMAP v0.1 — deferred from habit-detail-view](../../../ROADMAP.md), [habit-detail-view compound](../habit-detail-view/compound.md)
 
 ## Problem
@@ -201,28 +201,20 @@ with today's value" and "timer with today's value" states.
 
 ## Open questions
 
-- [ ] **Counter `+` / `−` or `+` only?** `−` helps correct
-  mistakes but adds visual weight. *Recommendation*: both, with
-  `−` disabled when value is 0.
-- [ ] **Timer: minute stepper in a sheet, or inline on detail?**
-  *Recommendation*: sheet. Matches iOS pattern for "log a thing
-  now" interactions (Health sessions, Reminders quick-add).
-- [ ] **History list scope**: just today + recent 30 days, or
-  full unbounded history? *Recommendation*: full history in a
-  `LazyVStack`, sorted descending. At habit-scale, perf is fine.
-- [ ] **Swipe-to-delete**: with or without confirmation?
-  *Recommendation*: without (iOS convention).
-- [ ] **Same-day timer logging**: replace the existing completion
-  or add another? *Recommendation*: replace (single record per
-  day invariant).
-- [ ] **Scrollable past-months calendar**: ship in this PR or
-  defer? *Recommendation*: defer. Scope creep; the history list
-  is the more useful surface.
-- [ ] **Update `HabitRowView` to show today's value for
-  counter/timer?** *Recommendation*: yes — it's a 10-line diff
-  and the `–/8` placeholder is a known eyesore.
-- [ ] **Haptic on counter target reached?** *Recommendation*:
-  yes, `.success` on transition from below-target to at-or-above.
+All resolved 2026-04-17:
+
+- [x] Counter controls: both `+` and `−`, minus disabled at 0.
+- [x] Timer: minute stepper in a modal sheet.
+- [x] History list: full history via `LazyVStack`, sorted
+  descending.
+- [x] Swipe-to-delete: no confirmation (iOS convention).
+- [x] Same-day timer: replace today's completion (single record
+  per day invariant).
+- [x] Scrollable past-months calendar: deferred.
+- [x] `HabitRowView` shows today's value for counter/timer when
+  present; falls back to `–/target`.
+- [x] Haptic on counter target reached: yes, on the below→at
+  transition.
 
 ## References
 

--- a/docs/plans/2026-04/detail-quick-log/research.md
+++ b/docs/plans/2026-04/detail-quick-log/research.md
@@ -1,0 +1,235 @@
+---
+# Research — Detail view quick-log + completion history
+
+**Date**: 2026-04-17
+**Status**: draft
+**Related**: [ROADMAP v0.1 — deferred from habit-detail-view](../../../ROADMAP.md), [habit-detail-view compound](../habit-detail-view/compound.md)
+
+## Problem
+
+Counter and timer habits appear on Today as read-only rows, and
+their detail view shows history/score/streak but no way to **log
+a completion**. The previous detail-view PR deferred this as
+"PR B." This PR delivers it:
+
+- **Counter habits**: quick-log a day's value (e.g. "8 glasses of
+  water") from the detail view.
+- **Timer habits**: quick-log a session's minutes.
+- **Completion history list**: a scrollable list below the
+  calendar showing recent completions with their values.
+
+Constraints:
+
+- **No Live Activities yet** (v0.3 scope). Timer logging is a
+  manual minute input, not a real start/stop timer.
+- **No notes / photos on completions** (post-v1.0 per ROADMAP).
+  Value-only.
+- **Today view stays binary-only for toggling** — counter/timer
+  rows still navigate to detail for logging.
+- **Data model unchanged** — `CompletionRecord` already stores
+  `value: Double` and an optional `note`.
+
+## Current state of the codebase
+
+What exists:
+
+- [`CompletionRecord`](../../../../Kado/Models/Persistence/CompletionRecord.swift)
+  — `value: Double` supports counter units or timer seconds.
+- [`CompletionToggler`](../../../../Kado/Services/CompletionToggler.swift)
+  — toggles today's binary completion (value = 1).
+- [`HabitDetailView`](../../../../Kado/Views/HabitDetail/HabitDetailView.swift)
+  — shows name, score, streak, monthly calendar. Edit + archive
+  toolbar.
+- [`MonthlyCalendarView`](../../../../Kado/UIComponents/MonthlyCalendarView.swift)
+  — shows per-day completion state. For counter/timer, "completed"
+  means ANY completion exists (regardless of value). Not ideal but
+  not a blocker.
+- [`HabitRowView`](../../../../Kado/UIComponents/HabitRowView.swift)
+  — counter/timer rows render with trailing `–/target` label (the
+  em-dash because today's value isn't threaded through).
+
+What's missing:
+
+- Any way to create a counter or timer `CompletionRecord`.
+- Any way to adjust today's counter value (increment / decrement).
+- A completion history list.
+- Today-value display on the calendar or the row.
+
+## Proposed approach
+
+**Three components on `HabitDetailView`, stacked below the score
+cards and above the calendar:**
+
+1. **Quick-log section** — per habit type:
+   - `.binary` / `.negative`: no-op. Toggling lives on Today.
+   - `.counter`: shows today's value as `N / target`, with a
+     `Stepper(value:) -> Button {−}` and `Button {+}` pair. The
+     `+` adds 1 to today's completion value (creates a record if
+     none); `−` subtracts 1, deletes the record when value drops
+     to 0.
+   - `.timer`: shows "Log a session" button opening a sheet with
+     a minute stepper + Save. Adds (or replaces) today's
+     completion with the given duration in seconds.
+
+2. **Completion history list** — scrollable `List` section below
+   the calendar showing up to 30 recent completions:
+   - For each: date (relative format "Today", "Yesterday", "3 days
+     ago", or date), value in habit-type-aware format.
+   - Swipe-to-delete for historic corrections.
+   - "Show more" button loads older entries (unbounded) if the list
+     exceeds 30 items.
+
+3. **Calendar today-value overlay** (optional): each counter/timer
+   cell shows a small value badge if completed, e.g. "6/8" in the
+   cell. Might be too cluttered at 32pt cell height — probably
+   skip for v0.1 and revisit.
+
+### Key components
+
+- **`CompletionLogger`** — extends the `CompletionToggler` pattern
+  for counter/timer operations:
+  ```swift
+  @MainActor
+  struct CompletionLogger {
+      let calendar: Calendar
+      init(calendar: Calendar = .current)
+      
+      func increment(habit: HabitRecord, by delta: Double, on date: Date, in context: ModelContext)
+      func logTimerSession(habit: HabitRecord, seconds: TimeInterval, on date: Date, in context: ModelContext)
+      func delete(completion: CompletionRecord, in context: ModelContext)
+  }
+  ```
+  TDD'd with in-memory `ModelContext` cases (mirrors
+  `CompletionToggler`).
+
+- **`CounterQuickLogView`** — small component rendering the
+  `−` / value / `+` trio. Shows visual cue when target reached
+  (e.g. checkmark overlay).
+
+- **`TimerLogSheet`** — modal sheet with a minute stepper and Save
+  button. Pre-fills with the habit's target minutes on first open;
+  remembers prior input on subsequent opens.
+
+- **`CompletionHistoryList`** — scrollable list with per-row cell
+  formatting by habit type. Swipe-to-delete + confirmation.
+
+### Data model changes
+
+None. `CompletionRecord.value: Double` already supports it.
+
+### UI changes
+
+- `HabitDetailView` gains a "log" section (conditional on type)
+  and a history list section.
+- `HabitRowView`'s trailing label updates to show today's value
+  when non-zero (`3/8` instead of `–/8`).
+- `MonthlyCalendarView` — no change (day-level completion state
+  already handles this).
+
+### Tests to write
+
+Pure-logic unit tests on `CompletionLogger`:
+
+```swift
+@Test("Incrementing a counter on a day with no completion creates one with value 1")
+@Test("Incrementing adds to an existing completion's value")
+@Test("Decrementing below zero deletes the completion")
+@Test("Logging a timer session replaces today's completion")
+@Test("Delete removes the completion and preserves others")
+```
+
+Also extend `HabitRowView` preview coverage to include "counter
+with today's value" and "timer with today's value" states.
+
+## Alternatives considered
+
+### Alternative A: Real timer (start / stop) on detail view
+
+- Idea: Tap "Start" to begin tracking, "Stop" to save session.
+  Requires `BackgroundTasks` / `ActivityKit` for resilience.
+- Why not: v0.3 scope per ROADMAP. Minute-based manual logging
+  covers the MVP use case ("I read for 25 minutes").
+
+### Alternative B: Editable value field (no stepper)
+
+- Idea: TextField for counter value, user types a number.
+- Why not: Steppers are the HIG pattern for bounded integer
+  input. Typing is less ergonomic for "+1 water glass" interactions.
+  An editable field could be a fallback for power users — defer.
+
+### Alternative C: Combine quick-log with the edit form
+
+- Idea: Open the edit sheet to log. Same UI as creation.
+- Why not: Quick-log is fundamentally "one tap" (increment by 1 or
+  start a session). An edit sheet is too heavy and would erode the
+  ergonomic win.
+
+### Alternative D: History as a second tab on the detail view
+
+- Idea: TabView with "Overview" (score/streak/calendar) and
+  "History" (list).
+- Why not: Extra navigation for a section most users will scroll
+  to. The inline scrollable list is more discoverable.
+
+## Risks and unknowns
+
+- **Counter decrement crossing zero**: What happens if user hits
+  "−" with value=1? Delete the record, or leave it at 0? We
+  already treat "no record" as "not completed," so deleting is the
+  coherent choice — but it means "−" and "+" aren't exactly
+  inverses (the final "-" deletes; the first "+" on a fresh day
+  creates). Test covers it.
+- **Timer session replacing vs adding**: If a user logs 25 min
+  twice in one day, does the second replace or add? Replace is
+  simpler; add matches "I did two sessions today" but complicates
+  the data model (single record per day is the current invariant).
+  Recommend **replace** for MVP; revisit if users ask.
+- **Counter target met feedback**: haptic, check overlay, or
+  both? Haptic on the transition is lowest-effort.
+- **History list pagination**: 30 items is arbitrary. Paginate
+  manually or use a LazyVStack with an unbounded fetch? For
+  v0.1, LazyVStack with the habit's full `completions` array
+  sorted descending should be fine at habit-scale (~hundreds
+  max).
+- **Swipe-to-delete confirmation**: iOS convention is no
+  confirmation for list swipe actions (undo lives in the parent
+  view). Align with convention; no dialog.
+- **Today row value display**: updating `HabitRowView` to show
+  today's value requires threading it through. Small diff. The
+  trailing label becomes `3/8` instead of `–/8` when a completion
+  exists.
+
+## Open questions
+
+- [ ] **Counter `+` / `−` or `+` only?** `−` helps correct
+  mistakes but adds visual weight. *Recommendation*: both, with
+  `−` disabled when value is 0.
+- [ ] **Timer: minute stepper in a sheet, or inline on detail?**
+  *Recommendation*: sheet. Matches iOS pattern for "log a thing
+  now" interactions (Health sessions, Reminders quick-add).
+- [ ] **History list scope**: just today + recent 30 days, or
+  full unbounded history? *Recommendation*: full history in a
+  `LazyVStack`, sorted descending. At habit-scale, perf is fine.
+- [ ] **Swipe-to-delete**: with or without confirmation?
+  *Recommendation*: without (iOS convention).
+- [ ] **Same-day timer logging**: replace the existing completion
+  or add another? *Recommendation*: replace (single record per
+  day invariant).
+- [ ] **Scrollable past-months calendar**: ship in this PR or
+  defer? *Recommendation*: defer. Scope creep; the history list
+  is the more useful surface.
+- [ ] **Update `HabitRowView` to show today's value for
+  counter/timer?** *Recommendation*: yes — it's a 10-line diff
+  and the `–/8` placeholder is a known eyesore.
+- [ ] **Haptic on counter target reached?** *Recommendation*:
+  yes, `.success` on transition from below-target to at-or-above.
+
+## References
+
+- [Stepper](https://developer.apple.com/documentation/swiftui/stepper)
+- [swipeActions](https://developer.apple.com/documentation/swiftui/view/swipeactions(edge:allowsfullswipe:content:))
+- [LazyVStack](https://developer.apple.com/documentation/swiftui/lazyvstack)
+- [habit-detail-view compound](../habit-detail-view/compound.md)
+  — parent PR's deferral of this scope.
+- [CompletionToggler](../../../../Kado/Services/CompletionToggler.swift)
+  — pattern the new logger mirrors.


### PR DESCRIPTION
## Why?
- Counter/timer habits exist in the data model but have no UI to log a completion
- Detail view shows score/streak/calendar but not a scrollable history
- Both pieces were deferred as "PR B" from the habit-detail-view PR

## What?
- **Counter**: \`+/−\` control on the detail view, target-reached haptic
- **Timer**: "Log a session" button opens a minute-stepper sheet
- **History list**: scrollable section below the calendar, swipe-to-delete, relative date labels
- **Today row**: counter/timer show today's value (\`3/8\` replaces the \`–/8\` placeholder)

## How?
- New \`CompletionLogger\` service mirrors \`CompletionToggler\`: concrete \`@MainActor struct\` with \`Calendar\` injection, 9 Swift Testing cases
- \`CounterQuickLogView\` (UIComponents) with \`.sensoryFeedback\` firing only on below→at transitions
- \`TimerLogSheet\` presents modally; prefill uses env calendar via \`.onAppear\`
- \`CompletionHistoryList\` with \`LazyVStack\` for long histories
- Research, plan, compound: [\`docs/plans/2026-04/detail-quick-log/\`](https://github.com/scastiel/kado/tree/feature/detail-quick-log/docs/plans/2026-04/detail-quick-log)

## Next steps
- **Live Activities / real timer start-stop** (v0.3 scope)
- **Notes / photos on completions** (post-v1.0)
- **Scrollable past-months calendar** (separate PR)
- **Per-completion historical target** (data-model change; belongs with score-history spec)
- Two lessons promoted to [CLAUDE.md](https://github.com/scastiel/kado/blob/feature/detail-quick-log/CLAUDE.md) in this PR: \`@State\` defaults that depend on \`@Environment\` must init in \`.onAppear\`, and \`#expect\` numeric comparisons require matching types on both sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)