### PR TITLE
feat(dev-mode): in-app toggle that swaps SwiftData store with a seeded sandbox

### DIFF
--- a/.claude/skills/conductor/SKILL.md
+++ b/.claude/skills/conductor/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: conductor
-description: Guides feature development through a four-stage workflow — research, plan, build, compound — with Markdown artifacts generated at each stage. Use when the user asks to work on a new feature, investigate a problem, draft a plan, start an implementation, or wrap up a completed piece of work. Also triggers on explicit requests like "do some research on X", "let's plan Y", "build the Z feature", or "let's compound what we just did".
+description: Guides feature development through a five-stage workflow — research, plan, build, compound, done — with Markdown artifacts generated at each stage. Use when the user asks to work on a new feature, investigate a problem, draft a plan, start an implementation, wrap up a completed piece of work, or check whether a PR is ready to merge. Also triggers on explicit requests like "do some research on X", "let's plan Y", "build the Z feature", "let's compound what we just did", or "is this ready to merge".
 ---
 
 # Conductor — Feature Development Workflow
 
 Conductor is a lightweight workflow that structures feature development
-into four optional stages: **research → plan → build → compound**. Each
-stage produces a Markdown artifact stored under `docs/plans/`.
+into five optional stages: **research → plan → build → compound → done**.
+Each of the first four stages produces a Markdown artifact stored under
+`docs/plans/`; `done` is a pre-merge checklist with no artifact.
 
 ## Core principle: flexibility over imposition
 
@@ -33,6 +34,7 @@ charge. Concretely:
 | `plan` | Turn research into an ordered, concrete task list | `plan.md` |
 | `build` | Implement the plan, committing regularly | (code changes) |
 | `compound` | Capture decisions, surprises, lessons for the future | `compound.md` |
+| `done` | Pre-merge checklist: code ready, reviewed, docs current, compound run, PR title/body fresh | (no artifact) |
 
 Detailed instructions for each stage live in separate files to keep
 this overview short. Load them as needed:
@@ -41,6 +43,7 @@ this overview short. Load them as needed:
 - For planning: read `plan.md`
 - For implementation: read `build.md`
 - For wrap-up: read `compound.md`
+- For pre-merge checklist: read `done.md`
 
 ## Directory convention
 
@@ -93,10 +96,52 @@ The user may start a stage with phrasings like:
   first task"
 - **Compound**: "Let's wrap this up", "Capture what we learned",
   "Write the postmortem"
+- **Done**: "Is this ready to merge?", "Run done", "Let's wrap up and
+  merge"
 
 When a stage is invoked, load its instruction file and follow it. Don't
 try to do all stages in one go — each produces a checkpoint the user
 can review before moving on.
+
+## Asking the user questions
+
+Every stage involves points where you need a decision from the user —
+resolving open questions in `research`, confirming task order in
+`plan`, picking between two implementations in `build`, confirming
+pre-merge checks in `done`. **Use the `AskUserQuestion` tool for
+these prompts**, not free-form prose.
+
+Why:
+
+- The question UI renders as a structured picker the user can answer
+  with a click rather than typing.
+- Multiple related questions can be batched in one call instead of
+  chained round-trips.
+- Options force you to pre-think the answer space, which catches
+  sloppy binary framings ("yes/no") when a third option exists.
+
+When to reach for it:
+
+- **Any time you'd otherwise write "Should I X or Y?"** — that's an
+  `AskUserQuestion` call with two options.
+- Confirming a stage transition (research → plan, plan → build).
+- `done`'s first four checks — each is a clean yes/no confirmation
+  that belongs in the tool, not in a paragraph.
+- Resolving an open question carried forward from an earlier stage.
+
+When not to reach for it:
+
+- Pure acknowledgments ("Ok", "Go") where you're not actually asking
+  anything — just proceed.
+- Open-ended prompts with no enumerable answer space ("What should
+  we call this feature?") — free-form text is fine.
+- Mid-sentence confirmations that interrupt flow. Batch them up and
+  ask once at a checkpoint.
+
+Keep question titles short (≤12 chars), option labels ≤12 chars, and
+descriptions ≤25 chars so the UI renders cleanly. Always include an
+"Other" option with `multiSelect: false` unless you're certain the
+options are exhaustive.
 
 ## Open questions
 

--- a/.claude/skills/conductor/done.md
+++ b/.claude/skills/conductor/done.md
@@ -1,0 +1,159 @@
+# Conductor — Done stage
+
+The done stage is the final pre-merge checklist. It runs after
+`compound` (or after `build` if compound was skipped) and answers one
+question: **is this PR ready to be merged?**
+
+Unlike earlier stages, `done` produces no Markdown artifact. It's a
+structured sweep through everything that should be true before a
+merge, reporting gaps to the user.
+
+## What done is for
+
+- Catching the things that are easy to forget right before merge:
+  stale PR title, unchecked plan boxes, missing compound, no review.
+- Giving the user a single clear verdict: ready to merge, or here
+  are the N things blocking.
+
+## What done is not
+
+- A replacement for CI. It doesn't run tests. If the user wants a
+  green build, they can say so.
+- A gate. The user is still in charge; they may merge despite
+  warnings. Done surfaces the state, not a veto.
+
+## The five checks
+
+Run them in this order. **Default to auto-passing a check when the
+evidence is already in hand** — don't ask the user to re-confirm
+things you can see for yourself. Only escalate to an `AskUserQuestion`
+prompt when evidence is actually missing.
+
+Auto-pass rules:
+
+- **Check 1 (code ready)**: auto-pass if you're not aware of any
+  remaining temp code, TODOs, debug prints, or stubs in the diff. If
+  you planted scaffolding you haven't cleaned up, flag it — otherwise
+  assume ready.
+- **Check 2 (reviewed)**: auto-pass if `/review` ran earlier in this
+  session, or if the user has already responded to review feedback.
+  Only ask if there's no trace of review in the conversation.
+- **Check 3 (docs up to date)**: auto-pass if `plan.md` status is
+  `done`, all checkboxes are `[x]`, and no `## Open questions`
+  section remains unresolved. If any of these are off, flag the
+  specific gap.
+- **Check 4 (compound ran)**: auto-pass if `compound.md` exists and
+  is non-trivial (more than the bare template). If it's missing or a
+  stub, flag it.
+- **Check 5 (PR title/body fresh)**: **just fix it**. If the title or
+  description is stale, rewrite and apply via `gh pr edit` without
+  asking — the user can always amend afterward. Report what you
+  changed in the final verdict.
+
+Only fall back to `AskUserQuestion` when an auto-pass rule actually
+can't fire (e.g. no `/review` in session, no `compound.md`, plan
+still has open tasks). In that case, batch the remaining questions
+into a single tool call.
+
+### 1. Is the code ready to be shipped?
+
+Default: **auto-pass**. Assume the code is ready unless you have
+specific reason to doubt it — leftover scaffolding, a TODO you
+planted, a known-broken path, an unresolved test failure you saw
+earlier. If anything like that lingers, flag it specifically. Don't
+re-run `test_sim` / `build_sim` to "be sure" — the user already
+verified the feature.
+
+### 2. Has the PR been reviewed?
+
+Default: **auto-pass** if `/review` ran earlier in this session, or
+if the user has already iterated on review feedback. Only ask when
+there's no trace of review in the conversation — in that case,
+suggest running `/review` before proceeding.
+
+### 3. Are the conductor documents up to date?
+
+Read whichever of these exist for the feature:
+
+- `docs/plans/<YYYY-MM>/<feature-slug>/research.md`
+- `docs/plans/<YYYY-MM>/<feature-slug>/plan.md`
+
+Auto-pass if all of:
+- `plan.md` status line says `done`.
+- Every task checkbox in `plan.md` is `[x]` (or explicitly
+  skipped/deferred with an inline note).
+- No unresolved `## Open questions` section remains.
+
+If any of these are off, flag the specific gap and ask how to
+resolve it — don't silently edit the docs, since the user may have
+intentionally left a task open.
+
+### 4. Has the compound process run?
+
+Auto-pass if `docs/plans/<YYYY-MM>/<feature-slug>/compound.md` exists
+and is non-trivial. If it's missing or a stub, flag it and offer to
+run the `compound` stage. Don't write `compound.md` yourself here.
+
+### 5. Are the PR title and description up to date?
+
+This is the one check where the skill **should act** when drift
+is detected.
+
+1. Identify the PR: run `gh pr view --json number,title,body` for
+   the current branch.
+2. Compare the title to the commits on the branch (especially the
+   most recent `feat(...)` / `fix(...)` commit subjects). If the
+   title still reflects the initial research-stage scope but the
+   branch has shipped the full feature, the title is stale.
+3. Compare the body to the actual state of the work:
+   - Does **Why?** still match?
+   - Does **What?** list what actually shipped, not what was
+     proposed?
+   - Does **How?** link to the current `compound.md` (if it
+     exists) alongside `research.md` / `plan.md`?
+   - Is **Next steps** still listing resolved open questions as
+     if they were open?
+4. If drift is found, **just rewrite and apply** with
+   `gh pr edit <number> --title ... --body ...`. Don't ask for
+   approval first — the user can amend afterward. Show the new
+   title + body in the final verdict so the user knows what
+   changed.
+
+If the PR title and body already match the shipped state, say so
+explicitly — silence looks like failure to check.
+
+## Final verdict
+
+After all five checks, print a single clear verdict:
+
+- **Ready to merge** — all checks passed, no blockers.
+- **Ready with caveats** — passes but user chose to override one
+  or more warnings (e.g. "skip compound, merging anyway"). List
+  the accepted caveats.
+- **Not ready** — one or more blockers. List them as bullets, in
+  priority order.
+
+Keep the verdict to ~5 lines. The user should be able to read it
+and act without scrolling.
+
+## Invocation patterns
+
+The user may start this stage with:
+
+- "Is this ready to merge?"
+- "Run done"
+- "Let's wrap up and merge"
+- "/conductor done"
+
+## When to skip done
+
+For trivial PRs (typo fixes, doc-only changes), the done checklist
+is overkill. If the user says "just merge it" on a one-line PR,
+don't force the ceremony. For any PR that went through the full
+research → plan → build → compound loop, run done before merge.
+
+## No transition after done
+
+Done is terminal. After the user confirms the verdict and merges,
+the conductor loop for this feature is closed. The next feature
+starts fresh with a new `research` (or whichever stage fits).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,18 @@ argument to `DefaultCloudAccountStatusObserver.init`. Both the
 class and any constants it references (e.g. `CloudContainerID`)
 need `nonisolated`, otherwise the init evaluation site warns.
 
+The same rule also extends to **static properties and static
+functions on a `@MainActor` type that are used as default-argument
+expressions on that type's init**. Even when the init itself is
+MainActor-isolated, Swift evaluates the default expression in the
+caller's context and warns ("converting `@MainActor () -> T` to
+`() -> T` loses global actor 'MainActor'"). Mark such defaults
+`nonisolated static` when they don't touch MainActor state — e.g.
+`DevModeController.defaultDevStoreURL` and
+`DevModeController.defaultProductionContainer()` are both
+`nonisolated static` because `URL` math and `ModelContainer.init`
+don't need MainActor.
+
 ### Dates and calendars
 Day arithmetic always goes through `Calendar` — never raw seconds.
 `addingTimeInterval(86400)` silently breaks across DST boundaries
@@ -246,6 +258,23 @@ KadoUITests/                # UI tests (XCTest)
   ```
   Applied in `TimerLogSheet` so the env calendar drives today-
   completion prefill, matching the save path.
+- **`.onChange(of: X, initial: true)` is stateless** — the callback
+  fires on launch and on change with the same signature, so it
+  can't distinguish "launched with X already true" from "user just
+  set X to true." If those two paths need different behavior, use
+  edge-triggered `.onChange(of: X) { old, new in ... }` and handle
+  the at-launch case via lazy init keyed on the presence/absence
+  of the underlying state. `DevModeController.devContainer()` uses
+  a "seed if empty" check for this — launches with dev mode already
+  on read the existing sqlite as-is; off→on transitions wipe the
+  file so the next lazy build reseeds.
+- **Swapping `.modelContainer(_:)` at runtime propagates to `@Query`
+  in place** — no `.id(...)` remount is required. `@Query` re-fetches
+  from the new container on the same view identity, so navigation
+  state, selected tab, and scroll position are preserved. Adding
+  `.id(flag)` as a defensive swap-trigger (as the Dev mode work
+  initially did) quietly resets all of that. Trust the swap; don't
+  rebuild the tree unless you've reproduced a real staleness bug.
 
 ### SwiftData
 - One `@Model` per persistent type, explicit relationships with

--- a/Kado/App/DevModeController.swift
+++ b/Kado/App/DevModeController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Observation
 import SwiftData
 
 /// Owns the two `ModelContainer`s the app can run against: the
@@ -14,7 +13,6 @@ import SwiftData
 /// can exercise the lifecycle without touching CloudKit or the real
 /// Application Support directory.
 @MainActor
-@Observable
 final class DevModeController {
     private let devStoreURL: URL
     private let productionContainerFactory: () -> ModelContainer
@@ -93,11 +91,12 @@ final class DevModeController {
 
     private func deleteDevStoreFiles() {
         let fm = FileManager.default
-        let base = devStoreURL.deletingPathExtension().lastPathComponent
         let directory = devStoreURL.deletingLastPathComponent()
-        // SwiftData writes `<name>.sqlite`, `<name>.sqlite-shm`, `<name>.sqlite-wal`.
-        for suffix in ["sqlite", "sqlite-shm", "sqlite-wal"] {
-            let url = directory.appendingPathComponent("\(base).\(suffix)")
+        let base = devStoreURL.deletingPathExtension().lastPathComponent
+        let ext = devStoreURL.pathExtension
+        // SwiftData writes `<name>.<ext>`, `<name>.<ext>-shm`, `<name>.<ext>-wal`.
+        for suffix in ["", "-shm", "-wal"] {
+            let url = directory.appendingPathComponent("\(base).\(ext)\(suffix)")
             try? fm.removeItem(at: url)
         }
     }

--- a/Kado/App/DevModeController.swift
+++ b/Kado/App/DevModeController.swift
@@ -34,14 +34,13 @@ final class DevModeController {
         enabled ? devContainer() : productionContainer()
     }
 
-    /// Wipe any previous sandbox, build a fresh dev container, seed
-    /// it. Call this on every off→on transition.
+    /// Wipe any previous sandbox on disk. Call this on every off→on
+    /// transition. The fresh container is built lazily on next
+    /// `container(forDevMode: true)` and seeded because the file is
+    /// now absent.
     func activateDevMode() {
         cachedDevContainer = nil
         deleteDevStoreFiles()
-        let fresh = buildDevContainer()
-        DevModeSeed.seed(into: fresh.mainContext)
-        cachedDevContainer = fresh
     }
 
     /// Drop the dev container reference. The sandbox file is left on
@@ -60,8 +59,17 @@ final class DevModeController {
     private func devContainer() -> ModelContainer {
         if let cachedDevContainer { return cachedDevContainer }
         let container = buildDevContainer()
+        seedIfEmpty(container)
         cachedDevContainer = container
         return container
+    }
+
+    private func seedIfEmpty(_ container: ModelContainer) {
+        let context = container.mainContext
+        let count = (try? context.fetchCount(FetchDescriptor<HabitRecord>())) ?? 0
+        if count == 0 {
+            DevModeSeed.seed(into: context)
+        }
     }
 
     private func buildDevContainer() -> ModelContainer {

--- a/Kado/App/DevModeController.swift
+++ b/Kado/App/DevModeController.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Observation
+import SwiftData
+
+/// Owns the two `ModelContainer`s the app can run against: the
+/// production CloudKit-backed store and an on-disk dev sandbox.
+///
+/// The root view reads `container(forDevMode:)` and hands the result
+/// to `.modelContainer(...)`. Activating dev mode wipes the sandbox
+/// file and reseeds it; deactivating simply drops the dev container
+/// reference — the sandbox file stays on disk but is ignored.
+///
+/// The production factory and sandbox URL are injectable so tests
+/// can exercise the lifecycle without touching CloudKit or the real
+/// Application Support directory.
+@MainActor
+@Observable
+final class DevModeController {
+    private let devStoreURL: URL
+    private let productionContainerFactory: () -> ModelContainer
+
+    private var cachedProductionContainer: ModelContainer?
+    private var cachedDevContainer: ModelContainer?
+
+    init(
+        devStoreURL: URL = DevModeController.defaultDevStoreURL,
+        productionContainerFactory: @escaping () -> ModelContainer = DevModeController.defaultProductionContainer
+    ) {
+        self.devStoreURL = devStoreURL
+        self.productionContainerFactory = productionContainerFactory
+    }
+
+    func container(forDevMode enabled: Bool) -> ModelContainer {
+        enabled ? devContainer() : productionContainer()
+    }
+
+    /// Wipe any previous sandbox, build a fresh dev container, seed
+    /// it. Call this on every off→on transition.
+    func activateDevMode() {
+        cachedDevContainer = nil
+        deleteDevStoreFiles()
+        let fresh = buildDevContainer()
+        DevModeSeed.seed(into: fresh.mainContext)
+        cachedDevContainer = fresh
+    }
+
+    /// Drop the dev container reference. The sandbox file is left on
+    /// disk (it will be wiped on the next `activateDevMode()`).
+    func deactivateDevMode() {
+        cachedDevContainer = nil
+    }
+
+    private func productionContainer() -> ModelContainer {
+        if let cachedProductionContainer { return cachedProductionContainer }
+        let container = productionContainerFactory()
+        cachedProductionContainer = container
+        return container
+    }
+
+    private func devContainer() -> ModelContainer {
+        if let cachedDevContainer { return cachedDevContainer }
+        let container = buildDevContainer()
+        cachedDevContainer = container
+        return container
+    }
+
+    private func buildDevContainer() -> ModelContainer {
+        ensureParentDirectoryExists(for: devStoreURL)
+        do {
+            let schema = Schema(versionedSchema: KadoSchemaV1.self)
+            let configuration = ModelConfiguration(
+                schema: schema,
+                url: devStoreURL,
+                cloudKitDatabase: .none
+            )
+            return try ModelContainer(
+                for: schema,
+                migrationPlan: KadoMigrationPlan.self,
+                configurations: configuration
+            )
+        } catch {
+            fatalError("Failed to construct dev ModelContainer: \(error)")
+        }
+    }
+
+    private func deleteDevStoreFiles() {
+        let fm = FileManager.default
+        let base = devStoreURL.deletingPathExtension().lastPathComponent
+        let directory = devStoreURL.deletingLastPathComponent()
+        // SwiftData writes `<name>.sqlite`, `<name>.sqlite-shm`, `<name>.sqlite-wal`.
+        for suffix in ["sqlite", "sqlite-shm", "sqlite-wal"] {
+            let url = directory.appendingPathComponent("\(base).\(suffix)")
+            try? fm.removeItem(at: url)
+        }
+    }
+
+    private func ensureParentDirectoryExists(for url: URL) {
+        let directory = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    nonisolated static let defaultDevStoreURL: URL = {
+        URL.applicationSupportDirectory.appendingPathComponent("KadoDev.sqlite")
+    }()
+
+    nonisolated static func defaultProductionContainer() -> ModelContainer {
+        do {
+            let schema = Schema(versionedSchema: KadoSchemaV1.self)
+            return try ModelContainer(
+                for: schema,
+                migrationPlan: KadoMigrationPlan.self,
+                configurations: ModelConfiguration(
+                    schema: schema,
+                    cloudKitDatabase: .private(CloudContainerID.kado)
+                )
+            )
+        } catch {
+            fatalError("Failed to construct production ModelContainer: \(error)")
+        }
+    }
+}

--- a/Kado/App/DevModeDefaults.swift
+++ b/Kado/App/DevModeDefaults.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Single source of truth for the `UserDefaults` keys that gate the
+/// in-app dev mode. Kept in one place so the flag and the "has
+/// confirmed the consequences" marker can never drift between the
+/// root view, the Settings section, and the sync-status section.
+nonisolated enum DevModeDefaults {
+    static let key = "kado.devMode"
+    static let hasConfirmedKey = "kado.devMode.hasConfirmed"
+}

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -3,30 +3,25 @@ import SwiftUI
 
 @main
 struct KadoApp: App {
-    let container: ModelContainer = {
-        do {
-            let schema = Schema(versionedSchema: KadoSchemaV1.self)
-            return try ModelContainer(
-                for: schema,
-                migrationPlan: KadoMigrationPlan.self,
-                configurations: ModelConfiguration(
-                    schema: schema,
-                    cloudKitDatabase: .private(CloudContainerID.kado)
-                )
-            )
-        } catch {
-            fatalError("Failed to construct ModelContainer: \(error)")
-        }
-    }()
+    @AppStorage("kado.devMode") private var isDevMode = false
 
+    @State private var devModeController = DevModeController()
     @State private var cloudAccountStatus = DefaultCloudAccountStatusObserver()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .task { await cloudAccountStatus.refresh() }
+                .id(isDevMode)
         }
-        .modelContainer(container)
+        .modelContainer(devModeController.container(forDevMode: isDevMode))
         .environment(\.cloudAccountStatus, cloudAccountStatus)
+        .onChange(of: isDevMode) { oldValue, newValue in
+            if newValue && !oldValue {
+                devModeController.activateDevMode()
+            } else if !newValue && oldValue {
+                devModeController.deactivateDevMode()
+            }
+        }
     }
 }

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 @main
 struct KadoApp: App {
-    @AppStorage("kado.devMode") private var isDevMode = false
+    @AppStorage(DevModeDefaults.key) private var isDevMode = false
 
     @State private var devModeController = DevModeController()
     @State private var cloudAccountStatus = DefaultCloudAccountStatusObserver()

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -12,7 +12,6 @@ struct KadoApp: App {
         WindowGroup {
             ContentView()
                 .task { await cloudAccountStatus.refresh() }
-                .id(isDevMode)
         }
         .modelContainer(devModeController.container(forDevMode: isDevMode))
         .environment(\.cloudAccountStatus, cloudAccountStatus)

--- a/Kado/Preview Content/PreviewContainer.swift
+++ b/Kado/Preview Content/PreviewContainer.swift
@@ -14,7 +14,7 @@ enum PreviewContainer {
                 for: HabitRecord.self, CompletionRecord.self,
                 configurations: ModelConfiguration(isStoredInMemoryOnly: true)
             )
-            seed(container.mainContext)
+            DevModeSeed.seed(into: container.mainContext)
             return container
         } catch {
             fatalError("Failed to construct preview ModelContainer: \(error)")
@@ -59,57 +59,4 @@ enum PreviewContainer {
         }
     }
 
-    static func seed(_ context: ModelContext) {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: .now)
-
-        let habits: [HabitRecord] = [
-            HabitRecord(
-                name: "Morning meditation",
-                frequency: .daily,
-                type: .binary,
-                createdAt: calendar.date(byAdding: .day, value: -45, to: today)!
-            ),
-            HabitRecord(
-                name: "Gym",
-                frequency: .specificDays([.monday, .wednesday, .friday]),
-                type: .binary,
-                createdAt: calendar.date(byAdding: .day, value: -60, to: today)!
-            ),
-            HabitRecord(
-                name: "Drink water",
-                frequency: .daily,
-                type: .counter(target: 8),
-                createdAt: calendar.date(byAdding: .day, value: -30, to: today)!
-            ),
-            HabitRecord(
-                name: "Read",
-                frequency: .daily,
-                type: .timer(targetSeconds: 1800),
-                createdAt: calendar.date(byAdding: .day, value: -20, to: today)!
-            ),
-            HabitRecord(
-                name: "No social media",
-                frequency: .daily,
-                type: .negative,
-                createdAt: calendar.date(byAdding: .day, value: -14, to: today)!
-            ),
-        ]
-
-        for habit in habits {
-            context.insert(habit)
-            for daysAgo in stride(from: 1, through: 14, by: 2) {
-                let date = calendar.date(byAdding: .day, value: -daysAgo, to: today)!
-                let value: Double = switch habit.type {
-                case .counter: 6
-                case .timer: 1500
-                default: 1
-                }
-                let completion = CompletionRecord(date: date, value: value, habit: habit)
-                context.insert(completion)
-            }
-        }
-
-        try? context.save()
-    }
 }

--- a/Kado/Services/DevModeSeed.swift
+++ b/Kado/Services/DevModeSeed.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftData
+
+/// Seeds a `ModelContext` with a realistic demo dataset covering each
+/// `Frequency` and `HabitType` variant, plus ~14 days of historical
+/// completions. Used by the in-app dev mode sandbox and by SwiftUI
+/// previews.
+@MainActor
+enum DevModeSeed {
+    static func seed(into context: ModelContext, calendar: Calendar = .current) {
+        let today = calendar.startOfDay(for: .now)
+
+        let habits: [HabitRecord] = [
+            HabitRecord(
+                name: "Morning meditation",
+                frequency: .daily,
+                type: .binary,
+                createdAt: calendar.date(byAdding: .day, value: -45, to: today)!
+            ),
+            HabitRecord(
+                name: "Gym",
+                frequency: .specificDays([.monday, .wednesday, .friday]),
+                type: .binary,
+                createdAt: calendar.date(byAdding: .day, value: -60, to: today)!
+            ),
+            HabitRecord(
+                name: "Drink water",
+                frequency: .daily,
+                type: .counter(target: 8),
+                createdAt: calendar.date(byAdding: .day, value: -30, to: today)!
+            ),
+            HabitRecord(
+                name: "Read",
+                frequency: .daily,
+                type: .timer(targetSeconds: 1800),
+                createdAt: calendar.date(byAdding: .day, value: -20, to: today)!
+            ),
+            HabitRecord(
+                name: "No social media",
+                frequency: .daily,
+                type: .negative,
+                createdAt: calendar.date(byAdding: .day, value: -14, to: today)!
+            ),
+        ]
+
+        for habit in habits {
+            context.insert(habit)
+            for daysAgo in stride(from: 1, through: 14, by: 2) {
+                let date = calendar.date(byAdding: .day, value: -daysAgo, to: today)!
+                let value: Double = switch habit.type {
+                case .counter: 6
+                case .timer: 1500
+                default: 1
+                }
+                let completion = CompletionRecord(date: date, value: value, habit: habit)
+                context.insert(completion)
+            }
+        }
+
+        try? context.save()
+    }
+}

--- a/Kado/Views/Settings/DevModeSection.swift
+++ b/Kado/Views/Settings/DevModeSection.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// Settings section for the in-app dev mode toggle.
+///
+/// Flipping the toggle on replaces the active SwiftData store with a
+/// seeded demo sandbox (see `DevModeController`). Flipping it off
+/// restores the real data. The real store is never touched — turning
+/// dev mode back on wipes and reseeds the sandbox.
+struct DevModeSection: View {
+    @AppStorage("kado.devMode") private var isDevMode = false
+
+    var body: some View {
+        Section {
+            Toggle(isOn: $isDevMode) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Dev mode")
+                        .font(.body)
+                    Text("Use a demo dataset instead of your own data.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .accessibilityHint(Text("Replaces your data with a demo dataset. Your real data is safe and returns when you turn this off."))
+        } header: {
+            Text("Developer")
+        } footer: {
+            Text("Replaces your data with a demo dataset. Your real data is safe and returns when you turn this off. Edits made while dev mode is on are discarded the next time you turn it on.")
+        }
+    }
+}
+
+#Preview("Off") {
+    NavigationStack {
+        Form { DevModeSection() }
+            .navigationTitle("Settings")
+    }
+}

--- a/Kado/Views/Settings/DevModeSection.swift
+++ b/Kado/Views/Settings/DevModeSection.swift
@@ -6,8 +6,14 @@ import SwiftUI
 /// seeded demo sandbox (see `DevModeController`). Flipping it off
 /// restores the real data. The real store is never touched — turning
 /// dev mode back on wipes and reseeds the sandbox.
+///
+/// The very first activation shows a confirmation alert so a user who
+/// flips the toggle by accident doesn't see their habits disappear
+/// without warning. Subsequent activations skip the alert.
 struct DevModeSection: View {
-    @AppStorage("kado.devMode") private var isDevMode = false
+    @AppStorage(DevModeDefaults.key) private var isDevMode = false
+    @AppStorage(DevModeDefaults.hasConfirmedKey) private var hasConfirmed = false
+    @State private var showingConfirmation = false
 
     var body: some View {
         Section {
@@ -21,11 +27,26 @@ struct DevModeSection: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .accessibilityHint(Text("Replaces your data with a demo dataset. Your real data is safe and returns when you turn this off."))
+            .onChange(of: isDevMode) { oldValue, newValue in
+                // Intercept the first on-flip: revert, prompt, re-flip on confirm.
+                if newValue && !oldValue && !hasConfirmed {
+                    isDevMode = false
+                    showingConfirmation = true
+                }
+            }
         } header: {
             Text("Developer")
         } footer: {
             Text("Replaces your data with a demo dataset. Your real data is safe and returns when you turn this off. Edits made while dev mode is on are discarded the next time you turn it on.")
+        }
+        .alert("Enable dev mode?", isPresented: $showingConfirmation) {
+            Button("Cancel", role: .cancel) { }
+            Button("Enable", role: .destructive) {
+                hasConfirmed = true
+                isDevMode = true
+            }
+        } message: {
+            Text("Your habits will be replaced by a demo dataset while dev mode is on. Your real habits are safe and will return as soon as you turn it off.")
         }
     }
 }

--- a/Kado/Views/Settings/SettingsView.swift
+++ b/Kado/Views/Settings/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
         NavigationStack {
             Form {
                 SyncStatusSection()
+                DevModeSection()
             }
             .navigationTitle("Settings")
         }

--- a/Kado/Views/Settings/SyncStatusSection.swift
+++ b/Kado/Views/Settings/SyncStatusSection.swift
@@ -9,20 +9,46 @@ import UIKit
 struct SyncStatusSection: View {
     @Environment(\.cloudAccountStatus) private var observer
     @Environment(\.openURL) private var openURL
+    @AppStorage("kado.devMode") private var isDevMode = false
 
     var body: some View {
         Section("iCloud") {
-            row(for: observer.status)
-            if showsSettingsLink(for: observer.status) {
-                Button {
-                    if let url = URL(string: UIApplication.openSettingsURLString) {
-                        openURL(url)
+            if isDevMode {
+                devModePausedRow
+            } else {
+                row(for: observer.status)
+                if showsSettingsLink(for: observer.status) {
+                    Button {
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            openURL(url)
+                        }
+                    } label: {
+                        Label("Open Settings", systemImage: "arrow.up.right.square")
                     }
-                } label: {
-                    Label("Open Settings", systemImage: "arrow.up.right.square")
                 }
             }
         }
+    }
+
+    private var devModePausedRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "pause.circle.fill")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+                .frame(width: 28)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Sync paused while dev mode is on")
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                Text("Your real habits are safe in iCloud. Turn dev mode off to resume syncing.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder

--- a/Kado/Views/Settings/SyncStatusSection.swift
+++ b/Kado/Views/Settings/SyncStatusSection.swift
@@ -9,7 +9,7 @@ import UIKit
 struct SyncStatusSection: View {
     @Environment(\.cloudAccountStatus) private var observer
     @Environment(\.openURL) private var openURL
-    @AppStorage("kado.devMode") private var isDevMode = false
+    @AppStorage(DevModeDefaults.key) private var isDevMode = false
 
     var body: some View {
         Section("iCloud") {

--- a/KadoTests/DevModeControllerTests.swift
+++ b/KadoTests/DevModeControllerTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Kado
+
+@Suite("DevModeController")
+@MainActor
+struct DevModeControllerTests {
+    private func makeController() throws -> (DevModeController, URL) {
+        let tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("DevModeControllerTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let storeURL = tempDir.appendingPathComponent("KadoDev.sqlite")
+
+        let factory: () -> ModelContainer = {
+            let schema = Schema(versionedSchema: KadoSchemaV1.self)
+            return try! ModelContainer(
+                for: schema,
+                migrationPlan: KadoMigrationPlan.self,
+                configurations: ModelConfiguration(
+                    schema: schema,
+                    isStoredInMemoryOnly: true
+                )
+            )
+        }
+
+        let controller = DevModeController(
+            devStoreURL: storeURL,
+            productionContainerFactory: factory
+        )
+        return (controller, tempDir)
+    }
+
+    @Test("activateDevMode seeds at least one habit of each HabitType")
+    func activateSeedsAllTypes() throws {
+        let (controller, tempDir) = try makeController()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        controller.activateDevMode()
+        let container = controller.container(forDevMode: true)
+        let habits = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
+        let types = Set(habits.map(\.type))
+
+        #expect(types.contains(.binary))
+        #expect(types.contains(.negative))
+        #expect(types.contains { if case .counter = $0 { return true } else { return false } })
+        #expect(types.contains { if case .timer = $0 { return true } else { return false } })
+    }
+
+    @Test("Off then on wipes sandbox edits")
+    func offOnWipesEdits() throws {
+        let (controller, tempDir) = try makeController()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        controller.activateDevMode()
+        let firstContainer = controller.container(forDevMode: true)
+        let sentinelName = "Sentinel-\(UUID().uuidString)"
+        firstContainer.mainContext.insert(
+            HabitRecord(name: sentinelName, frequency: .daily, type: .binary)
+        )
+        try firstContainer.mainContext.save()
+
+        controller.deactivateDevMode()
+        controller.activateDevMode()
+
+        let secondContainer = controller.container(forDevMode: true)
+        let habits = try secondContainer.mainContext.fetch(FetchDescriptor<HabitRecord>())
+        #expect(!habits.contains(where: { $0.name == sentinelName }))
+        #expect(!habits.isEmpty, "Reseed should repopulate the sandbox")
+    }
+
+    @Test("Production container is returned when dev mode is off")
+    func productionWhenOff() throws {
+        let (controller, tempDir) = try makeController()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let prod = controller.container(forDevMode: false)
+        let prodAgain = controller.container(forDevMode: false)
+        #expect(prod === prodAgain, "Production container should be cached")
+    }
+}

--- a/KadoTests/DevModeControllerTests.swift
+++ b/KadoTests/DevModeControllerTests.swift
@@ -69,6 +69,20 @@ struct DevModeControllerTests {
         #expect(!habits.isEmpty, "Reseed should repopulate the sandbox")
     }
 
+    @Test("Off then on returns a new dev container instance")
+    func offOnReturnsNewContainer() throws {
+        let (controller, tempDir) = try makeController()
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        controller.activateDevMode()
+        let before = controller.container(forDevMode: true)
+        controller.deactivateDevMode()
+        controller.activateDevMode()
+        let after = controller.container(forDevMode: true)
+
+        #expect(before !== after, "Container identity must change so .modelContainer(_:) sees a swap")
+    }
+
     @Test("Production container is returned when dev mode is off")
     func productionWhenOff() throws {
         let (controller, tempDir) = try makeController()

--- a/KadoTests/PreviewContainerTests.swift
+++ b/KadoTests/PreviewContainerTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import SwiftData
 @testable import Kado
 
-@Suite("PreviewContainer seeding")
+@Suite("DevModeSeed seeding")
 @MainActor
 struct PreviewContainerTests {
     @Test("Seeds five habits covering each frequency and type")
@@ -12,7 +12,7 @@ struct PreviewContainerTests {
             for: HabitRecord.self, CompletionRecord.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
-        PreviewContainer.seed(container.mainContext)
+        DevModeSeed.seed(into: container.mainContext)
 
         let habits = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
         #expect(habits.count == 5)

--- a/docs/plans/2026-04/dev-mode/compound.md
+++ b/docs/plans/2026-04/dev-mode/compound.md
@@ -1,0 +1,170 @@
+# Compound — Dev Mode
+
+**Date**: 2026-04-17
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: `feature/dev-mode` — https://github.com/scastiel/kado/pull/11
+
+## Summary
+
+Shipped an in-app **Dev mode** Settings toggle that swaps the live
+SwiftData store for an on-disk sandbox seeded with demo data. Real
+data is never touched: prod and dev are two distinct `ModelContainer`s
+owned by a `DevModeController`. Headline lesson: the simplest swap
+pattern (build two containers, bind `@AppStorage` to `.modelContainer`,
+let `@Query` re-fetch) works out of the box — no `.id(...)` remount
+hack needed, and the safety net you reach for up front can quietly
+degrade UX.
+
+## Decisions made
+
+- **Two `ModelContainer`s, never delete real data**: prod (CloudKit)
+  and dev (on-disk, no CloudKit) coexist; the swap happens at the
+  `.modelContainer(...)` call site. Container B in Alternative A
+  ("stash and restore") was rejected as too risky — a mid-swap crash
+  could sync deletions to CloudKit.
+- **Ship in Release, not Debug-only**: activation is a runtime
+  toggle, not a build flag, so the user can flip it on a shipped
+  build for demos/testing without installing a dev build.
+- **On-disk sandbox, not in-memory**: edits survive app launches
+  while dev mode stays on. `Application Support/KadoDev.sqlite`.
+- **Off→on wipes and reseeds**: no separate "Reseed" button — the
+  existing toggle doubles as the reset gesture.
+- **`@AppStorage("kado.devMode")` for the flag**: UserDefaults,
+  not `NSUbiquitousKeyValueStore`, so the flag does not sync to
+  iCloud. Default `false`.
+- **Seed extraction**: `PreviewContainer.seed` moved into
+  `Services/DevModeSeed.swift` so it's compiled into Release.
+  Preview helpers in `Preview Content/` still call it.
+- **Sync status reflects dev mode**: `SyncStatusSection` shows a
+  "Sync paused while dev mode is on" row so the Settings screen
+  isn't self-contradictory when the sandbox is active.
+
+## Surprises and how we handled them
+
+### `onChange(..., initial: true)` broke the persistence contract
+
+- **What happened**: the first wiring of the toggle used
+  `.onChange(of: isDevMode, initial: true)`, which called
+  `activateDevMode()` on every cold launch. That wiped the sandbox
+  file and reseeded, breaking the "edits persist across launches
+  while dev mode stays on" promise.
+- **What we did**: switched to edge-triggered `onChange` (explicit
+  old/new comparison for the off→on transition) and pushed
+  "seed if the habit table is empty" into `DevModeController.
+  devContainer()`. Result: launches with the flag already on read
+  the existing sqlite file as-is; first-ever activation or a
+  wipe-and-rebuild still seeds.
+- **Lesson**: `initial: true` on `onChange` is a convenient way to
+  fire setup code, but it's stateless — the callback can't tell
+  "app just launched with X already true" from "user just flipped
+  X to true." If the two paths need different behavior, don't use
+  `initial: true`.
+
+### The `.id(isDevMode)` safety net wasn't safe
+
+- **What happened**: the research flagged a risk that changing the
+  container passed to `.modelContainer(...)` might not re-fetch
+  `@Query`, and suggested `.id(isDevMode)` on the root view as a
+  fallback. We pre-emptively added it, and the trade-off showed
+  up in user testing — flipping the toggle reset the selected tab
+  and any in-flight navigation stack.
+- **What we did**: removed the `.id`. SwiftUI propagates the new
+  container to `@Query` automatically; data refreshes in place,
+  navigation state is preserved.
+- **Lesson**: a "defensive" modifier you add without testing the
+  unforced path first costs real UX. When you suspect a framework
+  might not do the right thing, try without the workaround and
+  measure; don't ship the workaround speculatively.
+
+### MainActor defaults on a `@MainActor @Observable` init
+
+- **What happened**: `DevModeController.defaultDevStoreURL` and
+  `defaultProductionContainer()` were initially plain `static`s on
+  the MainActor-isolated class. Swift 6 warned that evaluating
+  them as default-argument expressions (at a caller that might be
+  nonisolated) converts a `@MainActor () -> ModelContainer` to
+  `() -> ModelContainer` and loses isolation.
+- **What we did**: marked both `nonisolated static`. Neither touches
+  MainActor state (URL arithmetic + `ModelContainer.init` are both
+  fine off-actor), so the isolation drop was safe.
+- **Lesson**: `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` already
+  bit us with `CloudContainerID` and `DefaultCKAccountStatusProvider`.
+  Static defaults used as default arguments on MainActor types need
+  `nonisolated` — add this to the existing note in `CLAUDE.md`.
+
+## What worked well
+
+- **Injecting container factory + URL into `DevModeController`**
+  kept tests honest: the controller is exercised end-to-end without
+  constructing a real CloudKit container or writing into the app's
+  real Application Support.
+- **Seed function was already a single entry point**. Moving it
+  from Preview Content to Services was a two-line change — no
+  rewrite, no duplication.
+- **Plan's staged decomposition** (extract → controller → wire →
+  toggle → verify) meant each commit left the app in a working
+  state, including the tests.
+- **`seed-if-empty` is a clean invariant**. Both the cold-launch
+  path and the off→on wipe path end up in the same "empty
+  container" state, so one branch covers both.
+
+## For the next person
+
+- **Real data is untouched.** The toggle never writes to the prod
+  container. If you see something odd about the prod store while
+  working on dev mode, look elsewhere — dev mode cannot corrupt it.
+- **`KadoDev.sqlite` is intentionally left on disk when dev mode
+  is turned off.** That's not a leak; it's cached state so the
+  user's in-progress dev session survives app launches. Wiping
+  happens on the next off→on transition.
+- **Don't add `.id(isDevMode)` back** unless you've confirmed the
+  container swap stopped propagating to `@Query`. It's the kind of
+  modifier that looks harmless but eats navigation state.
+- **Prod container is still cached.** `DevModeController` holds it
+  for the app's lifetime. If you later add a "reset real data"
+  path, drop that cache too.
+- **`@AppStorage("kado.devMode")` is read in two places**: `KadoApp`
+  (to pick the container) and `SyncStatusSection` (to show the
+  paused row). Keep them in sync if the key changes.
+- **When `KadoSchemaV2` ships**, both containers pick it up
+  automatically via `KadoMigrationPlan`. The dev sandbox will be
+  migrated on first access; if migration ever gets messy, the
+  user can always toggle off/on to reseed.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** Don't use `.onChange(of: X, initial: true)` for
+  setup that should distinguish "launch with X=true" from "user
+  just set X=true." The callback is stateless; use
+  edge-triggered `onChange` and handle the at-launch case
+  elsewhere (e.g. lazy init keyed on presence/absence of state).
+- **[→ CLAUDE.md]** Swapping `.modelContainer(_:)` at runtime does
+  propagate to `@Query` in place — no `.id(...)` remount required.
+  Adding `.id` as a defensive swap-trigger resets navigation state
+  and is usually wrong.
+- **[→ CLAUDE.md]** Static defaults evaluated as default arguments
+  on a `@MainActor`-isolated type must be `nonisolated static`
+  under `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`. Extends the
+  existing `CloudContainerID` / `DefaultCKAccountStatusProvider`
+  note.
+- **[local]** When a feature shows a status ("Synced"), check
+  whether a sibling toggle/mode can contradict it, and reconcile
+  in the UI (the "paused" row).
+
+## Metrics
+
+- Tasks completed: 5 of 5
+- Tests added: 3 (in `DevModeControllerTests`)
+- Commits on branch: 8 (3 docs + 5 code)
+- Files touched: ~7
+
+## References
+
+- `Kado/App/DevModeController.swift` — the state machine.
+- `Kado/Services/DevModeSeed.swift` — the seed used by both the
+  sandbox and SwiftUI previews.
+- `Kado/App/KadoApp.swift` — the `@AppStorage` → `.modelContainer`
+  wiring.
+- Apple: [SwiftData `ModelConfiguration`](https://developer.apple.com/documentation/swiftdata/modelconfiguration).

--- a/docs/plans/2026-04/dev-mode/plan.md
+++ b/docs/plans/2026-04/dev-mode/plan.md
@@ -1,7 +1,7 @@
 # Plan — Dev Mode
 
 **Date**: 2026-04-17
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -174,6 +174,25 @@ the dev-mode flag.
 
 None blocking. Will revisit toggle copy during Task 4 based on how
 it reads in-app.
+
+## Notes during build
+
+- **Task 3**: initial sketch used `.onChange(of: isDevMode, initial: true)`
+  to drive activation, which wiped the sandbox on every cold launch
+  and broke the "edits persist across launches while dev mode stays
+  on" contract. Switched to edge-triggered `onChange` (off→on wipes
+  and reseeds; on→off drops the reference) and pushed the
+  "seed-if-empty" check into `DevModeController.devContainer()` so
+  first-time access seeds on demand.
+- **Post-build polish**: initial root used `.id(isDevMode)` on
+  `ContentView` as a safety net to force a remount on swap. Turned
+  out unnecessary — `.modelContainer(_:)` propagates the new
+  container and `@Query` re-fetches in place — and it had a real
+  cost (reset the selected tab/navigation stack). Removed the `.id`.
+- **Sync status row**: added a `"Sync paused while dev mode is on"`
+  state to `SyncStatusSection` (reads the same `@AppStorage` key) so
+  the iCloud section doesn't misleadingly advertise syncing while
+  the sandbox store is active.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/dev-mode/plan.md
+++ b/docs/plans/2026-04/dev-mode/plan.md
@@ -1,0 +1,185 @@
+# Plan — Dev Mode
+
+**Date**: 2026-04-17
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Add a user-facing Settings toggle that swaps the app's SwiftData
+store between the production CloudKit-backed container and an
+on-disk sandbox container seeded with a demo dataset. Real data is
+never touched. Shipped in Release. Dev mode off→on wipes and reseeds
+the sandbox; turning it off preserves the sandbox file but returns
+to real data.
+
+## Decisions locked in
+
+- Two `ModelContainer`s: production (CloudKit, current behavior) and
+  dev (on-disk at a dedicated URL, no CloudKit).
+- Dev container uses the same `KadoSchemaV1` / `KadoMigrationPlan`.
+- Dev mode flag stored as `@AppStorage("kado.devMode")` (UserDefaults,
+  not synced to iCloud). Default `false`.
+- Seed function moves out of `Preview Content/` into a Release-
+  compilable source location. Preview helpers (`PreviewContainer.shared`,
+  `emptyContainer`, etc.) stay in `Preview Content/` and call the
+  relocated seed.
+- Seed scope: ~14 days of history, one habit per `HabitType` variant,
+  mixed `Frequency` coverage (essentially today's `PreviewContainer.seed`).
+- Off→on transition wipes the dev `.sqlite` and reseeds. No separate
+  "Reseed" button.
+- Shipped in Debug and Release.
+
+## Task list
+
+### Task 1: Extract seed function into shippable source
+
+**Goal**: Move the seed logic so it's reachable from the main app
+target in Release, while preview helpers keep working.
+
+**Changes**:
+- New `Kado/Services/DevModeSeed.swift` exposing
+  `enum DevModeSeed { static func seed(into context: ModelContext, calendar: Calendar = .current) }`.
+- `Kado/Preview Content/PreviewContainer.swift`: delete the private
+  `seed(_:)`, call `DevModeSeed.seed(into:)` instead. Preview
+  variants unchanged otherwise.
+
+**Tests / verification**:
+- Existing preview-driven tests (if any) still pass.
+- `build_sim` clean.
+- Visual: open Xcode previews on `HabitListView` — seeded data still
+  shows.
+
+**Commit message**: `refactor(dev-mode): extract seed into shippable DevModeSeed`
+
+---
+
+### Task 2: Add DevModeController with container lifecycle
+
+**Goal**: Encapsulate the two-container logic behind one observable
+type that the app root can drive.
+
+**Changes**:
+- New `Kado/App/DevModeController.swift`: `@MainActor` `@Observable`
+  class. Responsibilities:
+  - Build / return the prod `ModelContainer` (lazy).
+  - Build / return the dev `ModelContainer` (lazy, on-disk at
+    `Application Support/KadoDev.sqlite`, no CloudKit).
+  - `func activateDevMode()` — delete the dev sqlite file if it
+    exists, build a fresh container, seed via `DevModeSeed`.
+  - `func deactivateDevMode()` — drop the dev container reference.
+  - `func container(forDevMode enabled: Bool) -> ModelContainer`
+    that routes correctly.
+- `CloudContainerID.kado` usage stays on the prod container only.
+
+**Tests / verification** (`KadoTests/DevModeControllerTests.swift`):
+- `@Test("Prod container uses CloudKit configuration")` — sanity.
+- `@Test("Dev container is on-disk, no CloudKit")`.
+- `@Test("activateDevMode seeds at least one habit per HabitType")`.
+- `@Test("Off→on cycle wipes sandbox edits")` — seed, insert a
+  sentinel habit, deactivate, reactivate, confirm only seeded
+  habits remain and sentinel is gone.
+
+**Commit message**: `feat(dev-mode): add DevModeController for container lifecycle`
+
+---
+
+### Task 3: Wire the container swap in KadoApp
+
+**Goal**: Make the root view drive its `.modelContainer(...)` from
+the dev-mode flag.
+
+**Changes**:
+- `Kado/App/KadoApp.swift`:
+  - Replace the current `let container` with a `@State` or `let`
+    `DevModeController`.
+  - `@AppStorage("kado.devMode") private var isDevMode = false`.
+  - Compute the active container from `controller.container(forDevMode: isDevMode)`.
+  - `.onChange(of: isDevMode)` — call `controller.activateDevMode()`
+    when turning on, `controller.deactivateDevMode()` when turning
+    off. Apply before the view re-reads the container so the swap
+    is atomic.
+
+**Tests / verification**:
+- `build_sim` clean.
+- Manual: launch app, no dev mode, real data (empty on fresh
+  install) shows. Then (with Task 4 landed) flip the toggle and
+  confirm the UI snaps to seeded data and back.
+
+**Commit message**: `feat(dev-mode): swap SwiftData container from app root`
+
+---
+
+### Task 4: Settings toggle + copy
+
+**Goal**: Surface the toggle in the Settings screen.
+
+**Changes**:
+- `Kado/Views/Settings/SettingsView.swift`: new `Section("Dev mode")`
+  (or similarly named) with a `Toggle` bound to
+  `@AppStorage("kado.devMode")`, and a footer explaining the
+  behavior: "Replace your data with a demo dataset. Your real data
+  is safe and returns when you turn this off."
+- Localized via `String(localized:)` — add EN + FR entries to the
+  string catalog.
+
+**Tests / verification**:
+- `screenshot` of Settings with toggle off and on.
+- Manual round-trip: toggle on → seeded data everywhere (Today,
+  Detail, History). Toggle off → original data back. Toggle on
+  again → fresh seed (any edits from previous dev session gone).
+
+**Commit message**: `feat(dev-mode): add Settings toggle`
+
+---
+
+### Task 5: Manual verification pass + PR polish
+
+**Goal**: End-to-end sanity before marking ready for review.
+
+**Changes**: none or tiny.
+
+**Verification**:
+- `build_sim` + `test_sim` both green.
+- iPhone 16 Pro: toggle cycle, create a habit while in dev mode,
+  toggle off and on, confirm it's gone.
+- iPad Air: same cycle.
+- VoiceOver on the Settings toggle reads correctly.
+- Dynamic Type XXXL on the Settings footer doesn't clip.
+- Confirm `KadoDev.sqlite` appears in the simulator sandbox under
+  Application Support while dev mode is on.
+
+**Commit message**: (none — or doc updates only)
+
+---
+
+## Risks and mitigation
+
+- **Container swap doesn't trigger `@Query` refresh.** → Confirm
+  with a 2-minute smoke test during Task 3. If SwiftUI caches the
+  container identity incorrectly, fall back to re-rooting the
+  `WindowGroup` content on a `.id(isDevMode)` modifier.
+- **Seed function now compiled in Release** (size cost). →
+  Negligible (~a few hundred lines of data), but worth noting.
+- **Schema evolution later**: when `KadoSchemaV2` ships, both
+  containers pick it up automatically since they share the
+  migration plan. Dev sandbox file gets migrated on first access
+  too — acceptable, since the user can always toggle off/on to
+  reseed.
+- **User confusion ("where did my data go?")**. → Footer copy is
+  explicit; the toggle itself says "Dev mode." Revisit wording if
+  testers misread it.
+
+## Open questions
+
+None blocking. Will revisit toggle copy during Task 4 based on how
+it reads in-app.
+
+## Out of scope
+
+- Release-facing "demo mode" with its own onboarding hook (if ever
+  desired, separate feature).
+- Reseed-while-on button.
+- Richer seed (60–90 days, streak-heavy, etc.).
+- Dev-mode-only debug tools (time travel, force-advance date,
+  inject completions) — possible future follow-ups.

--- a/docs/plans/2026-04/dev-mode/research.md
+++ b/docs/plans/2026-04/dev-mode/research.md
@@ -1,7 +1,7 @@
 # Research — Dev Mode
 
 **Date**: 2026-04-17
-**Status**: draft
+**Status**: ready for plan
 **Related**: `docs/ROADMAP.md`, `Kado/Preview Content/PreviewContainer.swift`
 
 ## Problem
@@ -52,10 +52,11 @@ to persist them at all.
 
 ## Proposed approach
 
-**Two `ModelContainer`s, swap at the root view.** Debug-only feature
-(wrapped in `#if DEBUG`) — matches intent ("dev mode"), keeps
-release builds simple, lets us reuse `PreviewContainer.seed`
-without moving it out of `Preview Content/`.
+**Two `ModelContainer`s, swap at the root view.** Shipped in both
+Debug and Release — the user activates dev mode from Settings at
+runtime, it is not a build-time flag. `PreviewContainer.seed` will
+need to move out of `Preview Content/` (Debug-only) into a regular
+source folder so it's reachable in Release builds.
 
 Flow:
 
@@ -64,9 +65,11 @@ Flow:
 2. A `DevModeController` (`@Observable`, `@MainActor`) owns two
    lazily-built containers:
    - `productionContainer`: today's CloudKit-backed container.
-   - `devContainer`: `ModelConfiguration(isStoredInMemoryOnly: true)`,
-     **no CloudKit**, seeded via `PreviewContainer.seed(_:)` on
-     first build.
+   - `devContainer`: on-disk at a separate URL (e.g.
+     `Application Support/KadoDev.sqlite`), **no CloudKit**,
+     seeded via the extracted seed function on first build.
+     Edits persist across app launches as long as dev mode stays
+     on.
    It exposes `var currentContainer: ModelContainer` derived from
    the toggle.
 3. `KadoApp.body` reads the toggle and applies the right container
@@ -74,21 +77,25 @@ Flow:
    tears down and rebuilds the environment when the identity of
    the injected container changes — all `@Query`s re-fetch, so
    the UI snaps to the new store without any per-view work.
-4. Turning dev mode **off** drops the in-memory container
-   reference (or recreates it next time) — sandbox edits vanish.
-5. Turning dev mode **on again** builds a fresh in-memory
-   container + reseeds — clean slate each session.
+4. Turning dev mode **off** drops the dev container reference.
+   The sandbox file stays on disk but is not accessed — real
+   data is back in the UI.
+5. Turning dev mode **on again** deletes the sandbox file and
+   rebuilds a fresh seeded container — a clean slate each
+   off→on cycle is how the user resets dev data (no separate
+   "Reseed" button needed).
 
 ### Key components
 
 - `DevModeController` (new, `Services/` or `App/`): lazy container
-  accessors, `isEnabled` mirror of the `@AppStorage` value.
-- `PreviewContainer.seed(_:)` (existing): reused as-is, possibly
-  expanded to cover longer history (60–90 days) for more satisfying
-  score/history views.
-- `SettingsView`: new section "Developer" with a `Toggle`, visible
-  only under `#if DEBUG`. Copy: "Dev mode — replace your data with
-  a demo dataset. Your real data is safe."
+  accessors, `isEnabled` mirror of the `@AppStorage` value,
+  wipe-and-reseed on off→on transition.
+- Seed function: extracted from `PreviewContainer` into a shippable
+  source folder (e.g. `Services/DevModeSeed.swift`) so it is
+  available in Release. Keep the ~14-day history as-is.
+- `SettingsView`: new section with a `Toggle`, always visible.
+  Copy: "Dev mode — replace your data with a demo dataset. Your
+  real data is safe and returns when you turn this off."
 - `KadoApp`: read toggle, bind to controller, swap container.
 
 ### Data model changes
@@ -97,8 +104,8 @@ None. Uses the existing schema for both containers.
 
 ### UI changes
 
-- Settings: new Developer section with a single toggle + footnote
-  explaining the effect. Only compiled in Debug builds.
+- Settings: new section with a single toggle + footnote
+  explaining the effect. Shipped in Release.
 - No other views change — they keep reading their `@Query` / env
   container.
 
@@ -107,11 +114,11 @@ None. Uses the existing schema for both containers.
 This is mostly wiring and Debug-only plumbing, so the testing bar
 is low. Worth covering:
 
-- `@Test("DevModeController returns a fresh in-memory container when enabled")`
+- `@Test("DevModeController returns the dev container when enabled")`
 - `@Test("DevModeController seeds dev container with at least one habit of each HabitType")`
-- `@Test("Toggling dev mode off discards the in-memory context")`
-  (i.e. calling `isEnabled = false` then `isEnabled = true` again
-  produces a new container identity).
+- `@Test("Toggling dev mode off→on wipes the sandbox and reseeds")`
+  (write a sentinel habit into the dev container, flip off then
+  on, confirm only seed habits remain).
 
 UI behavior (the swap itself) is adequately covered by manual
 check + screenshot.
@@ -157,23 +164,23 @@ exploring the app without committing real data.
   other long-lived services are fine — they don't hold a
   `ModelContext`. Double-check nothing else caches a context
   across the swap.
-- **`@AppStorage` default**: must be `false` in Release builds
-  regardless (defense in depth in case the flag gets flipped via
-  Simulator defaults).
+- **`@AppStorage` default**: `false`. User activates at runtime
+  from Settings.
+- **Seed file location**: moving `PreviewContainer.seed` into a
+  shipped source folder means it's compiled into Release. Keep
+  the Preview-only variants (`.shared`, `emptyContainer`, …) in
+  `Preview Content/` — only the seed function itself needs to move.
 
 ## Open questions
 
-- [ ] **Debug-only, or Release too?** Default proposal: Debug only
-  (cleanest; zero risk for end users). Confirm.
-- [ ] **Seed richness**: current seed is ~14 days. Want to push it
-  to 60–90 days to exercise score curves and history calendars
-  properly?
-- [ ] **Sandbox persistence**: in-memory and discarded each toggle
-  cycle (proposed), or on-disk at a separate URL so edits survive
-  across app launches while dev mode stays on?
-- [ ] **Reset control**: inside dev mode, should the Settings
-  section also expose a "Reseed dev data" button to re-roll the
-  sandbox without toggling off/on?
+Resolved:
+
+- [x] **Debug-only, or Release too?** → Release too. Runtime toggle,
+  no build-time flag.
+- [x] **Seed richness** → ~14 days is fine.
+- [x] **Sandbox persistence** → on-disk at a separate URL.
+- [x] **Reset control** → no separate button; off→on wipes and
+  reseeds.
 
 ## References
 

--- a/docs/plans/2026-04/dev-mode/research.md
+++ b/docs/plans/2026-04/dev-mode/research.md
@@ -1,0 +1,184 @@
+# Research — Dev Mode
+
+**Date**: 2026-04-17
+**Status**: draft
+**Related**: `docs/ROADMAP.md`, `Kado/Preview Content/PreviewContainer.swift`
+
+## Problem
+
+Working on Kadō — reviewing score curves, reviewing calendar/history
+rendering, tuning the detail view, demoing the app — is painful
+without realistic historical data. Today the only realistic seed
+lives in `PreviewContainer` and is only reachable from SwiftUI
+previews. Manually creating months of completion data in the running
+app is tedious and disposable.
+
+We want an in-app **dev mode**: a toggle in Settings that replaces
+the live SwiftData store with a seeded sandbox store. When turned
+off, the real data reappears untouched. Edits in dev mode can be
+discarded on exit — no iCloud sync from the sandbox, no requirement
+to persist them at all.
+
+"Done" from the user's perspective:
+- Flip a toggle in Settings → the whole app (Today, Detail, History,
+  Score) instantly operates on a rich seeded dataset.
+- Flip it back → real data returns, untouched.
+- Edits while in dev mode are local-only; losing them on exit is
+  acceptable (even desirable).
+
+## Current state of the codebase
+
+- **Single container at app root**: `KadoApp.swift` builds one
+  `ModelContainer` with `ModelConfiguration(cloudKitDatabase:
+  .private(CloudContainerID.kado))` around `KadoSchemaV1`, and
+  injects it via `.modelContainer(...)`. All `@Query` in the app
+  reads from this container.
+- **Preview seed already exists**: `Preview Content/PreviewContainer.swift`
+  has `static func seed(_ context: ModelContext)` covering all four
+  `HabitType` variants (binary / counter / timer / negative) and
+  mixed frequencies, with ~14 days of staggered completions. The
+  file is in Preview Content, so it's Debug-only and not shipped in
+  Release.
+- **Models**: `HabitRecord` (+ cascade `CompletionRecord`),
+  codable-as-data for `Frequency` and `HabitType`. CloudKit-shape
+  rules already applied (optional relationships, no uniqueness
+  constraints).
+- **Settings screen** (`Views/Settings/SettingsView.swift`): minimal,
+  only an iCloud account section. No `UserDefaults`/`@AppStorage`
+  used anywhere yet — this would be the first one.
+- **CloudKit**: wired up (container ID, entitlements, account
+  observer) but not yet user-facing / actively exercised in v0.1.
+  Risk of conflict with a sandbox container is low today.
+
+## Proposed approach
+
+**Two `ModelContainer`s, swap at the root view.** Debug-only feature
+(wrapped in `#if DEBUG`) — matches intent ("dev mode"), keeps
+release builds simple, lets us reuse `PreviewContainer.seed`
+without moving it out of `Preview Content/`.
+
+Flow:
+
+1. `@AppStorage("kado.devMode")` bool (UserDefaults — not synced to
+   iCloud by default, which is exactly what we want).
+2. A `DevModeController` (`@Observable`, `@MainActor`) owns two
+   lazily-built containers:
+   - `productionContainer`: today's CloudKit-backed container.
+   - `devContainer`: `ModelConfiguration(isStoredInMemoryOnly: true)`,
+     **no CloudKit**, seeded via `PreviewContainer.seed(_:)` on
+     first build.
+   It exposes `var currentContainer: ModelContainer` derived from
+   the toggle.
+3. `KadoApp.body` reads the toggle and applies the right container
+   via `.modelContainer(controller.currentContainer)`. SwiftUI
+   tears down and rebuilds the environment when the identity of
+   the injected container changes — all `@Query`s re-fetch, so
+   the UI snaps to the new store without any per-view work.
+4. Turning dev mode **off** drops the in-memory container
+   reference (or recreates it next time) — sandbox edits vanish.
+5. Turning dev mode **on again** builds a fresh in-memory
+   container + reseeds — clean slate each session.
+
+### Key components
+
+- `DevModeController` (new, `Services/` or `App/`): lazy container
+  accessors, `isEnabled` mirror of the `@AppStorage` value.
+- `PreviewContainer.seed(_:)` (existing): reused as-is, possibly
+  expanded to cover longer history (60–90 days) for more satisfying
+  score/history views.
+- `SettingsView`: new section "Developer" with a `Toggle`, visible
+  only under `#if DEBUG`. Copy: "Dev mode — replace your data with
+  a demo dataset. Your real data is safe."
+- `KadoApp`: read toggle, bind to controller, swap container.
+
+### Data model changes
+
+None. Uses the existing schema for both containers.
+
+### UI changes
+
+- Settings: new Developer section with a single toggle + footnote
+  explaining the effect. Only compiled in Debug builds.
+- No other views change — they keep reading their `@Query` / env
+  container.
+
+### Tests to write
+
+This is mostly wiring and Debug-only plumbing, so the testing bar
+is low. Worth covering:
+
+- `@Test("DevModeController returns a fresh in-memory container when enabled")`
+- `@Test("DevModeController seeds dev container with at least one habit of each HabitType")`
+- `@Test("Toggling dev mode off discards the in-memory context")`
+  (i.e. calling `isEnabled = false` then `isEnabled = true` again
+  produces a new container identity).
+
+UI behavior (the swap itself) is adequately covered by manual
+check + screenshot.
+
+## Alternatives considered
+
+### Alternative A: Single container, stash/restore user data
+
+Save user `HabitRecord`s to JSON on dev-mode enable, clear the
+store, seed, then restore on disable.
+
+- Why not: delete-and-restore on the real store is far scarier
+  than leaving it alone in a parked container. A crash mid-swap
+  could nuke user data, and it would sync the deletions to
+  CloudKit. The container-swap approach keeps real data 100%
+  untouched, at the cost of one extra `ModelContainer` instance.
+
+### Alternative B: In-memory flag on the existing container
+
+There is no runtime switch on `ModelConfiguration` — the
+`isStoredInMemoryOnly` flag is set at construction. Would still
+require rebuilding the container, so no win over Alternative
+(chosen).
+
+### Alternative C: Ship in Release too
+
+Could expose dev mode to end users as a "demo mode" for
+exploring the app without committing real data.
+
+- Why not now: conflates "dev tool for us" with "demo for users."
+  If we want a real demo mode later it deserves its own UX
+  (onboarding hook, explicit copy, localization). Debug-only is
+  the right MVP.
+
+## Risks and unknowns
+
+- **Container swap re-renders**: confirm that changing the
+  `ModelContainer` passed to `.modelContainer(_:)` actually
+  re-instantiates downstream `@Query`s. The SwiftUI contract here
+  is solid in practice but worth a 2-minute smoke test before
+  committing.
+- **Observer singletons**: `CloudAccountStatusObserving` and any
+  other long-lived services are fine — they don't hold a
+  `ModelContext`. Double-check nothing else caches a context
+  across the swap.
+- **`@AppStorage` default**: must be `false` in Release builds
+  regardless (defense in depth in case the flag gets flipped via
+  Simulator defaults).
+
+## Open questions
+
+- [ ] **Debug-only, or Release too?** Default proposal: Debug only
+  (cleanest; zero risk for end users). Confirm.
+- [ ] **Seed richness**: current seed is ~14 days. Want to push it
+  to 60–90 days to exercise score curves and history calendars
+  properly?
+- [ ] **Sandbox persistence**: in-memory and discarded each toggle
+  cycle (proposed), or on-disk at a separate URL so edits survive
+  across app launches while dev mode stays on?
+- [ ] **Reset control**: inside dev mode, should the Settings
+  section also expose a "Reseed dev data" button to re-roll the
+  sandbox without toggling off/on?
+
+## References
+
+- `Kado/App/KadoApp.swift` — current container wiring.
+- `Kado/Preview Content/PreviewContainer.swift` — existing seed.
+- `Kado/Models/HabitType.swift`, `Kado/Models/Frequency.swift` —
+  variants the seed must cover.
+- Apple: [SwiftData `ModelConfiguration`](https://developer.apple.com/documentation/swiftdata/modelconfiguration)


### PR DESCRIPTION
## Why?
- Testing score curves, history calendars, and detail views is painful without realistic historical data
- The only realistic seed lived in `PreviewContainer`, reachable only from SwiftUI previews

## What?
- Settings toggle under Developer; first activation shows a confirmation alert
- Swaps the live store for an on-disk seeded sandbox (~14 days of history, all `HabitType` variants)
- Disabling returns to real data; re-enabling wipes and reseeds the sandbox
- iCloud section shows "Sync paused while dev mode is on"
- Toggle is local-only (not iCloud-synced)

## How?
- `DevModeController` owns both containers (prod CloudKit + dev on-disk at `KadoDev.sqlite`)
- Swapped at `KadoApp` root via `.modelContainer(_:)` — propagates to `@Query` without remount
- Edge-triggered `onChange` activates/deactivates; lazy `seedIfEmpty` handles cold launches
- Seed lives in shippable `DevModeSeed` (Release-safe, not Preview-only)
- See [`research.md`](docs/plans/2026-04/dev-mode/research.md), [`plan.md`](docs/plans/2026-04/dev-mode/plan.md), [`compound.md`](docs/plans/2026-04/dev-mode/compound.md)

## Next steps
- None; open questions resolved, three lessons promoted to `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)