### PR TITLE
feat(l10n): populate v0.1 string catalog and consolidate weekday helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,7 +329,43 @@ Non-negotiable from MVP:
 - EN and FR by v1.0. FR must be native French (no machine translation),
   with attention to gender-neutral phrasing when possible.
 - Use String Catalogs (`.xcstrings`), not legacy `Localizable.strings`.
-- Every user-facing string goes through `String(localized:)`.
+- Every user-facing string goes through localization — but **prefer
+  SwiftUI's `LocalizedStringKey`-typed initializers over explicit
+  `String(localized:)` wrapping**. `Text("foo")`, `Button("foo")`,
+  `Label("foo", systemImage: …)`, `.navigationTitle("foo")`,
+  `Tab("foo", systemImage: …)`, `ContentUnavailableView("foo", …)`,
+  `Section("foo")`, `Picker("foo", selection:)`, etc. all accept
+  `LocalizedStringKey` — the literal is already on the localized
+  path. Reach for `String(localized:)` only when the API is
+  `String`-typed (e.g. `.accessibilityLabel(_:)` with a dynamic
+  value, `TextField` placeholders, `confirmationDialog(_:)` titles),
+  or when a ternary `Text(cond ? "A" : "B")` would otherwise
+  collapse to the non-localizing `StringProtocol` overload (in which
+  case split the `Text` or wrap each arm).
+- **Interpolated strings must be wrapped as a whole**:
+  `String(localized: "\(name), \(state)")` works;
+  `"\(name), \(state)"` is a raw concat that never reaches the
+  catalog.
+- **For weekday labels, use `Weekday.localizedShort`,
+  `.localizedMedium`, or `.localizedFull`** — backed by
+  `Calendar.*StandaloneWeekdaySymbols`, so they auto-localize in
+  every language Apple ships. Never hand-roll catalog entries for
+  weekday abbreviations: Xcode collapses identical keys (e.g.
+  `"T"` with a Tuesday comment and `"T"` with a Thursday comment
+  merge into one entry), and the FR translator is then forced to
+  pick a single letter for both. The same principle applies to
+  month names (use `Calendar.monthSymbols` / `.shortMonthSymbols`
+  when the need arises).
+- **`Localizable.xcstrings` is source code, not a build artifact**.
+  Under `xcodebuild` / XcodeBuildMCP, the `.xcstrings` is NOT
+  auto-populated from source — only the Xcode IDE runs that sync.
+  Hand-author entries when a new key is introduced, commit the
+  catalog alongside the source change. Xcode will merge future
+  extractions with existing entries rather than overwrite.
+- Every catalog entry needs a `comment` describing its on-screen
+  context (imperative, context-first, under ~80 chars). For
+  count-driven interpolations, declare plural variants via
+  `variations.plural.{one,other}`.
 
 ---
 

--- a/Kado/Models/Weekday.swift
+++ b/Kado/Models/Weekday.swift
@@ -21,6 +21,12 @@ extension Weekday {
         symbol(from: Calendar.current.veryShortStandaloneWeekdaySymbols)
     }
 
+    /// Three-letter standalone weekday abbreviation for frequency
+    /// subtitles and compact lists (e.g. "Mon" in EN, "lun." in FR).
+    var localizedMedium: String {
+        symbol(from: Calendar.current.shortStandaloneWeekdaySymbols)
+    }
+
     /// Full standalone weekday name for accessibility labels and
     /// contexts where the day appears on its own.
     var localizedFull: String {

--- a/Kado/Models/Weekday.swift
+++ b/Kado/Models/Weekday.swift
@@ -11,3 +11,24 @@ enum Weekday: Int, CaseIterable, Hashable, Codable, Sendable {
     case friday = 6
     case saturday = 7
 }
+
+extension Weekday {
+    /// One-letter standalone weekday symbol for picker cells and
+    /// calendar headers (e.g. "M" on Monday in EN, "L" in FR).
+    /// Sourced from `Calendar.veryShortStandaloneWeekdaySymbols`, so
+    /// it auto-localizes via the system without catalog entries.
+    var localizedShort: String {
+        symbol(from: Calendar.current.veryShortStandaloneWeekdaySymbols)
+    }
+
+    /// Full standalone weekday name for accessibility labels and
+    /// contexts where the day appears on its own.
+    var localizedFull: String {
+        symbol(from: Calendar.current.standaloneWeekdaySymbols)
+    }
+
+    private func symbol(from symbols: [String]) -> String {
+        guard symbols.indices.contains(rawValue - 1) else { return "" }
+        return symbols[rawValue - 1]
+    }
+}

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -1,7 +1,768 @@
 {
   "sourceLanguage" : "en",
+  "version" : "1.0",
   "strings" : {
-
-  },
-  "version" : "1.0"
+    "%@, %@" : {
+      "comment" : "VoiceOver label for a binary or negative habit row. First arg: habit name. Second arg: localized completion state ('done' or 'not done').",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, %2$@"
+          }
+        }
+      }
+    },
+    "%@, counter, target %lld" : {
+      "comment" : "VoiceOver label for a counter habit row. First arg: habit name. Second arg: target count.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, counter, target %2$lld"
+          }
+        }
+      }
+    },
+    "%@, timer, target %@" : {
+      "comment" : "VoiceOver label for a timer habit row. First arg: habit name. Second arg: formatted target duration (e.g. '30:00').",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@, timer, target %2$@"
+          }
+        }
+      }
+    },
+    "%lld / best %lld" : {
+      "comment" : "Streak metric card value. First arg: current streak length in days. Second arg: best-ever streak length in days.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld / best %2$lld"
+          }
+        }
+      }
+    },
+    "%lld days ago" : {
+      "comment" : "Relative date label in the completion history list, for dates between 2 and 6 days in the past.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld day ago"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld days ago"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld days per week" : {
+      "comment" : "Stepper label in the new-habit form and frequency summary in habit detail, for the 'N days per week' frequency.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld day per week"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%lld days per week"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%lld min" : {
+      "comment" : "Stepper label in the timer-log sheet showing the session length in minutes.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld min"
+          }
+        }
+      }
+    },
+    "A few times a week" : {
+      "comment" : "Frequency picker option in the new-habit form, selects the 'N days per week' mode.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A few times a week"
+          }
+        }
+      }
+    },
+    "Archive" : {
+      "comment" : "Verb. Used as the toolbar button on the habit detail screen and as the destructive action in the archive confirmation dialog.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archive"
+          }
+        }
+      }
+    },
+    "Archive this habit?" : {
+      "comment" : "Confirmation dialog title shown when the user taps the Archive toolbar button on a habit.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archive this habit?"
+          }
+        }
+      }
+    },
+    "Archived" : {
+      "comment" : "Badge shown on the habit detail header when the habit has been archived.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archived"
+          }
+        }
+      }
+    },
+    "Archived habits stop appearing on Today but keep their history." : {
+      "comment" : "Message body in the archive confirmation dialog, explaining what archiving does.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Archived habits stop appearing on Today but keep their history."
+          }
+        }
+      }
+    },
+    "Avoid" : {
+      "comment" : "Habit type label for negative habits (things the user is trying NOT to do). Used in the new-habit picker and as the type subtitle on habit detail.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avoid"
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "comment" : "Dismissive button in confirmation dialogs and form toolbars.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "Come back tomorrow, or check your habit detail to log a past day." : {
+      "comment" : "Empty-state description shown on the Today view when the user has habits but none are due today.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Come back tomorrow, or check your habit detail to log a past day."
+          }
+        }
+      }
+    },
+    "Counter" : {
+      "comment" : "Habit type picker option — habits measured by an incrementing count (e.g. glasses of water).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Counter"
+          }
+        }
+      }
+    },
+    "Counter · target %lld" : {
+      "comment" : "Type subtitle on habit detail for counter habits, with the daily target value.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Counter · target %lld"
+          }
+        }
+      }
+    },
+    "Decrement" : {
+      "comment" : "VoiceOver label for the minus button in the counter quick-log control.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Decrement"
+          }
+        }
+      }
+    },
+    "Delete" : {
+      "comment" : "Swipe action in the completion history list that removes a completion.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "comment" : "History list value label for binary habits on a completed day.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        }
+      }
+    },
+    "Edit" : {
+      "comment" : "Primary toolbar button on habit detail that opens the edit form.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit"
+          }
+        }
+      }
+    },
+    "Edit Habit" : {
+      "comment" : "Navigation title for the habit form when editing an existing habit.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Habit"
+          }
+        }
+      }
+    },
+    "Every %lld days" : {
+      "comment" : "Stepper label in the new-habit form and frequency summary in habit detail, for the 'every N days' frequency.",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Every %lld day"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Every %lld days"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "Every N days" : {
+      "comment" : "Frequency picker option in the new-habit form, selects the 'every N days' mode. The literal 'N' is a placeholder — feel free to localize idiomatically (e.g. 'Tous les N jours').",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Every N days"
+          }
+        }
+      }
+    },
+    "Every day" : {
+      "comment" : "Daily frequency label. Used as the picker option in the new-habit form and as the frequency subtitle on habit detail.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Every day"
+          }
+        }
+      }
+    },
+    "Frequency" : {
+      "comment" : "Section header in the new-habit form grouping frequency-related controls.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frequency"
+          }
+        }
+      }
+    },
+    "Habit name" : {
+      "comment" : "Text field placeholder in the new-habit form.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habit name"
+          }
+        }
+      }
+    },
+    "Habits you create will appear here." : {
+      "comment" : "Empty-state description shown on the Today view when the user has not yet created any habits.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habits you create will appear here."
+          }
+        }
+      }
+    },
+    "History" : {
+      "comment" : "Section header above the list of past completions on the habit detail screen.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "History"
+          }
+        }
+      }
+    },
+    "How is it measured?" : {
+      "comment" : "Picker label in the new-habit form introducing the habit type (binary, counter, timer, avoid).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "How is it measured?"
+          }
+        }
+      }
+    },
+    "Increment" : {
+      "comment" : "VoiceOver label for the plus button in the counter quick-log control.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Increment"
+          }
+        }
+      }
+    },
+    "Log a session" : {
+      "comment" : "Quick-log button on habit detail for timer habits — opens the timer-log sheet.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log a session"
+          }
+        }
+      }
+    },
+    "Log session" : {
+      "comment" : "Navigation title of the timer-log sheet.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log session"
+          }
+        }
+      }
+    },
+    "Mark as done" : {
+      "comment" : "VoiceOver label for the completion toggle on a habit row when the habit is not yet completed today.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as done"
+          }
+        }
+      }
+    },
+    "Mark as not done" : {
+      "comment" : "VoiceOver label for the completion toggle on a habit row when the habit is already completed today.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as not done"
+          }
+        }
+      }
+    },
+    "New Habit" : {
+      "comment" : "Navigation title for the habit form when creating a new habit.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Habit"
+          }
+        }
+      }
+    },
+    "New habit" : {
+      "comment" : "Toolbar button on the Today view that opens the new-habit sheet. Note: lower-case 'habit' distinguishes it from the 'New Habit' form title.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New habit"
+          }
+        }
+      }
+    },
+    "No habits yet" : {
+      "comment" : "Empty-state title shown on the Today view when the user has not yet created any habits.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No habits yet"
+          }
+        }
+      }
+    },
+    "No history yet." : {
+      "comment" : "Empty-state message shown in the completion history list when a habit has no completions.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No history yet."
+          }
+        }
+      }
+    },
+    "Nothing due today" : {
+      "comment" : "Empty-state title shown on the Today view when the user has habits but none are due today.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nothing due today"
+          }
+        }
+      }
+    },
+    "Preferences will land here as the app grows." : {
+      "comment" : "Placeholder description in the Settings tab while the feature is unimplemented.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferences will land here as the app grows."
+          }
+        }
+      }
+    },
+    "Repeats" : {
+      "comment" : "Picker label in the new-habit form introducing the frequency options.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Repeats"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "comment" : "Confirmation button in form toolbars and the timer-log sheet.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
+          }
+        }
+      }
+    },
+    "Saves as today's completion. If you already logged a session today, it will be replaced." : {
+      "comment" : "Footer text in the timer-log sheet clarifying single-completion-per-day semantics.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saves as today's completion. If you already logged a session today, it will be replaced."
+          }
+        }
+      }
+    },
+    "Score" : {
+      "comment" : "Metric card title on habit detail, shows the current habit score as a percentage.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Score"
+          }
+        }
+      }
+    },
+    "Seed habit not found" : {
+      "comment" : "Developer-only fallback shown in SwiftUI previews when the seeded habit is missing. Not user-facing in production; safe to leave untranslated if that simplifies review.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seed habit not found"
+          }
+        }
+      }
+    },
+    "Session length" : {
+      "comment" : "Section header in the timer-log sheet.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Session length"
+          }
+        }
+      }
+    },
+    "Settings" : {
+      "comment" : "Title of the Settings tab. Used as the tab label, the content-unavailable title, and the navigation title.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        }
+      }
+    },
+    "Slipped" : {
+      "comment" : "History list value label for negative habits (those the user is trying to avoid) on a day they broke the habit.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slipped"
+          }
+        }
+      }
+    },
+    "Specific days" : {
+      "comment" : "Frequency picker option in the new-habit form, selects the 'specific weekdays' mode.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specific days"
+          }
+        }
+      }
+    },
+    "Streak" : {
+      "comment" : "Metric card title on habit detail, shows the current and best streak lengths in days.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Streak"
+          }
+        }
+      }
+    },
+    "Target: %lld" : {
+      "comment" : "Stepper label in the new-habit form for the counter target value.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Target: %lld"
+          }
+        }
+      }
+    },
+    "Target: %lld min" : {
+      "comment" : "Stepper label in the new-habit form for the timer target value in minutes.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Target: %lld min"
+          }
+        }
+      }
+    },
+    "Timer" : {
+      "comment" : "Habit type picker option — habits measured by a session duration (e.g. meditate 10 minutes).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timer"
+          }
+        }
+      }
+    },
+    "Timer · target %lld min" : {
+      "comment" : "Type subtitle on habit detail for timer habits, with the daily target in minutes.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Timer · target %lld min"
+          }
+        }
+      }
+    },
+    "Today" : {
+      "comment" : "Title of the Today tab. Used as the tab label, the navigation title, and as a relative-date label ('Today') in the completion history list.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today"
+          }
+        }
+      }
+    },
+    "Type" : {
+      "comment" : "Section header in the new-habit form grouping habit-type controls.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type"
+          }
+        }
+      }
+    },
+    "Yes / no" : {
+      "comment" : "Habit type label for binary habits (done/not done, no intermediate state). Used in the new-habit picker and as the type subtitle on habit detail.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes / no"
+          }
+        }
+      }
+    },
+    "Yesterday" : {
+      "comment" : "Relative date label in the completion history list.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yesterday"
+          }
+        }
+      }
+    },
+    "completed" : {
+      "comment" : "VoiceOver state for a completed day cell in the monthly calendar grid.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "completed"
+          }
+        }
+      }
+    },
+    "done" : {
+      "comment" : "VoiceOver state for a binary/negative habit row on a completed day. Lower-case to read naturally inside an interpolated sentence ('Meditate, done').",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "done"
+          }
+        }
+      }
+    },
+    "missed" : {
+      "comment" : "VoiceOver state for a past day in the monthly calendar grid where the habit was due and not completed.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "missed"
+          }
+        }
+      }
+    },
+    "not done" : {
+      "comment" : "VoiceOver state for a binary/negative habit row on a not-yet-completed day. Lower-case to read naturally inside an interpolated sentence ('Meditate, not done').",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "not done"
+          }
+        }
+      }
+    },
+    "not scheduled" : {
+      "comment" : "VoiceOver state for a past day in the monthly calendar grid where the habit was not due per its frequency.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "not scheduled"
+          }
+        }
+      }
+    },
+    "of %lld" : {
+      "comment" : "Caption in the counter quick-log control, under the current value (e.g. '3' 'of 8'). Argument is the daily target count.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "of %lld"
+          }
+        }
+      }
+    },
+    "upcoming" : {
+      "comment" : "VoiceOver state for a future day cell in the monthly calendar grid.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "upcoming"
+          }
+        }
+      }
+    }
+  }
 }

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -104,7 +104,7 @@ struct HabitRowView: View {
             let state = isCompletedToday
                 ? String(localized: "done")
                 : String(localized: "not done")
-            return "\(habit.name), \(state)"
+            return String(localized: "\(habit.name), \(state)")
         case .counter(let target):
             return String(localized: "\(habit.name), counter, target \(Int(target))")
         case .timer(let targetSeconds):

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -39,7 +39,7 @@ struct MonthlyCalendarView: View {
     private var weekdayHeader: some View {
         HStack(spacing: 8) {
             ForEach(weekdayDisplayOrder, id: \.self) { weekday in
-                Text(shortLabel(for: weekday))
+                Text(weekday.localizedShort)
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity)
@@ -75,18 +75,6 @@ struct MonthlyCalendarView: View {
 
     private var weekdayDisplayOrder: [Weekday] {
         [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
-    }
-
-    private func shortLabel(for weekday: Weekday) -> String {
-        switch weekday {
-        case .monday: String(localized: "M", comment: "Short Monday label")
-        case .tuesday: String(localized: "T", comment: "Short Tuesday label")
-        case .wednesday: String(localized: "W", comment: "Short Wednesday label")
-        case .thursday: String(localized: "T", comment: "Short Thursday label")
-        case .friday: String(localized: "F", comment: "Short Friday label")
-        case .saturday: String(localized: "S", comment: "Short Saturday label")
-        case .sunday: String(localized: "S", comment: "Short Sunday label")
-        }
     }
 
     @ViewBuilder

--- a/Kado/UIComponents/WeekdayPicker.swift
+++ b/Kado/UIComponents/WeekdayPicker.swift
@@ -26,7 +26,7 @@ struct WeekdayPicker: View {
                 selection.insert(day)
             }
         } label: {
-            Text(shortLabel(for: day))
+            Text(day.localizedShort)
                 .font(.callout.weight(.medium))
                 .frame(maxWidth: .infinity)
                 .frame(height: 36)
@@ -37,32 +37,8 @@ struct WeekdayPicker: View {
                 )
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel(for: day))
+        .accessibilityLabel(day.localizedFull)
         .accessibilityAddTraits(isSelected ? .isSelected : [])
-    }
-
-    private func shortLabel(for day: Weekday) -> String {
-        switch day {
-        case .monday: String(localized: "M", comment: "Short Monday label")
-        case .tuesday: String(localized: "T", comment: "Short Tuesday label")
-        case .wednesday: String(localized: "W", comment: "Short Wednesday label")
-        case .thursday: String(localized: "T", comment: "Short Thursday label")
-        case .friday: String(localized: "F", comment: "Short Friday label")
-        case .saturday: String(localized: "S", comment: "Short Saturday label")
-        case .sunday: String(localized: "S", comment: "Short Sunday label")
-        }
-    }
-
-    private func accessibilityLabel(for day: Weekday) -> String {
-        switch day {
-        case .monday: String(localized: "Monday")
-        case .tuesday: String(localized: "Tuesday")
-        case .wednesday: String(localized: "Wednesday")
-        case .thursday: String(localized: "Thursday")
-        case .friday: String(localized: "Friday")
-        case .saturday: String(localized: "Saturday")
-        case .sunday: String(localized: "Sunday")
-        }
     }
 }
 

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -221,7 +221,7 @@ struct HabitDetailView: View {
             return String(localized: "\(n) days per week")
         case .specificDays(let days):
             let ordered: [Weekday] = [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
-            let labels = ordered.filter(days.contains).map(shortWeekday(_:))
+            let labels = ordered.filter(days.contains).map(\.localizedMedium)
             return labels.joined(separator: " · ")
         case .everyNDays(let n):
             return String(localized: "Every \(n) days")
@@ -255,17 +255,6 @@ struct HabitDetailView: View {
         }
     }
 
-    private func shortWeekday(_ weekday: Weekday) -> String {
-        switch weekday {
-        case .monday: String(localized: "Mon")
-        case .tuesday: String(localized: "Tue")
-        case .wednesday: String(localized: "Wed")
-        case .thursday: String(localized: "Thu")
-        case .friday: String(localized: "Fri")
-        case .saturday: String(localized: "Sat")
-        case .sunday: String(localized: "Sun")
-        }
-    }
 }
 
 /// Small wrapper for previews — fetches a seeded habit from the

--- a/Kado/Views/NewHabit/NewHabitFormView.swift
+++ b/Kado/Views/NewHabit/NewHabitFormView.swift
@@ -20,7 +20,9 @@ struct NewHabitFormView: View {
                 frequencySection
                 typeSection
             }
-            .navigationTitle(Text(model.isEditing ? "Edit Habit" : "New Habit"))
+            .navigationTitle(model.isEditing
+                ? String(localized: "Edit Habit")
+                : String(localized: "New Habit"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {

--- a/docs/plans/2026-04/translations-catalog/compound.md
+++ b/docs/plans/2026-04/translations-catalog/compound.md
@@ -1,0 +1,200 @@
+---
+# Compound — Translations catalog for v0.1
+
+**Date**: 2026-04-17
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [feature/translations-catalog](https://github.com/scastiel/kado/tree/feature/translations-catalog) → [kado#9](https://github.com/scastiel/kado/pull/9)
+
+## Summary
+
+Populated `Localizable.xcstrings` with ~60 hand-authored entries,
+each carrying a translator comment and — for three count-driven
+interpolations — EN plural variants. Source code was already largely
+localization-ready; only two genuine fixes landed. The headline
+lesson: **research over-counted the work** because it conflated
+"raw string literal" with "bypasses localization." Most SwiftUI
+`Text`/`Button`/`Label`/`ContentUnavailableView` inits accept
+`LocalizedStringKey`, so a bare `Text("Today")` is already on the
+localized path.
+
+## Decisions made
+
+- **Use `Calendar.*StandaloneWeekdaySymbols` for weekday labels**:
+  replaces 21 hand-rolled catalog entries (short + full × 7 days)
+  with system-localized symbols that work in every language Apple
+  ships, and sidesteps the EN-level `"T"/"T"` / `"S"/"S"` collision
+  problem entirely.
+- **English text as catalog keys**: Xcode 16's default, no
+  namespacing except where EN collisions force it (none ended up
+  needing it post-weekday pivot).
+- **Hand-author the catalog JSON** instead of relying on Xcode
+  auto-extraction: `xcodebuild` (MCP) doesn't sync the `.xcstrings`
+  file during non-interactive builds, only Xcode IDE does. Hand-
+  authoring is additive — Xcode will merge new extractions with
+  existing entries on the next IDE open.
+- **Plural variants on 3 keys only**: `"%lld days per week"`,
+  `"Every %lld days"`, `"%lld days ago"`. Other count-driven keys
+  like `"Target: %lld"` and `"of %lld"` appear after a colon or
+  inside a phrase where the singular form reads naturally in EN
+  and most target languages — not worth the plural machinery.
+- **Time formatter migration (`String(format:)` →
+  `DateComponentsFormatter`) deferred**: scoped out of this PR.
+  Separate pre-v1.0 task, tracked only in `research.md`'s
+  out-of-scope.
+- **Pseudo-locale verification deferred**: MCP can't toggle Xcode's
+  scheme-level "Include accented pseudo-language" option. Formal
+  accented-pseudo sweep happens at v1.0 pre-FR from the Xcode IDE.
+
+## Surprises and how we handled them
+
+### Research over-counted the work
+
+- **What happened**: the Explore agent's inventory flagged ~15–20
+  "raw literals that bypass localization." Upon close reading,
+  almost all of them were already going through `LocalizedStringKey`
+  via SwiftUI initializers (`Tab(_:systemImage:)`,
+  `ContentUnavailableView(_:systemImage:description:)`,
+  `Button("..")`, `Label("..", systemImage:)`,
+  `.navigationTitle("..")`, `Text("..")`).
+- **What we did**: verified each call site against Apple's signatures
+  before writing Swift. Tasks 2 and 3 collapsed to no-ops. Only two
+  genuine fixes remained: a ternary `Text(cond ? "A" : "B")` that
+  risks collapsing to the non-localizing `StringProtocol` overload,
+  and a raw `"\(habit.name), \(state)"` concatenation in
+  `HabitRowView.accessibilityLabelText`.
+- **Lesson**: "raw literal" is not a reliable heuristic for "needs
+  fixing." Before concluding a call site leaks, check the init
+  signature — SwiftUI's APIs default to `LocalizedStringKey` more
+  often than you'd expect.
+
+### Weekday labels had a latent bug we nearly papered over
+
+- **What happened**: the plan called for hand-rolled catalog entries
+  for each weekday, matching the pre-existing `String(localized: "M", comment: "Short Monday label")` pattern in
+  `WeekdayPicker`. That pattern has a latent bug: Xcode collapses
+  `"T"` with a Tuesday comment and `"T"` with a Thursday comment
+  into one catalog entry. The FR translator would be forced to pick
+  one of `"M"`/`"J"` for both.
+- **What we did**: switched to `Calendar.*StandaloneWeekdaySymbols`,
+  eliminating the hand-rolled entries entirely.
+- **Lesson**: when Swift's localization API lets two distinct
+  concepts share a key, the only safe options are (a) let the
+  system provide the strings, or (b) disambiguate keys explicitly.
+  Relying on comments to keep them separate does not work —
+  Xcode merges by key.
+
+### `xcodebuild` doesn't auto-populate `.xcstrings`
+
+- **What happened**: `LOCALIZATION_PREFERS_STRING_CATALOGS=YES` and
+  `SWIFT_EMIT_LOC_STRINGS=YES` are both on. Built the app five
+  times during Task 1; the catalog stayed empty after each build.
+- **What we did**: confirmed via project.pbxproj that the catalog
+  is included via `PBXFileSystemSynchronizedRootGroup` (so Xcode
+  *should* see it), but accepted that the auto-populate step only
+  runs in the Xcode IDE. Pivoted to hand-authoring.
+- **Lesson**: for non-interactive (CI/MCP) workflows, treat the
+  `.xcstrings` file as source code, not a build artifact. It's
+  fine — Xcode merges hand-authored entries with future extractions.
+
+### Pseudo-locale launch args don't accent output without scheme config
+
+- **What happened**: tried `-AppleLanguages (en-XA) -AppleLocale en_XA`
+  via both launch args and simulator-wide defaults. Neither produced
+  accented output (`"T̂ôd̂áŷ"`).
+- **What we did**: confirmed runtime behavior manually against the
+  Today view, deferred full accented-pseudo sweep to v1.0 pre-FR
+  with Xcode IDE scheme option enabled.
+- **Lesson**: the accented pseudo-locale is a scheme-level Xcode
+  feature, not a pure runtime locale trick. CLI verification needs
+  either an additional `en_XA` localization in the catalog or the
+  IDE scheme option. Document this as a v1.0 prereq.
+
+## What worked well
+
+- **Conductor's research → plan → build → compound flow** gave each
+  stage room to surface its own discoveries. The research-level
+  scope locks made the build straightforward even when specific
+  assumptions turned out wrong.
+- **Small commits** (one per task, sometimes per pivot) kept the PR
+  reviewable and the rollback granularity tight.
+- **Reading every call site before editing** caught the Tasks 2/3
+  no-ops early, saving a round of pointless diffs.
+- **Plural variants in `.xcstrings` JSON** were cleaner than feared
+  — the `variations.plural.{one,other}` structure is obvious once
+  seen, and EN's two forms map directly.
+
+## For the next person
+
+- **Don't hand-roll weekday labels anywhere else**. Use
+  `Weekday.localizedShort` / `.localizedMedium` / `.localizedFull`
+  on [Weekday.swift](Kado/Models/Weekday.swift). The system-provided
+  symbols are correct in every locale Apple supports.
+- **When adding a new user-facing string**: if it's in a SwiftUI
+  init that accepts `LocalizedStringKey`, just type the literal —
+  that's already localized. Only wrap in `String(localized:)` when
+  you're passing to a `String`-typed API (e.g. `.accessibilityLabel(_:)`
+  with a dynamic value, or `confirmationDialog(_:isPresented:)`).
+- **Ternaries inside localized-key APIs are a trap**:
+  `Text(cond ? "A" : "B")` may resolve to the non-localizing
+  `StringProtocol` overload because the ternary's type collapses
+  to `String`. Either split (`cond ? Text("A") : Text("B")`) or
+  wrap each arm in `String(localized:)` explicitly.
+- **The catalog file is source code, not an artifact**. Edit it
+  directly when needed; commit it alongside the source change
+  that introduces a new key. Xcode (when opened) will merge new
+  extractions, not overwrite existing entries.
+- **Interpolated accessibility labels need
+  `String(localized: "...")` around the whole format**, not around
+  individual substitutions. `"\(name), \(state)"` without a wrap
+  is a raw concat and never hits the catalog.
+- **Pseudo-locale testing is Xcode-IDE-only** for this project
+  today. Before shipping FR (v1.0), add that to a pre-FR checklist
+  rather than fighting MCP for it.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** Add to the Localization section: "Prefer
+  SwiftUI's `LocalizedStringKey`-typed initializers over explicit
+  `String(localized:)` wrapping. Use `String(localized:)` only for
+  `String`-typed APIs or when a ternary would otherwise collapse
+  to `StringProtocol`."
+- **[→ CLAUDE.md]** Add to the Localization section: "For weekday
+  and month labels, use `Weekday.localizedShort` /
+  `.localizedMedium` / `.localizedFull` (system-symbol-backed).
+  Never hand-roll catalog entries for calendar abbreviations —
+  Xcode collapses identical keys and loses per-language
+  disambiguation."
+- **[→ CLAUDE.md]** Add a note about `xcodebuild` not auto-syncing
+  `.xcstrings` under MCP / CI. Treat the catalog as hand-authored
+  source.
+- **[local]** The three plural-variant keys shipped
+  (`"%lld days per week"`, `"Every %lld days"`, `"%lld days ago"`)
+  cover EN's two forms. FR translator will likely want plural
+  variants on a few more (`"Target: %lld"` for target >1 sounds
+  fine, but e.g. some Slavic languages have 3+ forms). Revisit
+  per-language during v1.0.
+
+## Metrics
+
+- Tasks completed: 8 of 8 (2 no-ops; 1 partial/deferred)
+- Tests added: 0 (none required — localization validated at
+  build-extraction time; no behavior changes)
+- Commits: 7 (3 docs, 1 refactor, 3 chore(l10n))
+- Files touched: 7 source + 3 docs = 10
+  - Source: `Weekday.swift`, `WeekdayPicker.swift`,
+    `MonthlyCalendarView.swift`, `HabitDetailView.swift`,
+    `HabitRowView.swift`, `NewHabitFormView.swift`,
+    `Localizable.xcstrings`
+  - Docs: `research.md`, `plan.md`, `compound.md`
+- Net LOC: +793 / -57 (the catalog JSON dominates)
+- Build/test status: all green throughout, 106/106 tests passing
+
+## References
+
+- [Xcode 16 String Catalogs documentation](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog)
+- [`Calendar.standaloneWeekdaySymbols`](https://developer.apple.com/documentation/foundation/calendar/2293301-standaloneweekdaysymbols) — source of the weekday pivot
+- CLAUDE.md → Localization section (current)
+- `docs/ROADMAP.md` v0.1 → "EN localization (FR arrives in v1.0,
+  strings prepared now via String Catalog)"

--- a/docs/plans/2026-04/translations-catalog/plan.md
+++ b/docs/plans/2026-04/translations-catalog/plan.md
@@ -169,7 +169,7 @@ section header, empty state, "Delete" swipe action).
 
 ---
 
-### Task 6: Curate catalog — comments + plural variants
+### Task 6: Curate catalog — comments + plural variants ✅
 
 **Goal**: turn the raw extracted catalog into something a translator
 can work with cold. This is the only task that edits `.xcstrings`

--- a/docs/plans/2026-04/translations-catalog/plan.md
+++ b/docs/plans/2026-04/translations-catalog/plan.md
@@ -66,7 +66,7 @@ truth and localize through the catalog.
 
 ---
 
-### Task 2: Normalize ContentView + SettingsView
+### Task 2: Normalize ContentView + SettingsView ✅ (no-op)
 
 **Goal**: close the `Tab()` / `ContentUnavailableView` localization
 leaks flagged in research.
@@ -90,7 +90,7 @@ leaks flagged in research.
 
 ---
 
-### Task 3: Normalize TodayView
+### Task 3: Normalize TodayView ✅ (no-op)
 
 **Goal**: localize empty-state strings and the "New habit" toolbar
 label.
@@ -289,6 +289,20 @@ None blocking. Deferred:
   EN-collision problem entirely, and drops 14 keys from Task 6's
   curation scope. Zero visible EN change (EN symbols match what we
   were typing by hand).
+- **Task 2 no-op**: `Tab(_:systemImage:)`,
+  `ContentUnavailableView(_:systemImage:description:)`, and
+  `.navigationTitle(_:)` all accept `LocalizedStringKey` in iOS 18.
+  Research flagged these as raw-literal leaks — they aren't. Source
+  already correct; strings will surface in the catalog during Task 6.
+- **Catalog auto-population under xcodebuild**:
+  `LOCALIZATION_PREFERS_STRING_CATALOGS=YES` and
+  `SWIFT_EMIT_LOC_STRINGS=YES` are set, but `xcodebuild` (MCP) does
+  NOT write the extracted strings back into the `.xcstrings` file
+  during a normal build — that sync happens in the Xcode IDE. Impact:
+  Task 6 hand-authors the catalog JSON from the inventory rather than
+  relying on auto-extraction. Same endpoint, just more explicit. The
+  hand-authored keys will be preserved by Xcode on future extractions
+  (it merges, doesn't overwrite).
 
 ## Out of scope
 

--- a/docs/plans/2026-04/translations-catalog/plan.md
+++ b/docs/plans/2026-04/translations-catalog/plan.md
@@ -1,0 +1,294 @@
+---
+# Plan — Translations catalog for v0.1
+
+**Date**: 2026-04-17
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Make `Kado/Resources/Localizable.xcstrings` complete, consistent, and
+translation-ready so that v1.0's FR pass is purely a translator's job.
+No user-visible EN change. Two phases: normalize every user-facing
+call site to `LocalizedStringKey` or `String(localized:)`, then curate
+the auto-extracted catalog with translator comments and plural
+variants for the ~12 count-driven interpolations.
+
+## Decisions locked in
+
+- **English text as catalog keys** (Xcode 16 default). Use `comment`
+  to disambiguate duplicates; only namespace on genuine conflict.
+- **Weekday labels consolidated** onto the `Weekday` enum
+  (`localizedShort`, `localizedFull`). Both `WeekdayPicker` and
+  `MonthlyCalendarView` migrate.
+- **Pseudo-locale verification is manual** for v0.1 (launch with
+  `-AppleLocale en_XA` on iPhone 16 Pro, spot-check each view). No
+  automated test. Formalize in v1.0 pre-FR pass.
+- **Time formatter migration (`String(format:)` → `DateComponentsFormatter`)
+  is out-of-scope.** Flagged for a separate pre-v1.0 PR.
+- **No `LOCALIZATION_PREFERS_STRING_CATALOGS` build-setting change**
+  unless Xcode 16 requires it — the project already uses
+  `.xcstrings`; verify during Task 1's smoke build.
+- **Scope excludes `NSUsageDescription` strings** — none exist yet
+  (HealthKit / CloudKit / biometrics land in v0.2+).
+
+## Task list
+
+Each task leaves the project compiling, tests green, and the visible
+EN UI unchanged. The `Localizable.xcstrings` file grows on every
+normalization task (Xcode auto-extracts on build); commit it alongside
+its source change to keep diffs narrow.
+
+### Task 1: Weekday helpers + migrate consumers
+
+**Goal**: add `Weekday.localizedShort: String` and
+`Weekday.localizedFull: String` so weekday labels have one source of
+truth and localize through the catalog.
+
+**Changes**:
+- `Kado/Models/Weekday.swift` — add both computed properties returning
+  `String(localized:)` values with clear translator comments.
+- [WeekdayPicker.swift:46–64](Kado/UIComponents/WeekdayPicker.swift) —
+  replace hardcoded `"M"..."Sunday"` with
+  `weekday.localizedShort` / `weekday.localizedFull`.
+- [MonthlyCalendarView.swift:82–88](Kado/Views/HabitDetail/MonthlyCalendarView.swift) —
+  replace column-header literals with `Weekday.allCases.map(\.localizedShort)`.
+- `Kado/Resources/Localizable.xcstrings` — auto-extracted entries for
+  14 keys (7 short + 7 full).
+
+**Tests / verification**:
+- Existing `test_sim` stays green (no existing tests target these
+  views' text content directly).
+- Quick preview check: `WeekdayPicker` and `MonthlyCalendarView`
+  previews render identical labels.
+
+**Commit message**: `refactor(weekday): consolidate localized labels onto Weekday enum`
+
+---
+
+### Task 2: Normalize ContentView + SettingsView
+
+**Goal**: close the `Tab()` / `ContentUnavailableView` localization
+leaks flagged in research.
+
+**Changes**:
+- [ContentView.swift:12,15](Kado/Views/ContentView.swift) — wrap tab
+  titles: `Tab(String(localized: "Today"), ...)`,
+  `Tab(String(localized: "Settings"), ...)`. (`Tab.init` takes a
+  `String` for the title, not a `LocalizedStringKey`, so the explicit
+  wrap is required.)
+- [SettingsView.swift:11,13,15](Kado/Views/Settings/SettingsView.swift) —
+  wrap the `ContentUnavailableView` title (String-typed) and
+  `navigationTitle` if not already `Text`-wrapped.
+
+**Tests / verification**:
+- Launch sim, confirm tab bar + settings placeholder read identically.
+- Check `.xcstrings` gained `"Today"`, `"Settings"`,
+  `"Preferences will land here as the app grows."`.
+
+**Commit message**: `chore(l10n): wrap tab titles and settings placeholder`
+
+---
+
+### Task 3: Normalize TodayView
+
+**Goal**: localize empty-state strings and the "New habit" toolbar
+label.
+
+**Changes**:
+- [TodayView.swift:31,45,47,53,55](Kado/Views/Today/TodayView.swift) —
+  wrap `"New habit"`, `"No habits yet"`, `"Habits you create will
+  appear here."`, `"Nothing due today"`, `"Come back tomorrow, or
+  check your habit detail to log a past day."`. Most just need to pass
+  through `LocalizedStringKey`; `ContentUnavailableView`'s String-typed
+  init needs `String(localized:)`.
+
+**Tests / verification**:
+- Run the empty-state preview and the loaded preview; confirm visual
+  parity.
+- `.xcstrings` now has the five strings above.
+
+**Commit message**: `chore(l10n): localize Today view empty states and toolbar`
+
+---
+
+### Task 4: Normalize NewHabitFormView
+
+**Goal**: localize picker options, Cancel/Save buttons, and the
+conditional navigation title.
+
+**Changes**:
+- [NewHabitFormView.swift:23](Kado/Views/NewHabit/NewHabitFormView.swift) —
+  replace `Text(model.isEditing ? "Edit Habit" : "New Habit")` with
+  two explicit `String(localized:)` keys so each arm feeds the
+  catalog. `.navigationTitle(Text(...))` stays; the literal lookup is
+  done beforehand.
+- Lines 27, 30 — `Button("Cancel")`, `Button("Save")` already go
+  through `LocalizedStringKey`, so no source change — verify they
+  appear in the catalog after build.
+- Lines 50–53, 81–84 — `Text(...)` picker options already go through
+  `LocalizedStringKey`; verify extraction.
+- Lines 61, 70, 92, 99 — interpolated stepper labels are already
+  `String(localized:)`; no source change, but translator comments go
+  in during Task 7.
+
+**Tests / verification**:
+- Open the form preview (default + counter + specific-days variants);
+  all labels render identically.
+- `.xcstrings` gains picker options, button labels, both
+  nav-title variants.
+
+**Commit message**: `chore(l10n): localize new habit form strings`
+
+---
+
+### Task 5: Normalize HabitDetailView + TimerLogSheet + CompletionHistoryList
+
+**Goal**: wrap the remaining raw literals in the detail surface
+(`"Archived"` badge, timer-sheet headers/footers/buttons, history
+section header, empty state, "Delete" swipe action).
+
+**Changes**:
+- [HabitDetailView.swift:144](Kado/Views/HabitDetail/HabitDetailView.swift) —
+  wrap `"Archived"` badge text.
+- [HabitDetailView.swift:99](Kado/Views/HabitDetail/HabitDetailView.swift) —
+  `Label("Log a session", systemImage: ...)` already takes
+  `LocalizedStringKey`; verify extraction.
+- [TimerLogSheet.swift:33,35,38,42,45](Kado/Views/HabitDetail/TimerLogSheet.swift) —
+  wrap section header, footer, nav title, Cancel, Save. Most can use
+  `Text("…")` / `Button("…")` directly (LocalizedStringKey path).
+- [CompletionHistoryList.swift:19,24,73](Kado/Views/HabitDetail/CompletionHistoryList.swift) —
+  wrap `"History"`, `"No history yet."`, `"Delete"`.
+
+**Tests / verification**:
+- `HabitDetailView` preview (and archive-state variant), timer sheet
+  preview, history list preview — all visually identical.
+- `.xcstrings` gains these ~10 entries.
+
+**Commit message**: `chore(l10n): localize detail view, timer sheet, and history list`
+
+---
+
+### Task 6: Curate catalog — comments + plural variants
+
+**Goal**: turn the raw extracted catalog into something a translator
+can work with cold. This is the only task that edits `.xcstrings`
+directly (rather than via auto-extraction).
+
+**Changes**:
+- `Kado/Resources/Localizable.xcstrings`:
+  - Add a `comment` on every key describing where it appears and what
+    it means. Format: imperative, context-first, under ~80 chars.
+    Example for `"New habit"`: `"Toolbar button that opens the
+    new-habit sheet from Today view"`.
+  - Declare plural variants (`one` / `other`) for these 12 keys:
+    - `"%lld days per week"` (from `NewHabitFormView` and
+      `HabitDetailView`)
+    - `"Every %lld days"` (both views)
+    - `"%lld days ago"` (`CompletionHistoryList`)
+    - `"%lld min"` (`TimerLogSheet`, likely
+      `"%lld minute"` / `"%lld minutes"` in EN plural forms)
+    - `"Target: %lld"` (counter stepper)
+    - `"Target: %lld min"` (timer stepper)
+    - `"Counter · target %lld"` / `"Timer · target %lld min"` (habit
+      detail subtitle)
+    - `"%lld / best %lld"` (streak metric — needs per-arg plural
+      handling; document if not cleanly expressible)
+    - `"of %lld"` (counter quick-log)
+    - Accessibility: `"%@, counter, target %lld"`,
+      `"%@, timer, target %@"` (these mix `%@` and `%lld`; plural
+      applies only to `%lld`).
+  - For strings that appear identically in two views (e.g.
+    `"Every day"`, `"Yes / no"`), ensure they collapse to one catalog
+    entry and the comment covers both contexts.
+
+**Tests / verification**:
+- `build_sim` stays green.
+- Open the `.xcstrings` in Xcode, confirm the plural editor shows
+  `one` / `other` filled for EN.
+- `test_sim` stays green.
+
+**Commit message**: `chore(l10n): add translator comments and plural variants`
+
+---
+
+### Task 7: Manual pseudo-locale verification
+
+**Goal**: prove every visible string is in the catalog by running the
+app in the accented-pseudo-locale (`en_XA`) and eyeballing each view.
+
+**Changes**:
+- None to the project. This task is a verification gate.
+- Procedure:
+  1. `build_run_sim` with scheme arguments appended:
+     `-AppleLanguages (en-XA) -AppleLocale en_XA`. Confirm the MCP
+     tool path, or if unsupported, launch via Xcode's scheme editor
+     once.
+  2. Navigate Today (empty + loaded), open a habit, open the
+     edit form, open timer log sheet, swipe to delete a completion,
+     hit the archive confirmation, open Settings.
+  3. Every visible string should appear with accents (e.g.
+     `"T̂ôd̂áŷ"`). Any plain-ASCII string is **not** in the catalog —
+     treat as a bug, fix before closing.
+- Report back with a short list of any leaks found and a screenshot
+  confirmation of one or two views.
+
+**Tests / verification**: the pseudo-locale UI check is itself the
+test.
+
+**Commit message (if fixes found)**:
+`fix(l10n): catch strings missed by pseudo-locale verification`
+
+---
+
+### Task 8: Mark plan `done` and wrap up
+
+**Goal**: close out the PR for review.
+
+**Changes**:
+- Update `plan.md` status to `done`.
+- Flip the GitHub PR from draft to ready for review.
+- (Compound stage happens next, as its own conductor step.)
+
+**Commit message**: `docs(translations-catalog): mark plan done`
+
+## Risks and mitigation
+
+- **Xcode auto-extraction misses a string**: spotted by the Task 7
+  pseudo-locale pass. Mitigation: that task is the explicit gate.
+- **`.xcstrings` diff noise across commits**: Xcode reorders the JSON
+  occasionally. Mitigation: if it bites, pre-commit sort script.
+  Defer unless it actually makes reviews hard.
+- **`Tab.init` signature surprise**: research assumes `Tab("Today", ...)`
+  takes `String`, not `LocalizedStringKey`. Verify on Task 2 build;
+  if it accepts `LocalizedStringKey`, drop the `String(localized:)`
+  wrap and save one extraction step. No functional impact either way.
+- **Plural variant for multi-arg format strings** (`"%lld / best %lld"`):
+  `.xcstrings` plural handling is per-argument and can be awkward for
+  multi-`%lld` formats. Mitigation: if it doesn't express cleanly,
+  restructure the string (e.g. separate labels for current and best)
+  rather than fight the tooling. Decide when we hit it in Task 6.
+- **`en_XA` pseudo-locale launch argument flakiness under MCP**:
+  the `build_run_sim` wrapper may not expose custom launch args. If
+  so, launch once via Xcode's scheme editor and report back. Don't
+  block progress on MCP ergonomics.
+
+## Open questions
+
+None blocking. Deferred:
+- **Automated pseudo-locale test**: revisit during v1.0 pre-FR pass.
+- **`.xcstrings` stable-sort hook**: revisit if diffs become unreadable.
+
+## Out of scope
+
+- **FR translations** (v1.0).
+- **`String(format: "%02d:%02d", ...)` time formatters** in
+  `HabitRowView` and `CompletionHistoryList` — separate PR, pre-v1.0.
+- **`DateFormatter` style tuning** — formatters already localize via
+  `Locale.current`; nothing to do at catalog level.
+- **`NSUsageDescription` entries** — none exist yet; lands with
+  v0.2 HealthKit / widgets / notifications work.
+- **Generated Swift enum for keys** (SwiftGen-style) — rejected in
+  research; third-party dep is forbidden for v0.x.
+- **Compound stage** — handled as a separate conductor step after the
+  build tasks land.

--- a/docs/plans/2026-04/translations-catalog/plan.md
+++ b/docs/plans/2026-04/translations-catalog/plan.md
@@ -39,7 +39,7 @@ EN UI unchanged. The `Localizable.xcstrings` file grows on every
 normalization task (Xcode auto-extracts on build); commit it alongside
 its source change to keep diffs narrow.
 
-### Task 1: Weekday helpers + migrate consumers
+### Task 1: Weekday helpers + migrate consumers ✅
 
 **Goal**: add `Weekday.localizedShort: String` and
 `Weekday.localizedFull: String` so weekday labels have one source of
@@ -278,6 +278,17 @@ test.
 None blocking. Deferred:
 - **Automated pseudo-locale test**: revisit during v1.0 pre-FR pass.
 - **`.xcstrings` stable-sort hook**: revisit if diffs become unreadable.
+
+## Notes during build
+
+- **Task 1 pivot**: instead of hand-rolling 14 catalog entries for
+  weekday labels, the helpers now wrap
+  `Calendar.veryShortStandaloneWeekdaySymbols` and
+  `Calendar.standaloneWeekdaySymbols`. Strictly better: auto-localized
+  in every language Apple ships, removes the `"T"/"T"` and `"S"/"S"`
+  EN-collision problem entirely, and drops 14 keys from Task 6's
+  curation scope. Zero visible EN change (EN symbols match what we
+  were typing by hand).
 
 ## Out of scope
 

--- a/docs/plans/2026-04/translations-catalog/plan.md
+++ b/docs/plans/2026-04/translations-catalog/plan.md
@@ -142,7 +142,7 @@ conditional navigation title.
 
 ---
 
-### Task 5: Normalize HabitDetailView + TimerLogSheet + CompletionHistoryList
+### Task 5: Normalize HabitDetailView + TimerLogSheet + CompletionHistoryList ✅
 
 **Goal**: wrap the remaining raw literals in the detail surface
 (`"Archived"` badge, timer-sheet headers/footers/buttons, history

--- a/docs/plans/2026-04/translations-catalog/plan.md
+++ b/docs/plans/2026-04/translations-catalog/plan.md
@@ -2,7 +2,7 @@
 # Plan — Translations catalog for v0.1
 
 **Date**: 2026-04-17
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -212,7 +212,7 @@ directly (rather than via auto-extraction).
 
 ---
 
-### Task 7: Manual pseudo-locale verification
+### Task 7: Manual pseudo-locale verification ⚠️ (partial, deferred)
 
 **Goal**: prove every visible string is in the catalog by running the
 app in the accented-pseudo-locale (`en_XA`) and eyeballing each view.
@@ -241,7 +241,7 @@ test.
 
 ---
 
-### Task 8: Mark plan `done` and wrap up
+### Task 8: Mark plan `done` and wrap up ✅
 
 **Goal**: close out the PR for review.
 
@@ -294,6 +294,17 @@ None blocking. Deferred:
   `.navigationTitle(_:)` all accept `LocalizedStringKey` in iOS 18.
   Research flagged these as raw-literal leaks — they aren't. Source
   already correct; strings will surface in the catalog during Task 6.
+- **Task 7 deferral**: neither launch args
+  (`-AppleLanguages (en-XA) -AppleLocale en_XA`) nor simulator-wide
+  defaults produced accented-pseudo output — the catalog only has
+  an `"en"` localization, and iOS won't synthesize pseudo-locale
+  output at runtime without Xcode scheme's "Include double-length
+  pseudo-language" / "Use accented pseudo-language" option being
+  toggled. That option is not exposed via MCP. App does launch and
+  renders every visible string correctly against the hand-authored
+  catalog; runtime verification was scoped to the Today view. Full
+  accented-pseudo verification is deferred to the v1.0 pre-FR pass,
+  to be run from Xcode IDE with scheme option enabled.
 - **Catalog auto-population under xcodebuild**:
   `LOCALIZATION_PREFERS_STRING_CATALOGS=YES` and
   `SWIFT_EMIT_LOC_STRINGS=YES` are set, but `xcodebuild` (MCP) does

--- a/docs/plans/2026-04/translations-catalog/research.md
+++ b/docs/plans/2026-04/translations-catalog/research.md
@@ -1,0 +1,230 @@
+---
+# Research — Translations catalog for v0.1
+
+**Date**: 2026-04-17
+**Status**: ready for plan
+**Related**: `docs/ROADMAP.md` (v0.1 → "EN localization (FR arrives in
+v1.0, strings prepared now via String Catalog)"), `CLAUDE.md` →
+Localization section.
+
+## Problem
+
+Kadō's `Kado/Resources/Localizable.xcstrings` is present but empty.
+Meanwhile, the codebase has shipped five feature PRs (Today, New Habit,
+Habit Detail, Detail Quick Log, etc.) and accumulated a mix of:
+literals wrapped in `String(localized:)`, literals wrapped in plain
+`Text(...)` / `Button(...)` (which SwiftUI auto-localizes via
+`LocalizedStringKey`), and literals that bypass localization entirely
+(e.g. `"Today"` as a `Tab()` title, `"No habits yet"` in
+`ContentUnavailableView`). Interpolated strings like
+`"\(n) days per week"` are wrapped in `String(localized:)` but have no
+plural variants, so the eventual FR translator will hit grammar walls.
+
+v0.1 ships EN only. The goal of this workpackage is to **make the
+catalog complete, consistent, and translation-ready** so v1.0's FR
+pass becomes a translator's job, not an archaeology expedition.
+
+**"Done" from the user's perspective**: no visible change. Every
+string that exists today still reads the same in EN. Under the hood,
+the catalog lists every user-facing string, groups them sensibly,
+carries a comment explaining each, and declares plural variants where
+count-driven grammar will bite FR.
+
+## Current state of the codebase
+
+Inventoried with an Explore subagent. High-level counts (unique keys):
+
+- **~85–95 user-facing strings** across 10 views.
+- **~15–20 raw literals** that bypass `String(localized:)` (biggest
+  offenders: tab labels in [ContentView.swift:12](Kado/Views/ContentView.swift:12),
+  empty states in [TodayView.swift:45](Kado/Views/Today/TodayView.swift:45),
+  picker options in [NewHabitFormView.swift:50](Kado/Views/NewHabit/NewHabitFormView.swift:50),
+  `TimerLogSheet` buttons).
+- **~12 interpolated strings** that need plural variants
+  (e.g. `"\(n) days per week"`, `"\(days) days ago"`, `"\(minutes) min"`).
+- **Duplicate keys** across views (weekday abbreviations appear in
+  both [WeekdayPicker.swift:46–52](Kado/UIComponents/WeekdayPicker.swift)
+  and [MonthlyCalendarView.swift:82–88](Kado/Views/HabitDetail/MonthlyCalendarView.swift)).
+- **No `NSUsageDescription` strings** (no HealthKit / CloudKit /
+  biometrics permission prompts yet — lands in v0.2+).
+
+Nuance worth flagging:
+- Accessibility labels are wrapped (`String(localized:)`) in most
+  places — good. The Explore pass didn't surface any unwrapped
+  accessibility strings.
+- `Text(_ key: LocalizedStringKey)` and `Button(_ titleKey:)` already
+  go through the catalog automatically. Much of the "raw literal"
+  count is **already localized** — the `Text("Cancel")` in
+  `NewHabitFormView` feeds a `LocalizedStringKey`, same as
+  `String(localized:)`. The catalog just needs a populated key named
+  `"Cancel"`.
+- That said, `String(localized:)` vs bare string-literal-init
+  (`Tab("Today", ...)`, `ContentUnavailableView("No habits yet", ...)`)
+  behavior varies by API. Some are `String`-typed and won't localize
+  without explicit wrapping. This needs per-call-site verification,
+  not a blanket rule.
+
+## Proposed approach
+
+**Two passes, one catalog file, no runtime behavior change.**
+
+### Pass 1 — Normalize call sites
+
+Sweep every view and pick **one of two idioms** per string:
+- `Text("foo")` / `Button("foo")` / `Label("foo", systemImage: ...)`
+  where the SwiftUI initializer accepts `LocalizedStringKey`. This is
+  the cleanest form and auto-populates the catalog on build.
+- `String(localized: "foo", comment: "…")` for `String`-typed APIs
+  (`Tab(_:image:)` title, `TextField` placeholder, `navigationTitle`
+  when conditional, accessibility labels).
+
+Explicitly flag which APIs need which — the `Tab()` / `ContentUnavailableView`
+cases are where we currently leak.
+
+**Rule of thumb**: if Xcode's "Use Compiler to Extract Swift Strings"
+doesn't pick it up on next build, it's not localized.
+
+### Pass 2 — Populate the catalog
+
+1. Delete the empty catalog and rebuild so Xcode auto-extracts every
+   `LocalizedStringKey` and `String(localized:)` call into the
+   `.xcstrings` file. (Xcode 16 does this natively when
+   `LOCALIZATION_PREFERS_STRING_CATALOGS = YES`.)
+2. **Add translator comments** on every key. Comment format (short,
+   imperative, context-first): `"Toolbar button that opens the new-habit sheet"`,
+   `"Accessibility label announced when VoiceOver focuses the done toggle"`.
+3. **Declare plural variants** for the 12 interpolated keys. In
+   `.xcstrings` this is done via the "Vary by plural" UI; each entry
+   gets `one`/`other` buckets. EN rarely needs this (N=1 vs N=other),
+   but the structure must exist so the FR translator can write
+   `"un jour"` / `"deux jours"` without touching Swift.
+4. **De-duplicate**: weekday labels consolidated to one set of keys
+   (`"weekday.short.monday"`-style namespaced keys, or plain `"Mon"`
+   if we trust catalog de-duping — decision deferred to plan stage).
+5. Verify build is warning-free and `test_sim` still green.
+
+### Key components
+
+- **The catalog itself** (`Kado/Resources/Localizable.xcstrings`): the
+  sole source of truth. No secondary `.strings` file, no generated
+  Swift enum for keys (adds a dependency-like indirection we don't
+  need at v0.1 scale).
+- **SwiftUI views** (all 10 under `Kado/Views/`): normalized call
+  sites, no raw `String` literals on user-facing surfaces.
+- **`docs/plans/…/compound.md`** (produced at wrap-up): a short "how
+  we localize" note that replaces ad-hoc decisions with a team
+  (currently: solo) convention.
+
+### Data model changes
+
+None.
+
+### UI changes
+
+None visible. The output of every view must be byte-identical in EN
+before and after.
+
+### Tests to write
+
+Localization is notoriously under-tested because Xcode's build-time
+extraction catches most bugs. Proposed minimal suite:
+
+```swift
+@Test("Every user-facing view builds with a pseudo-locale without fatal errors")
+// Render each primary View with `.environment(\.locale, Locale(identifier: "en-XA"))`
+// (Xcode's accented-pseudo-locale) and ensure no runtime crash. This
+// surfaces missing keys as "[Missing]" placeholders rather than
+// silent fallbacks.
+```
+
+Alternatively skip tests — the extraction step is compile-time
+authoritative. **Open question below.**
+
+## Alternatives considered
+
+### Alternative A: Generated Swift enum for string keys
+
+Tools like SwiftGen emit `L10n.today.emptyTitle` constants. Removes
+typo risk, breaks on missing keys at compile time.
+
+- **Why not**: adds a code-gen step and a dev dependency. CLAUDE.md
+  forbids third-party deps for v0.x. Xcode 16's catalog already
+  auto-extracts and warns on unused keys. Reassess if the catalog
+  grows past ~300 keys or we ship multiple modules.
+
+### Alternative B: Defer the whole pass until v1.0
+
+Ship v0.1 as-is, fix everything when FR translation starts.
+
+- **Why not**: ROADMAP explicitly calls this out as v0.1 scope
+  ("strings prepared now via String Catalog"). The longer we wait,
+  the more debt accumulates — v0.2 adds widgets, notifications,
+  CSV/JSON import/export flows with tons of new strings and
+  `NSUsageDescription` entries. Doing this now while the surface is
+  ~90 strings is cheap; doing it at v1.0 with 300+ is not.
+
+### Alternative C: Also seed FR translations now
+
+Start FR in v0.1, even partial.
+
+- **Why not** (rejected on user call — scope (b)): translator quality
+  matters more than speed, and CLAUDE.md mandates native FR (not
+  machine-translated). Better to do one clean FR pass at v1.0 than
+  drip-feed and accumulate inconsistencies.
+
+## Risks and unknowns
+
+- **Catalog auto-extraction scope**: Xcode extracts from
+  `LocalizedStringKey` and `String(localized:)`, but not from
+  `String(...)` init with a variable. Any dynamic string (e.g.,
+  `habit.name` interpolated into an accessibility label) is exempt
+  from the catalog — only the **format string** gets extracted. Need
+  to verify each interpolated accessibility label in
+  [HabitRowView.swift:109](Kado/UIComponents/HabitRowView.swift:109)
+  has its literal shell (`"%@, counter, target %lld"`) extracted
+  cleanly, not the interpolated result.
+- **`.xcstrings` JSON diff noise**: the file format is a big JSON
+  blob. Every build rewrites key order occasionally. Pre-commit
+  hook or a stable-sort script might be needed if diffs become
+  unreadable. Defer unless it bites.
+- **DateFormatter/NumberFormatter usage**: these are locale-aware
+  already (they read `Locale.current`), so nothing to do at the
+  catalog level. But calls like `String(format: "%02d:%02d", ...)`
+  in [HabitRowView.swift:115–119](Kado/UIComponents/HabitRowView.swift:115)
+  are not — that's a distinct concern (RTL, Arabic numerals) deferred
+  to v1.0+.
+- **Swift 6 warnings**: enabling strict localization (the
+  `SWIFT_STRICT_CONCURRENCY`-adjacent `LOCALIZATION_EXPORT_SUPPORTED`
+  setting) may surface new warnings. Verify build stays green.
+
+## Resolved decisions
+
+- [x] **Testing**: manual for v0.1 (compile-time extraction +
+      `-AppleLocale en_XA` launch argument spot-check on each view).
+      Formalize a pseudo-locale smoke test in the v1.0 pre-FR pass,
+      when a regression would actually hurt.
+- [x] **Key naming**: **English text as the key**. This is the Xcode 16
+      default and what the catalog auto-extractor produces. If two
+      different English strings need distinct translations, use
+      `comment` to disambiguate; only fall back to namespaced keys
+      for that specific conflict.
+- [x] **Weekday labels consolidation**: extract
+      `Weekday.localizedShort` / `.localizedFull` helpers on the
+      `Weekday` enum. One source of truth, removes drift risk between
+      `WeekdayPicker` and `MonthlyCalendarView`.
+- [x] **Scope of the normalization pass**: the `String(format:)` time
+      formatter in `HabitRowView` / `CompletionHistoryList` is
+      **out-of-scope**. It's a formatter concern, not a catalog
+      concern. Flag as follow-up; handle with a DateComponentsFormatter
+      migration in a separate PR (likely pre-v1.0 alongside the FR
+      pass).
+
+## References
+
+- [Xcode 16 String Catalogs — Apple docs](https://developer.apple.com/documentation/xcode/localizing-and-varying-text-with-a-string-catalog)
+- [WWDC23 "Discover String Catalogs"](https://developer.apple.com/videos/play/wwdc2023/10155/)
+- CLAUDE.md → Localization ("Every user-facing string goes through
+  `String(localized:)`")
+- Prior `docs/plans/2026-04/` entries for surrounding context
+  (`today-view`, `new-habit-form`, `habit-detail-view`,
+  `detail-quick-log`).


### PR DESCRIPTION
## Why?

- `Kado/Resources/Localizable.xcstrings` was present but empty while five feature PRs had accumulated a mix of localized / partially-localized strings. ROADMAP v0.1: "EN localization (FR arrives in v1.0, strings prepared now via String Catalog)".
- Cheaper to do this at ~90 strings today than at v1.0 with 300+ — and ships two genuine localization bugs that would have bitten the FR translator.

## What?

- **Catalog**: 60+ hand-authored keys in `Localizable.xcstrings`, each with a translator comment. EN plural variants on three count-driven keys (`"%lld days per week"`, `"Every %lld days"`, `"%lld days ago"`).
- **Weekday consolidation**: new `Weekday.localizedShort` / `.localizedMedium` / `.localizedFull` backed by `Calendar.*StandaloneWeekdaySymbols`. `WeekdayPicker`, `MonthlyCalendarView`, and `HabitDetailView` migrate off their hand-rolled switches. Removes a latent `"T"/"T"` EN-collision bug (Tuesday/Thursday sharing one catalog entry).
- **Two bug fixes**:
  - `Text(model.isEditing ? "Edit Habit" : "New Habit")` in `NewHabitFormView` risked collapsing to the non-localizing `StringProtocol` overload — now `String(localized:)` per arm.
  - `HabitRowView.accessibilityLabelText` was building `"\(name), \(state)"` as a raw concat with no catalog entry — now wrapped.
- **Docs**: full conductor artifacts (research → plan → compound) under `docs/plans/2026-04/translations-catalog/`, plus three durable conventions lifted into `CLAUDE.md`.
- **No visible EN change.** All 106 tests remain green.

## How?

- Two-pass approach after research showed most call sites were already correct: (1) normalize remaining source — only two genuine fixes + weekday consolidation, (2) hand-author the catalog.
- Catalog is **hand-authored, not auto-extracted**: `xcodebuild` (via XcodeBuildMCP) doesn't sync `.xcstrings` during non-interactive builds — only Xcode IDE does. Xcode will merge future extractions with hand-authored entries rather than overwrite.
- Decisions locked in research: English text as catalog keys, weekday labels via `Weekday` enum, `String(format:)` time-formatter migration deferred to a separate pre-v1.0 PR.

## Next steps

- [ ] Full pseudo-locale sweep at v1.0 pre-FR (requires Xcode IDE scheme's "Include accented pseudo-language" option; not exposed via MCP)
- [ ] Follow-up PR pre-v1.0: migrate `String(format: "%02d:%02d", …)` time formatters in `HabitRowView` / `CompletionHistoryList` to `DateComponentsFormatter`
- [ ] Per-language plural review during FR pass (EN plurals may not cover e.g. Slavic 3-form grammars if those languages are added later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)