### PR TITLE
feat(overview): multi-habit overview tab for v0.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,13 +300,29 @@ KadoUITests/                # UI tests (XCTest)
   that walks `Schema.entities` and asserts `relationship.isOptional`
   / `!attribute.isUnique` — see `KadoTests/CloudKitShapeTests.swift`
   for the canonical pattern.
-- **Composite Codable workaround**: SwiftData on Xcode 26 / iOS 18
-  does not reliably support enums with associated values as direct
-  stored properties on `@Model` — `ModelContainer.init` crashes at
-  runtime even though build is clean. Workaround: store as
-  `private var fooData: Data` and expose `var foo: Foo { get / set }`
-  with explicit JSON encode/decode. See `HabitRecord` for the canonical
-  pattern. Re-evaluate when Apple fixes the underlying bug.
+- **Custom-enum storage workaround**: SwiftData on Xcode 26 / iOS 18
+  does not reliably support **any** custom enum type as a direct
+  `@Model` stored property — not just associated-value enums. Even
+  plain `String`-raw-value enums (e.g. `HabitColor`) crash at load
+  with `Could not cast Optional<Any> to <EnumType>` despite Codable
+  / Sendable / RawRepresentable being satisfied. Workarounds:
+  - For associated-value enums, store `private var fooData: Data`
+    and expose `var foo: Foo` with explicit JSON encode/decode.
+    Canonical: `HabitRecord.frequency`, `.type` in every schema
+    version.
+  - For `RawRepresentable` enums with primitive raw values, store
+    `private var fooRaw: String` (or the enum's raw type) and
+    expose `var foo: Foo { Foo(rawValue: fooRaw) ?? .default }`.
+    Canonical: `HabitRecord.color` in `KadoSchemaV2`.
+
+  Re-evaluate when Apple fixes the underlying bug.
+- **`@Model` default-argument values must be fully qualified.**
+  `var color: HabitColor = .blue` fails with "A default value
+  requires a fully qualified domain named value (from macro
+  'Model')" plus a cascade of "type 'Any?' has no member 'blue'"
+  errors. Write `var color: HabitColor = HabitColor.blue` instead.
+  Only `@Model` class bodies need this — plain struct initializers
+  tolerate leading-dot shorthand as usual.
 
 ---
 

--- a/Kado/App/DevModeController.swift
+++ b/Kado/App/DevModeController.swift
@@ -73,20 +73,34 @@ final class DevModeController {
     private func buildDevContainer() -> ModelContainer {
         ensureParentDirectoryExists(for: devStoreURL)
         do {
-            let schema = Schema(versionedSchema: KadoSchemaV1.self)
-            let configuration = ModelConfiguration(
-                schema: schema,
-                url: devStoreURL,
-                cloudKitDatabase: .none
-            )
-            return try ModelContainer(
-                for: schema,
-                migrationPlan: KadoMigrationPlan.self,
-                configurations: configuration
-            )
+            return try makeDevContainer()
         } catch {
-            fatalError("Failed to construct dev ModelContainer: \(error)")
+            // Dev sandbox is disposable — if SwiftData can't open the
+            // file (e.g. stale schema from an older schema version that
+            // pre-dates the current migration plan), wipe and rebuild
+            // empty. A production container does NOT get this
+            // treatment; user data is never silently discarded.
+            deleteDevStoreFiles()
+            do {
+                return try makeDevContainer()
+            } catch {
+                fatalError("Failed to construct dev ModelContainer after wipe: \(error)")
+            }
         }
+    }
+
+    private func makeDevContainer() throws -> ModelContainer {
+        let schema = Schema(versionedSchema: KadoSchemaV2.self)
+        let configuration = ModelConfiguration(
+            schema: schema,
+            url: devStoreURL,
+            cloudKitDatabase: .none
+        )
+        return try ModelContainer(
+            for: schema,
+            migrationPlan: KadoMigrationPlan.self,
+            configurations: configuration
+        )
     }
 
     private func deleteDevStoreFiles() {
@@ -115,7 +129,7 @@ final class DevModeController {
 
     nonisolated static func defaultProductionContainer() -> ModelContainer {
         do {
-            let schema = Schema(versionedSchema: KadoSchemaV1.self)
+            let schema = Schema(versionedSchema: KadoSchemaV2.self)
             return try ModelContainer(
                 for: schema,
                 migrationPlan: KadoMigrationPlan.self,

--- a/Kado/Models/Habit.swift
+++ b/Kado/Models/Habit.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 /// Lightweight value-type representation of a habit, used by the score
-/// and frequency services. The SwiftData `@Model` wrapper (next PR)
-/// will project to / from this struct.
+/// and frequency services. The SwiftData `@Model` wrapper projects to
+/// / from this struct via `HabitRecord.snapshot`.
 ///
 /// Equality and hashing are by `id` only: two snapshots of the same
 /// habit at different times (e.g. before and after a rename) compare
-/// equal, matching the persistence-identity model SwiftData will use.
+/// equal, matching the persistence-identity model SwiftData uses.
 struct Habit: Identifiable, Hashable, Sendable {
     let id: UUID
     var name: String
@@ -14,6 +14,8 @@ struct Habit: Identifiable, Hashable, Sendable {
     var type: HabitType
     var createdAt: Date
     var archivedAt: Date?
+    var color: HabitColor
+    var icon: String
 
     init(
         id: UUID = UUID(),
@@ -21,7 +23,9 @@ struct Habit: Identifiable, Hashable, Sendable {
         frequency: Frequency,
         type: HabitType,
         createdAt: Date,
-        archivedAt: Date? = nil
+        archivedAt: Date? = nil,
+        color: HabitColor = .blue,
+        icon: String = HabitIcon.default
     ) {
         self.id = id
         self.name = name
@@ -29,6 +33,8 @@ struct Habit: Identifiable, Hashable, Sendable {
         self.type = type
         self.createdAt = createdAt
         self.archivedAt = archivedAt
+        self.color = color
+        self.icon = icon
     }
 
     static func == (lhs: Habit, rhs: Habit) -> Bool {

--- a/Kado/Models/HabitColor.swift
+++ b/Kado/Models/HabitColor.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+/// A curated palette of habit colors. Each case resolves to a SwiftUI
+/// `Color` that adapts to light and dark mode via Apple's system hues.
+///
+/// Raw values are stable strings so the on-disk / CloudKit shape
+/// survives enum reordering.
+nonisolated enum HabitColor: String, Codable, Sendable, Hashable, CaseIterable {
+    case red
+    case orange
+    case yellow
+    case green
+    case mint
+    case teal
+    case blue
+    case purple
+
+    var color: Color {
+        switch self {
+        case .red: .red
+        case .orange: .orange
+        case .yellow: .yellow
+        case .green: .green
+        case .mint: .mint
+        case .teal: .teal
+        case .blue: .blue
+        case .purple: .purple
+        }
+    }
+}

--- a/Kado/Models/HabitIcon.swift
+++ b/Kado/Models/HabitIcon.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// A curated shortlist of SF Symbol names usable as habit glyphs. The
+/// list is intentionally short (~30) to keep the picker scannable;
+/// full SF Symbol search is deferred.
+enum HabitIcon {
+    /// Fallback symbol for habits that haven't picked an icon (e.g. V1
+    /// habits migrated to V2 without user interaction).
+    static let `default`: String = "circle"
+
+    static let curated: [String] = [
+        // Movement
+        "figure.walk",
+        "figure.run",
+        "dumbbell.fill",
+        "figure.yoga",
+        "bicycle",
+        "figure.pool.swim",
+
+        // Mind + body
+        "figure.mind.and.body",
+        "leaf.fill",
+        "moon.stars.fill",
+        "bed.double.fill",
+
+        // Nutrition + hydration
+        "drop.fill",
+        "cup.and.saucer.fill",
+        "fork.knife",
+        "carrot.fill",
+
+        // Learning + creative
+        "book.fill",
+        "pencil",
+        "music.note",
+        "paintbrush.fill",
+        "camera.fill",
+
+        // Health + wellbeing
+        "heart.fill",
+        "pills.fill",
+
+        // Daily rhythms
+        "sun.max.fill",
+        "flame.fill",
+        "sparkles",
+        "star.fill",
+        "checkmark.circle.fill",
+        "target",
+
+        // Work + home
+        "laptopcomputer",
+        "phone.fill",
+        "house.fill",
+    ]
+}

--- a/Kado/Models/Persistence/CompletionRecord.swift
+++ b/Kado/Models/Persistence/CompletionRecord.swift
@@ -43,5 +43,3 @@ extension KadoSchemaV1 {
         }
     }
 }
-
-typealias CompletionRecord = KadoSchemaV1.CompletionRecord

--- a/Kado/Models/Persistence/HabitRecord.swift
+++ b/Kado/Models/Persistence/HabitRecord.swift
@@ -81,5 +81,3 @@ extension KadoSchemaV1 {
         }
     }
 }
-
-typealias HabitRecord = KadoSchemaV1.HabitRecord

--- a/Kado/Models/Persistence/KadoMigrationPlan.swift
+++ b/Kado/Models/Persistence/KadoMigrationPlan.swift
@@ -1,13 +1,19 @@
 import Foundation
 import SwiftData
 
-/// Migration plan for Kadō's persistent schema. `stages` stays empty
-/// while v1 is the only shipped version; the first real stage lands
-/// alongside `KadoSchemaV2`.
+/// Migration plan for Kadō's persistent schema. Schemas are listed
+/// oldest-to-newest; `stages` bridges each consecutive pair.
 enum KadoMigrationPlan: SchemaMigrationPlan {
     static var schemas: [any VersionedSchema.Type] {
-        [KadoSchemaV1.self]
+        [KadoSchemaV1.self, KadoSchemaV2.self]
     }
 
-    static var stages: [MigrationStage] { [] }
+    static var stages: [MigrationStage] {
+        [
+            .lightweight(
+                fromVersion: KadoSchemaV1.self,
+                toVersion: KadoSchemaV2.self
+            )
+        ]
+    }
 }

--- a/Kado/Models/Persistence/KadoSchemaV2.swift
+++ b/Kado/Models/Persistence/KadoSchemaV2.swift
@@ -1,0 +1,136 @@
+import Foundation
+import SwiftData
+
+/// Version 2 of Kadō's persistent schema. Adds per-habit `color` and
+/// `icon`, migrated from V1 via a lightweight stage. V1 stays frozen
+/// — never modify a shipped schema in place.
+enum KadoSchemaV2: VersionedSchema {
+    static let versionIdentifier = Schema.Version(2, 0, 0)
+
+    static var models: [any PersistentModel.Type] {
+        [HabitRecord.self, CompletionRecord.self]
+    }
+}
+
+extension KadoSchemaV2 {
+    /// Persistent representation of a habit. Mirrors V1 plus `color`
+    /// and `icon`, both defaulted so CloudKit / lightweight-migration
+    /// can fill existing rows.
+    ///
+    /// `Frequency` and `HabitType` are stored as JSON-encoded `Data`
+    /// because SwiftData's `@Model` macro mishandles composite Codable
+    /// enums on this toolchain. `HabitColor` hits the same ceiling
+    /// despite being a plain String-raw-value enum — SwiftData reads
+    /// it back as `Any?` and fails to cast. Workaround: store the raw
+    /// String and expose `color: HabitColor` via a computed accessor.
+    @Model
+    final class HabitRecord {
+        var id: UUID = UUID()
+        var name: String = ""
+        private var frequencyData: Data = Data()
+        private var typeData: Data = Data()
+        var createdAt: Date = Date()
+        var archivedAt: Date?
+        private var colorRaw: String = "blue"
+        var icon: String = "circle"
+
+        @Relationship(deleteRule: .cascade, inverse: \CompletionRecord.habit)
+        var completions: [CompletionRecord]? = []
+
+        init(
+            id: UUID = UUID(),
+            name: String = "",
+            frequency: Frequency = .daily,
+            type: HabitType = .binary,
+            createdAt: Date = .now,
+            archivedAt: Date? = nil,
+            color: HabitColor = .blue,
+            icon: String = HabitIcon.default,
+            completions: [CompletionRecord]? = []
+        ) {
+            self.id = id
+            self.name = name
+            self.frequencyData = Self.encode(frequency)
+            self.typeData = Self.encode(type)
+            self.createdAt = createdAt
+            self.archivedAt = archivedAt
+            self.colorRaw = color.rawValue
+            self.icon = icon
+            self.completions = completions
+        }
+
+        var frequency: Frequency {
+            get { Self.decode(frequencyData, fallback: .daily) }
+            set { frequencyData = Self.encode(newValue) }
+        }
+
+        var type: HabitType {
+            get { Self.decode(typeData, fallback: .binary) }
+            set { typeData = Self.encode(newValue) }
+        }
+
+        var color: HabitColor {
+            get { HabitColor(rawValue: colorRaw) ?? .blue }
+            set { colorRaw = newValue.rawValue }
+        }
+
+        var snapshot: Habit {
+            Habit(
+                id: id,
+                name: name,
+                frequency: frequency,
+                type: type,
+                createdAt: createdAt,
+                archivedAt: archivedAt,
+                color: color,
+                icon: icon
+            )
+        }
+
+        private static func encode<T: Encodable>(_ value: T) -> Data {
+            try! JSONEncoder().encode(value)
+        }
+
+        private static func decode<T: Decodable>(_ data: Data, fallback: T) -> T {
+            (try? JSONDecoder().decode(T.self, from: data)) ?? fallback
+        }
+    }
+
+    /// Persistent completion event. Identical shape to V1 — copied so
+    /// V2 is a complete, self-contained schema.
+    @Model
+    final class CompletionRecord {
+        var id: UUID = UUID()
+        var date: Date = Date()
+        var value: Double = 1.0
+        var note: String?
+        var habit: HabitRecord?
+
+        init(
+            id: UUID = UUID(),
+            date: Date = .now,
+            value: Double = 1.0,
+            note: String? = nil,
+            habit: HabitRecord? = nil
+        ) {
+            self.id = id
+            self.date = date
+            self.value = value
+            self.note = note
+            self.habit = habit
+        }
+
+        var snapshot: Completion {
+            Completion(
+                id: id,
+                habitID: habit!.id,
+                date: date,
+                value: value,
+                note: note
+            )
+        }
+    }
+}
+
+typealias HabitRecord = KadoSchemaV2.HabitRecord
+typealias CompletionRecord = KadoSchemaV2.CompletionRecord

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -103,6 +103,17 @@
         }
       }
     },
+    "%lld%% complete" : {
+      "comment" : "Status label for an Overview cell that shows partial completion (counter or timer between 0 and target). Used in the cell popover and in the VoiceOver label. %lld is the percentage 0-100.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld%% complete"
+          }
+        }
+      }
+    },
     "A few times a week" : {
       "comment" : "Frequency picker option in the new-habit form, selects the 'N days per week' mode.",
       "localizations" : {
@@ -187,6 +198,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "Completed" : {
+      "comment" : "Status label in the Overview cell popover for a fully-completed day.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completed"
           }
         }
       }
@@ -441,6 +463,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mark as not done"
+          }
+        }
+      }
+    },
+    "Missed" : {
+      "comment" : "Status label in the Overview cell popover for a scheduled day with no completion logged.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Missed"
           }
         }
       }

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -489,6 +489,17 @@
         }
       }
     },
+    "Not scheduled" : {
+      "comment" : "Status label in the Overview cell popover when a day is off-schedule for the habit.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not scheduled"
+          }
+        }
+      }
+    },
     "Nothing due today" : {
       "comment" : "Empty-state title shown on the Today view when the user has habits but none are due today.",
       "localizations" : {
@@ -562,6 +573,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Score"
+          }
+        }
+      }
+    },
+    "Scored" : {
+      "comment" : "Status label in the Overview cell popover for a day that contributes to the EMA score (past or today, on-schedule).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scored"
           }
         }
       }
@@ -694,6 +716,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Type"
+          }
+        }
+      }
+    },
+    "Upcoming" : {
+      "comment" : "Status label in the Overview cell popover for a future day.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Upcoming"
           }
         }
       }

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -224,6 +224,17 @@
         }
       }
     },
+    "Create habits from the Today tab to see them here." : {
+      "comment" : "Empty-state description on the Overview tab when no habits exist.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create habits from the Today tab to see them here."
+          }
+        }
+      }
+    },
     "Decrement" : {
       "comment" : "VoiceOver label for the minus button in the counter quick-log control.",
       "localizations" : {
@@ -485,6 +496,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nothing due today"
+          }
+        }
+      }
+    },
+    "Overview" : {
+      "comment" : "Tab + navigation title for the multi-habit overview matrix.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Overview"
           }
         }
       }

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -114,6 +114,17 @@
         }
       }
     },
+    "Appearance" : {
+      "comment" : "Section header in the new-habit form grouping the color + icon pickers.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
+          }
+        }
+      }
+    },
     "Archive" : {
       "comment" : "Verb. Used as the toolbar button on the habit detail screen and as the destructive action in the archive confirmation dialog.",
       "localizations" : {

--- a/Kado/Services/DailyValue.swift
+++ b/Kado/Services/DailyValue.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Per-day completion value for a habit, in `[0.0, 1.0]`. No smoothing
+/// or history — just what happened on one specific day. Used by both
+/// the habit-score calculator (as the EMA input) and the Overview
+/// matrix (as the cell opacity source), so the two stay defined in
+/// one place.
+///
+/// - Binary and negative habits: 0 or 1.
+/// - Counter and timer habits: `achieved / target`, capped at 1.
+enum DailyValue {
+    static func compute(for habit: Habit, completionsOnDay: [Completion]) -> Double {
+        switch habit.type {
+        case .binary:
+            return completionsOnDay.isEmpty ? 0.0 : 1.0
+        case .counter(let target):
+            guard target > 0 else { return 0.0 }
+            let achieved = completionsOnDay.reduce(0.0) { $0 + $1.value }
+            return min(1.0, achieved / target)
+        case .timer(let targetSeconds):
+            guard targetSeconds > 0 else { return 0.0 }
+            let achievedSeconds = completionsOnDay.reduce(0.0) { $0 + $1.value }
+            return min(1.0, achievedSeconds / targetSeconds)
+        case .negative:
+            return completionsOnDay.isEmpty ? 1.0 : 0.0
+        }
+    }
+}

--- a/Kado/Services/DefaultHabitScoreCalculator.swift
+++ b/Kado/Services/DefaultHabitScoreCalculator.swift
@@ -48,7 +48,10 @@ struct DefaultHabitScoreCalculator: HabitScoreCalculating {
         var day = firstDay
         while day <= lastDay {
             if frequencyEvaluator.isDue(habit: habit, on: day, completions: completions) {
-                let value = derivedValue(for: habit, completionsOnDay: completionsByDay[day] ?? [])
+                let value = DailyValue.compute(
+                    for: habit,
+                    completionsOnDay: completionsByDay[day] ?? []
+                )
                 score = (1 - alpha) * score + alpha * value
             }
             result.append(DailyScore(date: day, score: score))
@@ -63,23 +66,6 @@ struct DefaultHabitScoreCalculator: HabitScoreCalculating {
     ) -> [Date: [Completion]] {
         Dictionary(grouping: completions.filter { $0.habitID == habit.id }) {
             calendar.startOfDay(for: $0.date)
-        }
-    }
-
-    private func derivedValue(for habit: Habit, completionsOnDay: [Completion]) -> Double {
-        switch habit.type {
-        case .binary:
-            return completionsOnDay.isEmpty ? 0.0 : 1.0
-        case .counter(let target):
-            guard target > 0 else { return 0.0 }
-            let achieved = completionsOnDay.reduce(0.0) { $0 + $1.value }
-            return min(1.0, achieved / target)
-        case .timer(let targetSeconds):
-            guard targetSeconds > 0 else { return 0.0 }
-            let achievedSeconds = completionsOnDay.reduce(0.0) { $0 + $1.value }
-            return min(1.0, achievedSeconds / targetSeconds)
-        case .negative:
-            return completionsOnDay.isEmpty ? 1.0 : 0.0
         }
     }
 }

--- a/Kado/Services/DevModeSeed.swift
+++ b/Kado/Services/DevModeSeed.swift
@@ -2,11 +2,16 @@ import Foundation
 import SwiftData
 
 /// Seeds a `ModelContext` with a realistic demo dataset covering each
-/// `Frequency` and `HabitType` variant, plus ~14 days of historical
+/// `Frequency` and `HabitType` variant, plus ~30 days of historical
 /// completions. Used by the in-app dev mode sandbox and by SwiftUI
 /// previews.
 @MainActor
 enum DevModeSeed {
+    /// Completions per habit in the seed dataset (every other day for
+    /// 30 days from today). Kept as a constant so tests can reference
+    /// it without duplicating arithmetic.
+    static let completionsPerHabit = 15
+
     static func seed(into context: ModelContext, calendar: Calendar = .current) {
         let today = calendar.startOfDay(for: .now)
 
@@ -15,37 +20,48 @@ enum DevModeSeed {
                 name: "Morning meditation",
                 frequency: .daily,
                 type: .binary,
-                createdAt: calendar.date(byAdding: .day, value: -45, to: today)!
+                createdAt: calendar.date(byAdding: .day, value: -45, to: today)!,
+                color: .purple,
+                icon: "figure.mind.and.body"
             ),
             HabitRecord(
                 name: "Gym",
                 frequency: .specificDays([.monday, .wednesday, .friday]),
                 type: .binary,
-                createdAt: calendar.date(byAdding: .day, value: -60, to: today)!
+                createdAt: calendar.date(byAdding: .day, value: -60, to: today)!,
+                color: .orange,
+                icon: "dumbbell.fill"
             ),
             HabitRecord(
                 name: "Drink water",
                 frequency: .daily,
                 type: .counter(target: 8),
-                createdAt: calendar.date(byAdding: .day, value: -30, to: today)!
+                createdAt: calendar.date(byAdding: .day, value: -30, to: today)!,
+                color: .blue,
+                icon: "drop.fill"
             ),
             HabitRecord(
                 name: "Read",
                 frequency: .daily,
                 type: .timer(targetSeconds: 1800),
-                createdAt: calendar.date(byAdding: .day, value: -20, to: today)!
+                createdAt: calendar.date(byAdding: .day, value: -40, to: today)!,
+                color: .mint,
+                icon: "book.fill"
             ),
             HabitRecord(
                 name: "No social media",
                 frequency: .daily,
                 type: .negative,
-                createdAt: calendar.date(byAdding: .day, value: -14, to: today)!
+                createdAt: calendar.date(byAdding: .day, value: -30, to: today)!,
+                color: .red,
+                icon: "flame.fill"
             ),
         ]
 
         for habit in habits {
             context.insert(habit)
-            for daysAgo in stride(from: 1, through: 14, by: 2) {
+            // 15 completions per habit, every other day going back 29 days.
+            for daysAgo in stride(from: 1, through: 29, by: 2) {
                 let date = calendar.date(byAdding: .day, value: -daysAgo, to: today)!
                 let value: Double = switch habit.type {
                 case .counter: 6

--- a/Kado/Services/OverviewMatrix.swift
+++ b/Kado/Services/OverviewMatrix.swift
@@ -27,7 +27,41 @@ enum OverviewMatrix {
         scoreCalculator: any HabitScoreCalculating,
         frequencyEvaluator: any FrequencyEvaluating
     ) -> [MatrixRow] {
-        // Stub — implementation lands in the follow-up commit.
-        []
+        let todayStart = calendar.startOfDay(for: today)
+        let activeHabits = habits
+            .filter { $0.archivedAt == nil }
+            .sorted { $0.createdAt < $1.createdAt }
+
+        guard let firstDay = days.first, let lastDay = days.last else {
+            return activeHabits.map { MatrixRow(habit: $0, days: []) }
+        }
+
+        return activeHabits.map { habit in
+            let habitCompletions = completions.filter { $0.habitID == habit.id }
+            let history = scoreCalculator.scoreHistory(
+                for: habit,
+                completions: habitCompletions,
+                from: firstDay,
+                to: lastDay
+            )
+            let scoreByDay = Dictionary(
+                uniqueKeysWithValues: history.map { ($0.date, $0.score) }
+            )
+            let habitCreatedStart = calendar.startOfDay(for: habit.createdAt)
+
+            let cells = days.map { day -> DayCell in
+                if day > todayStart { return .future }
+                if day < habitCreatedStart { return .notDue }
+                if !frequencyEvaluator.isDue(
+                    habit: habit,
+                    on: day,
+                    completions: habitCompletions
+                ) {
+                    return .notDue
+                }
+                return .scored(scoreByDay[day] ?? 0.0)
+            }
+            return MatrixRow(habit: habit, days: cells)
+        }
     }
 }

--- a/Kado/Services/OverviewMatrix.swift
+++ b/Kado/Services/OverviewMatrix.swift
@@ -21,12 +21,19 @@ enum DayCell: Equatable, Sendable {
 
     /// Opacity used to tint the habit color when rendering this cell.
     /// `nil` for non-scored cells (caller renders a neutral
-    /// placeholder). The 0.08 floor keeps score-near-zero days
-    /// perceptible against the cell background.
+    /// placeholder).
+    ///
+    /// Linear remap from `[0, 1]` value to `[0.2, 1.0]` opacity.
+    /// The 0.2 floor keeps value-0 cells clearly colored — otherwise
+    /// missed-due cells visually collapse into the gray of `.notDue`
+    /// neighbors, losing the "scheduled but missed" signal.
     var colorOpacity: Double? {
         switch self {
-        case .future, .notDue: nil
-        case .scored(let s): max(0.08, min(1.0, s))
+        case .future, .notDue:
+            return nil
+        case .scored(let s):
+            let clamped = max(0.0, min(1.0, s))
+            return 0.2 + 0.8 * clamped
         }
     }
 }

--- a/Kado/Services/OverviewMatrix.swift
+++ b/Kado/Services/OverviewMatrix.swift
@@ -6,9 +6,14 @@ struct MatrixRow: Equatable, Sendable {
     let days: [DayCell]
 }
 
-/// Per-day state for the matrix. `.scored` carries the EMA score on
-/// that day (0...1); `.notDue` covers pre-creation and off-schedule
-/// days; `.future` is used for dates beyond today.
+/// Per-day state for the matrix. `.scored` carries the day's raw
+/// completion value (0...1); `.notDue` covers pre-creation and
+/// off-schedule days; `.future` is used for dates beyond today.
+///
+/// The value is intentionally NOT the EMA habit score. Daily habits
+/// with partial completion would render as a uniform mid-tone under
+/// EMA smoothing, hiding the per-day "did I do it?" pattern the user
+/// expects to see. See `DailyValue` for the mapping.
 enum DayCell: Equatable, Sendable {
     case future
     case notDue
@@ -35,7 +40,6 @@ enum OverviewMatrix {
         days: [Date],
         today: Date,
         calendar: Calendar,
-        scoreCalculator: any HabitScoreCalculating,
         frequencyEvaluator: any FrequencyEvaluating
     ) -> [MatrixRow] {
         let todayStart = calendar.startOfDay(for: today)
@@ -43,21 +47,11 @@ enum OverviewMatrix {
             .filter { $0.archivedAt == nil }
             .sorted { $0.createdAt < $1.createdAt }
 
-        guard let firstDay = days.first, let lastDay = days.last else {
-            return activeHabits.map { MatrixRow(habit: $0, days: []) }
-        }
-
         return activeHabits.map { habit in
             let habitCompletions = completions.filter { $0.habitID == habit.id }
-            let history = scoreCalculator.scoreHistory(
-                for: habit,
-                completions: habitCompletions,
-                from: firstDay,
-                to: lastDay
-            )
-            let scoreByDay = Dictionary(
-                uniqueKeysWithValues: history.map { ($0.date, $0.score) }
-            )
+            let completionsByDay = Dictionary(grouping: habitCompletions) {
+                calendar.startOfDay(for: $0.date)
+            }
             let habitCreatedStart = calendar.startOfDay(for: habit.createdAt)
 
             let cells = days.map { day -> DayCell in
@@ -70,7 +64,11 @@ enum OverviewMatrix {
                 ) {
                     return .notDue
                 }
-                return .scored(scoreByDay[day] ?? 0.0)
+                let value = DailyValue.compute(
+                    for: habit,
+                    completionsOnDay: completionsByDay[day] ?? []
+                )
+                return .scored(value)
             }
             return MatrixRow(habit: habit, days: cells)
         }

--- a/Kado/Services/OverviewMatrix.swift
+++ b/Kado/Services/OverviewMatrix.swift
@@ -13,6 +13,17 @@ enum DayCell: Equatable, Sendable {
     case future
     case notDue
     case scored(Double)
+
+    /// Opacity used to tint the habit color when rendering this cell.
+    /// `nil` for non-scored cells (caller renders a neutral
+    /// placeholder). The 0.08 floor keeps score-near-zero days
+    /// perceptible against the cell background.
+    var colorOpacity: Double? {
+        switch self {
+        case .future, .notDue: nil
+        case .scored(let s): max(0.08, min(1.0, s))
+        }
+    }
 }
 
 /// Turns habits + completions + a day range into matrix rows.

--- a/Kado/Services/OverviewMatrix.swift
+++ b/Kado/Services/OverviewMatrix.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// One row of the Overview matrix: a habit plus its per-day cells.
+struct MatrixRow: Equatable, Sendable {
+    let habit: Habit
+    let days: [DayCell]
+}
+
+/// Per-day state for the matrix. `.scored` carries the EMA score on
+/// that day (0...1); `.notDue` covers pre-creation and off-schedule
+/// days; `.future` is used for dates beyond today.
+enum DayCell: Equatable, Sendable {
+    case future
+    case notDue
+    case scored(Double)
+}
+
+/// Turns habits + completions + a day range into matrix rows.
+/// Stateless; the View computes a fresh matrix per render.
+enum OverviewMatrix {
+    static func compute(
+        habits: [Habit],
+        completions: [Completion],
+        days: [Date],
+        today: Date,
+        calendar: Calendar,
+        scoreCalculator: any HabitScoreCalculating,
+        frequencyEvaluator: any FrequencyEvaluating
+    ) -> [MatrixRow] {
+        // Stub — implementation lands in the follow-up commit.
+        []
+    }
+}

--- a/Kado/UIComponents/DayColumnHeader.swift
+++ b/Kado/UIComponents/DayColumnHeader.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Column header for one day in the Overview matrix: weekday letter
+/// above the day-of-month number. The weekday label uses Apple's
+/// localized single-letter symbols, already covered by
+/// `Weekday.localizedShort`.
+struct DayColumnHeader: View {
+    let date: Date
+    var width: CGFloat = 32
+    @Environment(\.calendar) private var calendar
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(weekdayLetter)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text("\(calendar.component(.day, from: date))")
+                .font(.caption.weight(.semibold).monospacedDigit())
+                .foregroundStyle(isToday ? Color.accentColor : .primary)
+        }
+        .frame(width: width)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var weekdayLetter: String {
+        let weekdayInt = calendar.component(.weekday, from: date)
+        return Weekday(rawValue: weekdayInt)?.localizedShort ?? ""
+    }
+
+    private var isToday: Bool {
+        calendar.isDateInToday(date)
+    }
+
+    private var accessibilityLabel: String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateStyle = .full
+        return formatter.string(from: date)
+    }
+}
+
+#Preview("Week") {
+    let today = Date()
+    return HStack(spacing: 4) {
+        ForEach(0..<7, id: \.self) { offset in
+            DayColumnHeader(
+                date: Calendar.current.date(byAdding: .day, value: offset - 3, to: today)!
+            )
+        }
+    }
+    .padding()
+}

--- a/Kado/UIComponents/HabitColorPicker.swift
+++ b/Kado/UIComponents/HabitColorPicker.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Horizontal row of color swatches. The selected swatch shows a
+/// check; others are plain circles in their own color.
+struct HabitColorPicker: View {
+    @Binding var selection: HabitColor
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ForEach(HabitColor.allCases, id: \.self) { color in
+                Button {
+                    selection = color
+                } label: {
+                    swatch(for: color)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(color.rawValue.capitalized)
+                .accessibilityAddTraits(selection == color ? [.isSelected] : [])
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func swatch(for color: HabitColor) -> some View {
+        Circle()
+            .fill(color.color)
+            .frame(width: 30, height: 30)
+            .overlay {
+                if selection == color {
+                    Image(systemName: "checkmark")
+                        .font(.footnote.weight(.bold))
+                        .foregroundStyle(.white)
+                }
+            }
+            .overlay {
+                Circle()
+                    .strokeBorder(
+                        selection == color ? Color.primary.opacity(0.25) : Color.clear,
+                        lineWidth: 2
+                    )
+            }
+    }
+}
+
+#Preview("Picker") {
+    @Previewable @State var color: HabitColor = .mint
+    return Form {
+        Section("Color") {
+            HabitColorPicker(selection: $color)
+        }
+    }
+}

--- a/Kado/UIComponents/HabitIconPicker.swift
+++ b/Kado/UIComponents/HabitIconPicker.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Grid of curated SF Symbols. The selected icon renders on a tinted
+/// background; others sit in a neutral fill.
+struct HabitIconPicker: View {
+    @Binding var selection: String
+    var tint: Color = .accentColor
+
+    private let columns = Array(
+        repeating: GridItem(.flexible(minimum: 36), spacing: 10),
+        count: 5
+    )
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(HabitIcon.curated, id: \.self) { icon in
+                Button {
+                    selection = icon
+                } label: {
+                    cell(for: icon)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(icon)
+                .accessibilityAddTraits(selection == icon ? [.isSelected] : [])
+            }
+        }
+    }
+
+    private func cell(for icon: String) -> some View {
+        Image(systemName: icon)
+            .font(.title3)
+            .frame(maxWidth: .infinity)
+            .frame(height: 40)
+            .foregroundStyle(selection == icon ? Color.white : tint)
+            .background {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(selection == icon ? tint : Color(.tertiarySystemFill))
+            }
+    }
+}
+
+#Preview("Picker") {
+    @Previewable @State var icon: String = "book.fill"
+    return Form {
+        Section("Icon") {
+            HabitIconPicker(selection: $icon, tint: HabitColor.mint.color)
+        }
+    }
+}

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -37,7 +37,7 @@ struct HabitRowView: View {
         case .binary, .negative:
             if let onToggle {
                 Button(action: onToggle) {
-                    toggleImage
+                    iconBadge
                 }
                 .buttonStyle(.borderless)
                 .sensoryFeedback(.success, trigger: isCompletedToday)
@@ -47,25 +47,31 @@ struct HabitRowView: View {
                         : String(localized: "Mark as done")
                 )
             } else {
-                toggleImage
+                iconBadge
             }
-        case .counter:
-            nonInteractiveIcon("number.circle")
-        case .timer:
-            nonInteractiveIcon("timer")
+        case .counter, .timer:
+            iconBadge
         }
     }
 
-    private var toggleImage: some View {
-        Image(systemName: isCompletedToday ? "checkmark.circle.fill" : "circle")
-            .font(.title2)
-            .foregroundStyle(isCompletedToday ? Color.accentColor : Color.secondary)
-    }
-
-    private func nonInteractiveIcon(_ systemName: String) -> some View {
-        Image(systemName: systemName)
-            .font(.title2)
-            .foregroundStyle(.secondary)
+    /// Circular badge showing the habit's icon in its color. Fills with
+    /// the habit color when the day is complete; shows an outline
+    /// treatment otherwise.
+    private var iconBadge: some View {
+        ZStack {
+            Circle()
+                .fill(isCompletedToday ? habit.color.color : Color.clear)
+                .overlay {
+                    Circle()
+                        .strokeBorder(
+                            habit.color.color.opacity(isCompletedToday ? 0 : 0.5),
+                            lineWidth: 1.5
+                        )
+                }
+            Image(systemName: habit.icon)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(isCompletedToday ? Color.white : habit.color.color)
+        }
     }
 
     @ViewBuilder
@@ -123,22 +129,22 @@ struct HabitRowView: View {
 #Preview("All types — not done") {
     List {
         HabitRowView(
-            habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
+            habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now, color: .purple, icon: "figure.mind.and.body"),
             isCompletedToday: false,
             onToggle: {}
         )
         HabitRowView(
-            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
+            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now, color: .blue, icon: "drop.fill"),
             isCompletedToday: false,
             onToggle: nil
         )
         HabitRowView(
-            habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now),
+            habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now, color: .mint, icon: "book.fill"),
             isCompletedToday: false,
             onToggle: nil
         )
         HabitRowView(
-            habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now),
+            habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now, color: .red, icon: "flame.fill"),
             isCompletedToday: false,
             onToggle: {}
         )
@@ -148,22 +154,22 @@ struct HabitRowView: View {
 #Preview("All types — done") {
     List {
         HabitRowView(
-            habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now),
+            habit: Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now, color: .purple, icon: "figure.mind.and.body"),
             isCompletedToday: true,
             onToggle: {}
         )
         HabitRowView(
-            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now),
+            habit: Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now, color: .blue, icon: "drop.fill"),
             isCompletedToday: true,
             onToggle: nil
         )
         HabitRowView(
-            habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now),
+            habit: Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now, color: .mint, icon: "book.fill"),
             isCompletedToday: true,
             onToggle: nil
         )
         HabitRowView(
-            habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now),
+            habit: Habit(name: "No social media", frequency: .daily, type: .negative, createdAt: .now, color: .red, icon: "flame.fill"),
             isCompletedToday: true,
             onToggle: {}
         )

--- a/Kado/UIComponents/MatrixCell.swift
+++ b/Kado/UIComponents/MatrixCell.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// One cell in the Overview matrix. Fills with the habit's color at
+/// an opacity derived from its EMA score. Non-scored cells render
+/// neutral placeholders (tertiary fill for not-due days, empty for
+/// future days).
+struct MatrixCell: View {
+    let state: DayCell
+    let color: HabitColor
+    var size: CGFloat = 32
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(fill)
+            .frame(width: size, height: size)
+    }
+
+    private var fill: Color {
+        switch state {
+        case .future:
+            Color.clear
+        case .notDue:
+            Color(.tertiarySystemFill)
+        case .scored:
+            color.color.opacity(state.colorOpacity ?? 0)
+        }
+    }
+}
+
+#Preview("Cell states") {
+    VStack(alignment: .leading, spacing: 8) {
+        ForEach(HabitColor.allCases, id: \.self) { color in
+            HStack(spacing: 4) {
+                Text(color.rawValue.capitalized)
+                    .font(.caption.monospaced())
+                    .frame(width: 60, alignment: .leading)
+                MatrixCell(state: .future, color: color)
+                MatrixCell(state: .notDue, color: color)
+                ForEach([0.1, 0.3, 0.5, 0.7, 0.9, 1.0], id: \.self) { s in
+                    MatrixCell(state: .scored(s), color: color)
+                }
+            }
+        }
+    }
+    .padding()
+}
+
+#Preview("Dark") {
+    VStack(alignment: .leading, spacing: 8) {
+        ForEach(HabitColor.allCases, id: \.self) { color in
+            HStack(spacing: 4) {
+                Text(color.rawValue.capitalized)
+                    .font(.caption.monospaced())
+                    .frame(width: 60, alignment: .leading)
+                MatrixCell(state: .future, color: color)
+                MatrixCell(state: .notDue, color: color)
+                ForEach([0.1, 0.3, 0.5, 0.7, 0.9, 1.0], id: \.self) { s in
+                    MatrixCell(state: .scored(s), color: color)
+                }
+            }
+        }
+    }
+    .padding()
+    .preferredColorScheme(.dark)
+}

--- a/Kado/UIComponents/MatrixRowView.swift
+++ b/Kado/UIComponents/MatrixRowView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+/// One habit's row in the Overview matrix: a leading label (icon +
+/// name) and a horizontal list of day cells. The `cellTap` closure
+/// receives the cell's index into `cells` so the caller can map back
+/// to the corresponding day.
+struct MatrixRowView: View {
+    let habit: Habit
+    let cells: [DayCell]
+    var cellSize: CGFloat = 32
+    var cellSpacing: CGFloat = 4
+    var cellTap: ((Int) -> Void)? = nil
+
+    var body: some View {
+        HStack(spacing: cellSpacing) {
+            ForEach(Array(cells.enumerated()), id: \.offset) { index, cell in
+                if let cellTap {
+                    Button {
+                        cellTap(index)
+                    } label: {
+                        MatrixCell(state: cell, color: habit.color, size: cellSize)
+                    }
+                    .buttonStyle(.plain)
+                } else {
+                    MatrixCell(state: cell, color: habit.color, size: cellSize)
+                }
+            }
+        }
+    }
+}
+
+/// A leading label for the Overview matrix: habit icon tinted by its
+/// color, followed by the habit name. Factored out so the full-view
+/// can stack it sticky-left of the scrolling cell region.
+struct HabitRowLabel: View {
+    let habit: Habit
+    var height: CGFloat = 32
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: habit.icon)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(habit.color.color)
+                .frame(width: 24)
+            Text(habit.name)
+                .font(.subheadline)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .frame(height: height, alignment: .leading)
+    }
+}
+
+#Preview("Row — varied states") {
+    let habit = Habit(
+        name: "Morning meditation",
+        frequency: .daily,
+        type: .binary,
+        createdAt: Calendar.current.date(byAdding: .day, value: -20, to: .now)!,
+        color: .purple,
+        icon: "figure.mind.and.body"
+    )
+    let cells: [DayCell] = [
+        .notDue, .scored(0.1), .scored(0.3), .scored(0.6), .scored(0.9),
+        .scored(1.0), .notDue, .scored(0.5), .scored(0.7), .future, .future,
+    ]
+    return VStack(alignment: .leading, spacing: 8) {
+        HabitRowLabel(habit: habit)
+        MatrixRowView(habit: habit, cells: cells)
+    }
+    .padding()
+}

--- a/Kado/UIComponents/MatrixRowView.swift
+++ b/Kado/UIComponents/MatrixRowView.swift
@@ -10,21 +10,32 @@ struct MatrixRowView: View {
     var cellSize: CGFloat = 32
     var cellSpacing: CGFloat = 4
     var cellTap: ((Int) -> Void)? = nil
+    /// Optional per-cell accessibility label. Passed the cell index
+    /// into `cells` so the caller can compose `{habit, date, state}`.
+    var cellAccessibilityLabel: ((Int) -> String)? = nil
 
     var body: some View {
         HStack(spacing: cellSpacing) {
             ForEach(Array(cells.enumerated()), id: \.offset) { index, cell in
-                if let cellTap {
-                    Button {
-                        cellTap(index)
-                    } label: {
-                        MatrixCell(state: cell, color: habit.color, size: cellSize)
-                    }
-                    .buttonStyle(.plain)
-                } else {
-                    MatrixCell(state: cell, color: habit.color, size: cellSize)
-                }
+                cellView(cell: cell, index: index)
+                    .accessibilityLabel(
+                        cellAccessibilityLabel?(index) ?? ""
+                    )
             }
+        }
+    }
+
+    @ViewBuilder
+    private func cellView(cell: DayCell, index: Int) -> some View {
+        if let cellTap {
+            Button {
+                cellTap(index)
+            } label: {
+                MatrixCell(state: cell, color: habit.color, size: cellSize)
+            }
+            .buttonStyle(.plain)
+        } else {
+            MatrixCell(state: cell, color: habit.color, size: cellSize)
         }
     }
 }

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -147,7 +147,7 @@ struct MonthlyCalendarView: View {
     private func fill(for state: CellState) -> Color {
         switch state {
         case .future: Color(.tertiarySystemFill)
-        case .completed: Color.accentColor.opacity(0.9)
+        case .completed: habit.color.color.opacity(0.9)
         case .missed: Color(.secondarySystemFill)
         case .nonDue: Color(.tertiarySystemFill).opacity(0.4)
         }

--- a/Kado/ViewModels/NewHabitFormModel.swift
+++ b/Kado/ViewModels/NewHabitFormModel.swift
@@ -20,6 +20,9 @@ final class NewHabitFormModel {
     var counterTarget: Double = 1
     var timerTargetMinutes: Int = 10
 
+    var color: HabitColor = .blue
+    var icon: String = HabitIcon.default
+
     /// When non-nil, save mutates this record in place instead of
     /// creating a new one.
     private(set) var editingRecord: HabitRecord?
@@ -68,6 +71,8 @@ final class NewHabitFormModel {
         case .negative:
             self.typeKind = .negative
         }
+        self.color = record.color
+        self.icon = record.icon
     }
 
     var isEditing: Bool { editingRecord != nil }
@@ -120,7 +125,9 @@ final class NewHabitFormModel {
         HabitRecord(
             name: trimmedName,
             frequency: frequency,
-            type: type
+            type: type,
+            color: color,
+            icon: icon
         )
     }
 
@@ -132,6 +139,8 @@ final class NewHabitFormModel {
             record.name = trimmedName
             record.frequency = frequency
             record.type = type
+            record.color = color
+            record.icon = icon
             try? context.save()
             return record
         } else {

--- a/Kado/Views/ContentView.swift
+++ b/Kado/Views/ContentView.swift
@@ -12,6 +12,9 @@ struct ContentView: View {
             Tab("Today", systemImage: "list.bullet.clipboard") {
                 TodayView()
             }
+            Tab("Overview", systemImage: "square.grid.2x2") {
+                OverviewView()
+            }
             Tab("Settings", systemImage: "gearshape") {
                 SettingsView()
             }

--- a/Kado/Views/NewHabit/NewHabitFormView.swift
+++ b/Kado/Views/NewHabit/NewHabitFormView.swift
@@ -17,6 +17,7 @@ struct NewHabitFormView: View {
         NavigationStack {
             Form {
                 nameSection
+                appearanceSection
                 frequencySection
                 typeSection
             }
@@ -43,6 +44,13 @@ struct NewHabitFormView: View {
             TextField(String(localized: "Habit name"), text: $model.name)
                 .focused($nameFocused)
                 .submitLabel(.done)
+        }
+    }
+
+    private var appearanceSection: some View {
+        Section(String(localized: "Appearance")) {
+            HabitColorPicker(selection: $model.color)
+            HabitIconPicker(selection: $model.icon, tint: model.color.color)
         }
     }
 

--- a/Kado/Views/Overview/CellPopoverContent.swift
+++ b/Kado/Views/Overview/CellPopoverContent.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+/// Small popover body that inspects one (habit × day) cell. Shows the
+/// habit identity, the date, the day's state in plain language, and
+/// — for scored cells — the EMA score as a percentage.
+struct CellPopoverContent: View {
+    let habit: Habit
+    let date: Date
+    let cell: DayCell
+    @Environment(\.calendar) private var calendar
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: habit.icon)
+                    .foregroundStyle(habit.color.color)
+                Text(habit.name)
+                    .font(.headline)
+            }
+            Text(formattedDate)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            HStack {
+                Text(stateLabel)
+                    .font(.callout.weight(.medium))
+                Spacer()
+                if let percent = scorePercent {
+                    Text(percent)
+                        .font(.callout.monospacedDigit())
+                        .foregroundStyle(habit.color.color)
+                }
+            }
+        }
+        .padding()
+        .frame(minWidth: 220, maxWidth: 280)
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateStyle = .full
+        return formatter.string(from: date)
+    }
+
+    private var stateLabel: String {
+        switch cell {
+        case .future: String(localized: "Upcoming")
+        case .notDue: String(localized: "Not scheduled")
+        case .scored: String(localized: "Scored")
+        }
+    }
+
+    private var scorePercent: String? {
+        guard case .scored(let s) = cell else { return nil }
+        return "\(Int((s * 100).rounded()))%"
+    }
+}
+
+#Preview("Scored") {
+    CellPopoverContent(
+        habit: Habit(
+            name: "Morning meditation",
+            frequency: .daily,
+            type: .binary,
+            createdAt: .now,
+            color: .purple,
+            icon: "figure.mind.and.body"
+        ),
+        date: .now,
+        cell: .scored(0.72)
+    )
+}
+
+#Preview("Not scheduled") {
+    CellPopoverContent(
+        habit: Habit(
+            name: "Gym",
+            frequency: .specificDays([.monday, .wednesday, .friday]),
+            type: .binary,
+            createdAt: .now,
+            color: .orange,
+            icon: "dumbbell.fill"
+        ),
+        date: .now,
+        cell: .notDue
+    )
+}

--- a/Kado/Views/Overview/CellPopoverContent.swift
+++ b/Kado/Views/Overview/CellPopoverContent.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 /// Small popover body that inspects one (habit × day) cell. Shows the
-/// habit identity, the date, the day's state in plain language, and
-/// — for scored cells — the EMA score as a percentage.
+/// habit identity, the date, and the day's completion status in
+/// plain language. For partial counter/timer completions, adds a
+/// percentage.
 struct CellPopoverContent: View {
     let habit: Habit
     let date: Date
@@ -20,16 +21,8 @@ struct CellPopoverContent: View {
             Text(formattedDate)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
-            HStack {
-                Text(stateLabel)
-                    .font(.callout.weight(.medium))
-                Spacer()
-                if let percent = scorePercent {
-                    Text(percent)
-                        .font(.callout.monospacedDigit())
-                        .foregroundStyle(habit.color.color)
-                }
-            }
+            Text(statusLabel)
+                .font(.callout.weight(.medium))
         }
         .padding()
         .frame(minWidth: 220, maxWidth: 280)
@@ -43,21 +36,26 @@ struct CellPopoverContent: View {
         return formatter.string(from: date)
     }
 
-    private var stateLabel: String {
+    private var statusLabel: String {
         switch cell {
-        case .future: String(localized: "Upcoming")
-        case .notDue: String(localized: "Not scheduled")
-        case .scored: String(localized: "Scored")
+        case .future:
+            return String(localized: "Upcoming")
+        case .notDue:
+            return String(localized: "Not scheduled")
+        case .scored(let s):
+            if s >= 1.0 {
+                return String(localized: "Completed")
+            } else if s <= 0.0 {
+                return String(localized: "Missed")
+            } else {
+                let percent = Int((s * 100).rounded())
+                return String(localized: "\(percent)% complete")
+            }
         }
-    }
-
-    private var scorePercent: String? {
-        guard case .scored(let s) = cell else { return nil }
-        return "\(Int((s * 100).rounded()))%"
     }
 }
 
-#Preview("Scored") {
+#Preview("Completed") {
     CellPopoverContent(
         habit: Habit(
             name: "Morning meditation",
@@ -68,7 +66,37 @@ struct CellPopoverContent: View {
             icon: "figure.mind.and.body"
         ),
         date: .now,
-        cell: .scored(0.72)
+        cell: .scored(1.0)
+    )
+}
+
+#Preview("Partial") {
+    CellPopoverContent(
+        habit: Habit(
+            name: "Drink water",
+            frequency: .daily,
+            type: .counter(target: 8),
+            createdAt: .now,
+            color: .blue,
+            icon: "drop.fill"
+        ),
+        date: .now,
+        cell: .scored(0.5)
+    )
+}
+
+#Preview("Missed") {
+    CellPopoverContent(
+        habit: Habit(
+            name: "Gym",
+            frequency: .specificDays([.monday, .wednesday, .friday]),
+            type: .binary,
+            createdAt: .now,
+            color: .orange,
+            icon: "dumbbell.fill"
+        ),
+        date: .now,
+        cell: .scored(0.0)
     )
 }
 

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -3,11 +3,13 @@ import SwiftUI
 
 /// Overview tab: one card per non-archived habit. Each card stacks
 /// the habit label (icon + name) above a horizontal strip of day
-/// cells covering the last ~30 days. Cards stack vertically so the
-/// large `Overview` title collapses naturally while scrolling, like
-/// Today and Settings. Each card's cell strip owns its own
-/// horizontal scroll (anchored at today on the right); labels stay
-/// put since they live outside the strip.
+/// cells. Cards scroll vertically so the `Overview` nav title
+/// collapses naturally like Today and Settings.
+///
+/// Every cell-strip ScrollView shares one `scrollPosition` binding,
+/// so panning horizontally on any card simultaneously scrolls all
+/// cards. Labels live outside the horizontal scroll region and
+/// therefore stay put.
 struct OverviewView: View {
     @Query(
         filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
@@ -19,6 +21,7 @@ struct OverviewView: View {
     @Environment(\.frequencyEvaluator) private var frequencyEvaluator
 
     @State private var selection: CellSelection?
+    @State private var scrolledDay: Date?
 
     private static let dayWindow = 30
     private static let cellSize: CGFloat = 36
@@ -103,38 +106,45 @@ struct OverviewView: View {
             }
 
             ScrollView(.horizontal, showsIndicators: false) {
-                MatrixRowView(
-                    habit: row.habit,
-                    cells: row.days,
-                    cellSize: Self.cellSize,
-                    cellSpacing: Self.cellSpacing,
-                    cellTap: { index in
-                        guard days.indices.contains(index),
-                              row.days.indices.contains(index) else { return }
-                        selection = CellSelection(
-                            habit: row.habit,
-                            date: days[index],
-                            cell: row.days[index]
+                HStack(spacing: Self.cellSpacing) {
+                    ForEach(Array(zip(days, row.days).enumerated()), id: \.offset) { _, pair in
+                        let (day, cell) = pair
+                        Button {
+                            selection = CellSelection(habit: row.habit, date: day, cell: cell)
+                        } label: {
+                            MatrixCell(
+                                state: cell,
+                                color: row.habit.color,
+                                size: Self.cellSize
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(
+                            Self.accessibilityLabel(
+                                habit: row.habit,
+                                date: day,
+                                cell: cell,
+                                calendar: calendar
+                            )
                         )
-                    },
-                    cellAccessibilityLabel: { index in
-                        guard days.indices.contains(index),
-                              row.days.indices.contains(index) else { return "" }
-                        return Self.accessibilityLabel(
-                            habit: row.habit,
-                            date: days[index],
-                            cell: row.days[index],
-                            calendar: calendar
-                        )
+                        .id(day)
                     }
-                )
+                }
+                .scrollTargetLayout()
                 .padding(.vertical, 2)
             }
-            .defaultScrollAnchor(.trailing)
+            .scrollPosition(id: $scrolledDay, anchor: .trailing)
         }
         .padding(12)
         .background(Color(.secondarySystemGroupedBackground))
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .onAppear {
+            // Anchor every card at today on first appearance; subsequent
+            // pans update the shared binding, syncing all cards.
+            if scrolledDay == nil {
+                scrolledDay = days.last
+            }
+        }
     }
 
     private func dayRange(endingAt today: Date) -> [Date] {

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -89,14 +89,27 @@ struct OverviewView: View {
             }
             .padding(.vertical, 8)
         }
-        .popover(item: $selection) { sel in
-            CellPopoverContent(
-                habit: sel.habit,
-                date: sel.date,
-                cell: sel.cell
-            )
-            .presentationCompactAdaptation(.popover)
-        }
+    }
+
+    /// Binding that reflects whether a specific (habit, date) cell is
+    /// the currently selected one. Used to attach `.popover` per-cell
+    /// so the popover anchors to the tapped button rather than the
+    /// whole matrix.
+    private func selectionBinding(habit: Habit, date: Date) -> Binding<Bool> {
+        Binding(
+            get: {
+                guard let sel = selection else { return false }
+                return sel.habit.id == habit.id && sel.date == date
+            },
+            set: { newValue in
+                if !newValue,
+                   let sel = selection,
+                   sel.habit.id == habit.id,
+                   sel.date == date {
+                    selection = nil
+                }
+            }
+        )
     }
 
     private func scrollingCells(rows: [MatrixRow], days: [Date]) -> some View {
@@ -179,6 +192,10 @@ struct OverviewView: View {
                         calendar: calendar
                     )
                 )
+                .popover(isPresented: selectionBinding(habit: row.habit, date: day)) {
+                    CellPopoverContent(habit: row.habit, date: day, cell: cell)
+                        .presentationCompactAdaptation(.popover)
+                }
             }
         }
         .frame(height: Self.cellSize)

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -133,18 +133,12 @@ struct OverviewView: View {
                 .scrollTargetLayout()
                 .padding(.vertical, 2)
             }
-            .scrollPosition(id: $scrolledDay, anchor: .trailing)
+            .defaultScrollAnchor(.trailing)
+            .scrollPosition(id: $scrolledDay)
         }
         .padding(12)
         .background(Color(.secondarySystemGroupedBackground))
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-        .onAppear {
-            // Anchor every card at today on first appearance; subsequent
-            // pans update the shared binding, syncing all cards.
-            if scrolledDay == nil {
-                scrolledDay = days.last
-            }
-        }
     }
 
     private func dayRange(endingAt today: Date) -> [Date] {

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -30,7 +30,9 @@ struct OverviewView: View {
     private static let cellSize: CGFloat = 36
     private static let cellSpacing: CGFloat = 6
     private static let labelHeight: CGFloat = 28
-    private static let rowGap: CGFloat = 8
+    private static let labelBottomPadding: CGFloat = 8
+    private static let rowGap: CGFloat = 12
+    private static let headerHeight: CGFloat = 40
 
     struct CellSelection: Identifiable, Equatable {
         let habit: Habit
@@ -100,9 +102,19 @@ struct OverviewView: View {
     private func scrollingCells(rows: [MatrixRow], days: [Date]) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 0) {
+                // Date column headers — scroll horizontally with the cells.
+                HStack(spacing: Self.cellSpacing) {
+                    ForEach(days, id: \.self) { day in
+                        DayColumnHeader(date: day, width: Self.cellSize)
+                    }
+                }
+                .frame(height: Self.headerHeight)
+
+                Color.clear.frame(height: Self.rowGap)
+
                 ForEach(rows, id: \.habit.id) { row in
-                    // Transparent spacer where the label will overlay.
-                    Color.clear.frame(height: Self.labelHeight)
+                    // Transparent spacer where the label + padding overlay.
+                    Color.clear.frame(height: Self.labelHeight + Self.labelBottomPadding)
                     cellRow(row, days: days)
                     if row.habit.id != rows.last?.habit.id {
                         Color.clear.frame(height: Self.rowGap)
@@ -116,6 +128,10 @@ struct OverviewView: View {
 
     private func labelsOverlay(rows: [MatrixRow]) -> some View {
         VStack(alignment: .leading, spacing: 0) {
+            // Match the date-header row + its trailing gap so the first
+            // label lands in the first habit's spacer slot.
+            Color.clear.frame(height: Self.headerHeight + Self.rowGap)
+
             ForEach(rows, id: \.habit.id) { row in
                 HStack(spacing: 8) {
                     Image(systemName: row.habit.icon)
@@ -128,9 +144,10 @@ struct OverviewView: View {
                 }
                 .frame(height: Self.labelHeight, alignment: .leading)
 
-                // Spacer matching the cell row so the next label lands
-                // above that habit's cell row.
-                Color.clear.frame(height: Self.cellSize)
+                // Spacer for the breathing room below the name + the
+                // cell row itself, so the next label lines up with the
+                // next habit's spacer slot.
+                Color.clear.frame(height: Self.labelBottomPadding + Self.cellSize)
                 if row.habit.id != rows.last?.habit.id {
                     Color.clear.frame(height: Self.rowGap)
                 }

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -1,15 +1,13 @@
 import SwiftData
 import SwiftUI
 
-/// Overview tab: a habits × days matrix. Each row is one non-archived
-/// habit; each column is one of the last ~30 days; each cell is
-/// tinted by the habit's color at an opacity derived from its EMA
-/// score that day.
-///
-/// Layout: sticky left column (habit icon + name) outside the
-/// horizontal scroll view; the scrolling region contains day-column
-/// headers plus one row of cells per habit. Initial scroll position
-/// anchors at today (newest-on-right, scroll left into history).
+/// Overview tab: one card per non-archived habit. Each card stacks
+/// the habit label (icon + name) above a horizontal strip of day
+/// cells covering the last ~30 days. Cards stack vertically so the
+/// large `Overview` title collapses naturally while scrolling, like
+/// Today and Settings. Each card's cell strip owns its own
+/// horizontal scroll (anchored at today on the right); labels stay
+/// put since they live outside the strip.
 struct OverviewView: View {
     @Query(
         filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
@@ -23,11 +21,8 @@ struct OverviewView: View {
     @State private var selection: CellSelection?
 
     private static let dayWindow = 30
-    private static let cellSize: CGFloat = 32
-    private static let cellSpacing: CGFloat = 4
-    private static let labelWidth: CGFloat = 130
-    private static let headerHeight: CGFloat = 36
-    private static let rowHeight: CGFloat = 32
+    private static let cellSize: CGFloat = 36
+    private static let cellSpacing: CGFloat = 6
 
     struct CellSelection: Identifiable, Equatable {
         let habit: Habit
@@ -39,14 +34,17 @@ struct OverviewView: View {
 
     var body: some View {
         NavigationStack {
-            Group {
-                if records.isEmpty {
-                    emptyState
-                } else {
-                    matrix
-                }
-            }
-            .navigationTitle("Overview")
+            content
+                .navigationTitle("Overview")
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if records.isEmpty {
+            emptyState
+        } else {
+            matrix
         }
     }
 
@@ -58,14 +56,13 @@ struct OverviewView: View {
         )
     }
 
-    @ViewBuilder
     private var matrix: some View {
+        let today = calendar.startOfDay(for: .now)
+        let days = dayRange(endingAt: today)
         let habits = records.map { $0.snapshot }
         let completions = records.flatMap {
             ($0.completions ?? []).map { $0.snapshot }
         }
-        let today = calendar.startOfDay(for: .now)
-        let days = dayRange(endingAt: today)
         let rows = OverviewMatrix.compute(
             habits: habits,
             completions: completions,
@@ -75,20 +72,14 @@ struct OverviewView: View {
             frequencyEvaluator: frequencyEvaluator
         )
 
-        HStack(alignment: .top, spacing: 8) {
-            stickyLabelColumn(rows: rows)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                VStack(alignment: .leading, spacing: Self.cellSpacing) {
-                    dayHeaderRow(days: days)
-                    ForEach(rows, id: \.habit.id) { row in
-                        cellRow(row, days: days)
-                    }
+        return ScrollView(.vertical) {
+            LazyVStack(spacing: 12) {
+                ForEach(rows, id: \.habit.id) { row in
+                    habitCard(row, days: days)
                 }
             }
-            .defaultScrollAnchor(.trailing)
+            .padding()
         }
-        .padding()
         .popover(item: $selection) { sel in
             CellPopoverContent(
                 habit: sel.habit,
@@ -99,52 +90,57 @@ struct OverviewView: View {
         }
     }
 
-    private func stickyLabelColumn(rows: [MatrixRow]) -> some View {
-        VStack(alignment: .leading, spacing: Self.cellSpacing) {
-            Color.clear.frame(height: Self.headerHeight)
-            ForEach(rows, id: \.habit.id) { row in
-                HabitRowLabel(habit: row.habit, height: Self.rowHeight)
+    private func habitCard(_ row: MatrixRow, days: [Date]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: row.habit.icon)
+                    .font(.callout.weight(.semibold))
+                    .foregroundStyle(row.habit.color.color)
+                Text(row.habit.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                MatrixRowView(
+                    habit: row.habit,
+                    cells: row.days,
+                    cellSize: Self.cellSize,
+                    cellSpacing: Self.cellSpacing,
+                    cellTap: { index in
+                        guard days.indices.contains(index),
+                              row.days.indices.contains(index) else { return }
+                        selection = CellSelection(
+                            habit: row.habit,
+                            date: days[index],
+                            cell: row.days[index]
+                        )
+                    },
+                    cellAccessibilityLabel: { index in
+                        guard days.indices.contains(index),
+                              row.days.indices.contains(index) else { return "" }
+                        return Self.accessibilityLabel(
+                            habit: row.habit,
+                            date: days[index],
+                            cell: row.days[index],
+                            calendar: calendar
+                        )
+                    }
+                )
+                .padding(.vertical, 2)
+            }
+            .defaultScrollAnchor(.trailing)
         }
-        .frame(width: Self.labelWidth, alignment: .leading)
+        .padding(12)
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 
-    private func dayHeaderRow(days: [Date]) -> some View {
-        HStack(spacing: Self.cellSpacing) {
-            ForEach(days, id: \.self) { day in
-                DayColumnHeader(date: day, width: Self.cellSize)
-            }
+    private func dayRange(endingAt today: Date) -> [Date] {
+        (0..<Self.dayWindow).reversed().compactMap { offset in
+            calendar.date(byAdding: .day, value: -offset, to: today)
         }
-        .frame(height: Self.headerHeight)
-    }
-
-    private func cellRow(_ row: MatrixRow, days: [Date]) -> some View {
-        MatrixRowView(
-            habit: row.habit,
-            cells: row.days,
-            cellSize: Self.cellSize,
-            cellSpacing: Self.cellSpacing,
-            cellTap: { index in
-                guard days.indices.contains(index),
-                      row.days.indices.contains(index) else { return }
-                selection = CellSelection(
-                    habit: row.habit,
-                    date: days[index],
-                    cell: row.days[index]
-                )
-            },
-            cellAccessibilityLabel: { index in
-                guard days.indices.contains(index),
-                      row.days.indices.contains(index) else { return "" }
-                return Self.accessibilityLabel(
-                    habit: row.habit,
-                    date: days[index],
-                    cell: row.days[index],
-                    calendar: calendar
-                )
-            }
-        )
-        .frame(height: Self.rowHeight)
     }
 
     /// Composes a per-cell VoiceOver label:
@@ -178,12 +174,6 @@ struct OverviewView: View {
             }
         }
         return "\(habit.name), \(dateString), \(state)"
-    }
-
-    private func dayRange(endingAt today: Date) -> [Date] {
-        (0..<Self.dayWindow).reversed().compactMap { offset in
-            calendar.date(byAdding: .day, value: -offset, to: today)
-        }
     }
 }
 

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -1,0 +1,141 @@
+import SwiftData
+import SwiftUI
+
+/// Overview tab: a habits × days matrix. Each row is one non-archived
+/// habit; each column is one of the last ~30 days; each cell is
+/// tinted by the habit's color at an opacity derived from its EMA
+/// score that day.
+///
+/// Layout: sticky left column (habit icon + name) outside the
+/// horizontal scroll view; the scrolling region contains day-column
+/// headers plus one row of cells per habit. Initial scroll position
+/// anchors at today (newest-on-right, scroll left into history).
+struct OverviewView: View {
+    @Query(
+        filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
+        sort: \HabitRecord.createdAt
+    )
+    private var records: [HabitRecord]
+
+    @Environment(\.calendar) private var calendar
+    @Environment(\.habitScoreCalculator) private var scoreCalculator
+    @Environment(\.frequencyEvaluator) private var frequencyEvaluator
+
+    private static let dayWindow = 30
+    private static let cellSize: CGFloat = 32
+    private static let cellSpacing: CGFloat = 4
+    private static let labelWidth: CGFloat = 130
+    private static let headerHeight: CGFloat = 36
+    private static let rowHeight: CGFloat = 32
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if records.isEmpty {
+                    emptyState
+                } else {
+                    matrix
+                }
+            }
+            .navigationTitle("Overview")
+        }
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No habits yet",
+            systemImage: "square.grid.2x2",
+            description: Text("Create habits from the Today tab to see them here.")
+        )
+    }
+
+    @ViewBuilder
+    private var matrix: some View {
+        let habits = records.map { $0.snapshot }
+        let completions = records.flatMap {
+            ($0.completions ?? []).map { $0.snapshot }
+        }
+        let today = calendar.startOfDay(for: .now)
+        let days = dayRange(endingAt: today)
+        let rows = OverviewMatrix.compute(
+            habits: habits,
+            completions: completions,
+            days: days,
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+
+        HStack(alignment: .top, spacing: 8) {
+            stickyLabelColumn(rows: rows)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: Self.cellSpacing) {
+                    dayHeaderRow(days: days)
+                    ForEach(rows, id: \.habit.id) { row in
+                        cellRow(row)
+                    }
+                }
+            }
+            .defaultScrollAnchor(.trailing)
+        }
+        .padding()
+    }
+
+    private func stickyLabelColumn(rows: [MatrixRow]) -> some View {
+        VStack(alignment: .leading, spacing: Self.cellSpacing) {
+            Color.clear.frame(height: Self.headerHeight)
+            ForEach(rows, id: \.habit.id) { row in
+                HabitRowLabel(habit: row.habit, height: Self.rowHeight)
+            }
+        }
+        .frame(width: Self.labelWidth, alignment: .leading)
+    }
+
+    private func dayHeaderRow(days: [Date]) -> some View {
+        HStack(spacing: Self.cellSpacing) {
+            ForEach(days, id: \.self) { day in
+                DayColumnHeader(date: day, width: Self.cellSize)
+            }
+        }
+        .frame(height: Self.headerHeight)
+    }
+
+    private func cellRow(_ row: MatrixRow) -> some View {
+        HStack(spacing: Self.cellSpacing) {
+            ForEach(Array(row.days.enumerated()), id: \.offset) { _, cell in
+                MatrixCell(state: cell, color: row.habit.color, size: Self.cellSize)
+            }
+        }
+        .frame(height: Self.rowHeight)
+    }
+
+    private func dayRange(endingAt today: Date) -> [Date] {
+        (0..<Self.dayWindow).reversed().compactMap { offset in
+            calendar.date(byAdding: .day, value: -offset, to: today)
+        }
+    }
+}
+
+#Preview("Populated") {
+    OverviewView()
+        .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("Empty") {
+    OverviewView()
+        .modelContainer(PreviewContainer.emptyContainer())
+}
+
+#Preview("Dark") {
+    OverviewView()
+        .modelContainer(PreviewContainer.shared)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Dynamic Type XXXL") {
+    OverviewView()
+        .modelContainer(PreviewContainer.shared)
+        .environment(\.dynamicTypeSize, .accessibility3)
+}

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -134,9 +134,46 @@ struct OverviewView: View {
                     date: days[index],
                     cell: row.days[index]
                 )
+            },
+            cellAccessibilityLabel: { index in
+                guard days.indices.contains(index),
+                      row.days.indices.contains(index) else { return "" }
+                return Self.accessibilityLabel(
+                    habit: row.habit,
+                    date: days[index],
+                    cell: row.days[index],
+                    calendar: calendar
+                )
             }
         )
         .frame(height: Self.rowHeight)
+    }
+
+    /// Composes a per-cell VoiceOver label:
+    /// `"{habit}, {localized date}, {state}[, score {pct}%]"`.
+    private static func accessibilityLabel(
+        habit: Habit,
+        date: Date,
+        cell: DayCell,
+        calendar: Calendar
+    ) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateStyle = .full
+        let dateString = formatter.string(from: date)
+
+        let state: String
+        switch cell {
+        case .future:
+            state = String(localized: "upcoming")
+        case .notDue:
+            state = String(localized: "not scheduled")
+        case .scored(let s):
+            let percent = Int((s * 100).rounded())
+            state = String(localized: "score \(percent)%")
+        }
+        return "\(habit.name), \(dateString), \(state)"
     }
 
     private func dayRange(endingAt today: Date) -> [Date] {

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -18,7 +18,6 @@ struct OverviewView: View {
     private var records: [HabitRecord]
 
     @Environment(\.calendar) private var calendar
-    @Environment(\.habitScoreCalculator) private var scoreCalculator
     @Environment(\.frequencyEvaluator) private var frequencyEvaluator
 
     @State private var selection: CellSelection?
@@ -73,7 +72,6 @@ struct OverviewView: View {
             days: days,
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
 
@@ -150,7 +148,7 @@ struct OverviewView: View {
     }
 
     /// Composes a per-cell VoiceOver label:
-    /// `"{habit}, {localized date}, {state}[, score {pct}%]"`.
+    /// `"{habit}, {localized date}, {state}"`.
     private static func accessibilityLabel(
         habit: Habit,
         date: Date,
@@ -170,8 +168,14 @@ struct OverviewView: View {
         case .notDue:
             state = String(localized: "not scheduled")
         case .scored(let s):
-            let percent = Int((s * 100).rounded())
-            state = String(localized: "score \(percent)%")
+            if s >= 1.0 {
+                state = String(localized: "completed")
+            } else if s <= 0.0 {
+                state = String(localized: "missed")
+            } else {
+                let percent = Int((s * 100).rounded())
+                state = String(localized: "\(percent)% complete")
+            }
         }
         return "\(habit.name), \(dateString), \(state)"
     }

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -3,18 +3,17 @@ import SwiftUI
 
 /// Overview tab: habits × days matrix.
 ///
-/// Layout:
-/// - Outer vertical `ScrollView` so the large `Overview` title
-///   collapses as on Today and Settings.
-/// - Inside, an `HStack(alignment: .top)`:
-///   - Leading column (pinned): habit icon + name per row. Sits
-///     outside the horizontal scroll so it stays put.
-///   - Trailing column: a single `ScrollView(.horizontal)` wrapping
-///     a `VStack` of cell rows. One scroll view → one scroll state
-///     → every row moves together. Anchored at today via
-///     `defaultScrollAnchor(.trailing)`.
-/// - Row heights match between the labels column and the cells
-///   column so the two stay aligned visually.
+/// Layout (single horizontal scroll):
+/// - One full-width `ScrollView(.horizontal)` holds a VStack that,
+///   per habit, alternates a clear "name" spacer and a cells row.
+///   Every cell row moves together because there's only one scroll
+///   state.
+/// - A sibling VStack overlays the scroll view with the habit
+///   labels, positioned over the clear spacer rows. It has a
+///   transparent background and `.allowsHitTesting(false)` so the
+///   scroll + cell taps still reach the layer below.
+/// - Outer `ScrollView(.vertical)` keeps the "Overview" title
+///   collapsing like Today and Settings.
 struct OverviewView: View {
     @Query(
         filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
@@ -30,8 +29,8 @@ struct OverviewView: View {
     private static let dayWindow = 30
     private static let cellSize: CGFloat = 36
     private static let cellSpacing: CGFloat = 6
-    private static let rowSpacing: CGFloat = 8
-    private static let labelWidth: CGFloat = 130
+    private static let labelHeight: CGFloat = 28
+    private static let rowGap: CGFloat = 8
 
     struct CellSelection: Identifiable, Equatable {
         let habit: Habit
@@ -82,12 +81,11 @@ struct OverviewView: View {
         )
 
         return ScrollView(.vertical) {
-            HStack(alignment: .top, spacing: 12) {
-                labelsColumn(rows: rows)
-                cellsScrollView(rows: rows, days: days)
+            ZStack(alignment: .topLeading) {
+                scrollingCells(rows: rows, days: days)
+                labelsOverlay(rows: rows)
             }
-            .padding(.horizontal)
-            .padding(.top, 8)
+            .padding(.vertical, 8)
         }
         .popover(item: $selection) { sel in
             CellPopoverContent(
@@ -99,35 +97,47 @@ struct OverviewView: View {
         }
     }
 
-    private func labelsColumn(rows: [MatrixRow]) -> some View {
-        VStack(alignment: .leading, spacing: Self.rowSpacing) {
+    private func scrollingCells(rows: [MatrixRow], days: [Date]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(rows, id: \.habit.id) { row in
+                    // Transparent spacer where the label will overlay.
+                    Color.clear.frame(height: Self.labelHeight)
+                    cellRow(row, days: days)
+                    if row.habit.id != rows.last?.habit.id {
+                        Color.clear.frame(height: Self.rowGap)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+        }
+        .defaultScrollAnchor(.trailing)
+    }
+
+    private func labelsOverlay(rows: [MatrixRow]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
             ForEach(rows, id: \.habit.id) { row in
                 HStack(spacing: 8) {
                     Image(systemName: row.habit.icon)
                         .font(.callout.weight(.semibold))
                         .foregroundStyle(row.habit.color.color)
-                        .frame(width: 22)
                     Text(row.habit.name)
-                        .font(.subheadline)
+                        .font(.subheadline.weight(.medium))
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
-                .frame(height: Self.cellSize, alignment: .leading)
-            }
-        }
-        .frame(width: Self.labelWidth, alignment: .leading)
-    }
+                .frame(height: Self.labelHeight, alignment: .leading)
 
-    private func cellsScrollView(rows: [MatrixRow], days: [Date]) -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            VStack(alignment: .leading, spacing: Self.rowSpacing) {
-                ForEach(rows, id: \.habit.id) { row in
-                    cellRow(row, days: days)
+                // Spacer matching the cell row so the next label lands
+                // above that habit's cell row.
+                Color.clear.frame(height: Self.cellSize)
+                if row.habit.id != rows.last?.habit.id {
+                    Color.clear.frame(height: Self.rowGap)
                 }
             }
-            .padding(.trailing, 8)
         }
-        .defaultScrollAnchor(.trailing)
+        .padding(.horizontal, 16)
+        .allowsHitTesting(false)
     }
 
     private func cellRow(_ row: MatrixRow, days: [Date]) -> some View {

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -1,15 +1,20 @@
 import SwiftData
 import SwiftUI
 
-/// Overview tab: one card per non-archived habit. Each card stacks
-/// the habit label (icon + name) above a horizontal strip of day
-/// cells. Cards scroll vertically so the `Overview` nav title
-/// collapses naturally like Today and Settings.
+/// Overview tab: habits × days matrix.
 ///
-/// Every cell-strip ScrollView shares one `scrollPosition` binding,
-/// so panning horizontally on any card simultaneously scrolls all
-/// cards. Labels live outside the horizontal scroll region and
-/// therefore stay put.
+/// Layout:
+/// - Outer vertical `ScrollView` so the large `Overview` title
+///   collapses as on Today and Settings.
+/// - Inside, an `HStack(alignment: .top)`:
+///   - Leading column (pinned): habit icon + name per row. Sits
+///     outside the horizontal scroll so it stays put.
+///   - Trailing column: a single `ScrollView(.horizontal)` wrapping
+///     a `VStack` of cell rows. One scroll view → one scroll state
+///     → every row moves together. Anchored at today via
+///     `defaultScrollAnchor(.trailing)`.
+/// - Row heights match between the labels column and the cells
+///   column so the two stay aligned visually.
 struct OverviewView: View {
     @Query(
         filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
@@ -21,11 +26,12 @@ struct OverviewView: View {
     @Environment(\.frequencyEvaluator) private var frequencyEvaluator
 
     @State private var selection: CellSelection?
-    @State private var scrolledDay: Date?
 
     private static let dayWindow = 30
     private static let cellSize: CGFloat = 36
     private static let cellSpacing: CGFloat = 6
+    private static let rowSpacing: CGFloat = 8
+    private static let labelWidth: CGFloat = 130
 
     struct CellSelection: Identifiable, Equatable {
         let habit: Habit
@@ -76,12 +82,12 @@ struct OverviewView: View {
         )
 
         return ScrollView(.vertical) {
-            LazyVStack(spacing: 12) {
-                ForEach(rows, id: \.habit.id) { row in
-                    habitCard(row, days: days)
-                }
+            HStack(alignment: .top, spacing: 12) {
+                labelsColumn(rows: rows)
+                cellsScrollView(rows: rows, days: days)
             }
-            .padding()
+            .padding(.horizontal)
+            .padding(.top, 8)
         }
         .popover(item: $selection) { sel in
             CellPopoverContent(
@@ -93,52 +99,62 @@ struct OverviewView: View {
         }
     }
 
-    private func habitCard(_ row: MatrixRow, days: [Date]) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                Image(systemName: row.habit.icon)
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(row.habit.color.color)
-                Text(row.habit.name)
-                    .font(.headline)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Self.cellSpacing) {
-                    ForEach(Array(zip(days, row.days).enumerated()), id: \.offset) { _, pair in
-                        let (day, cell) = pair
-                        Button {
-                            selection = CellSelection(habit: row.habit, date: day, cell: cell)
-                        } label: {
-                            MatrixCell(
-                                state: cell,
-                                color: row.habit.color,
-                                size: Self.cellSize
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel(
-                            Self.accessibilityLabel(
-                                habit: row.habit,
-                                date: day,
-                                cell: cell,
-                                calendar: calendar
-                            )
-                        )
-                        .id(day)
-                    }
+    private func labelsColumn(rows: [MatrixRow]) -> some View {
+        VStack(alignment: .leading, spacing: Self.rowSpacing) {
+            ForEach(rows, id: \.habit.id) { row in
+                HStack(spacing: 8) {
+                    Image(systemName: row.habit.icon)
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(row.habit.color.color)
+                        .frame(width: 22)
+                    Text(row.habit.name)
+                        .font(.subheadline)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
-                .scrollTargetLayout()
-                .padding(.vertical, 2)
+                .frame(height: Self.cellSize, alignment: .leading)
             }
-            .defaultScrollAnchor(.trailing)
-            .scrollPosition(id: $scrolledDay)
         }
-        .padding(12)
-        .background(Color(.secondarySystemGroupedBackground))
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .frame(width: Self.labelWidth, alignment: .leading)
+    }
+
+    private func cellsScrollView(rows: [MatrixRow], days: [Date]) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: Self.rowSpacing) {
+                ForEach(rows, id: \.habit.id) { row in
+                    cellRow(row, days: days)
+                }
+            }
+            .padding(.trailing, 8)
+        }
+        .defaultScrollAnchor(.trailing)
+    }
+
+    private func cellRow(_ row: MatrixRow, days: [Date]) -> some View {
+        HStack(spacing: Self.cellSpacing) {
+            ForEach(Array(zip(days, row.days).enumerated()), id: \.offset) { _, pair in
+                let (day, cell) = pair
+                Button {
+                    selection = CellSelection(habit: row.habit, date: day, cell: cell)
+                } label: {
+                    MatrixCell(
+                        state: cell,
+                        color: row.habit.color,
+                        size: Self.cellSize
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(
+                    Self.accessibilityLabel(
+                        habit: row.habit,
+                        date: day,
+                        cell: cell,
+                        calendar: calendar
+                    )
+                )
+            }
+        }
+        .frame(height: Self.cellSize)
     }
 
     private func dayRange(endingAt today: Date) -> [Date] {

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -21,12 +21,22 @@ struct OverviewView: View {
     @Environment(\.habitScoreCalculator) private var scoreCalculator
     @Environment(\.frequencyEvaluator) private var frequencyEvaluator
 
+    @State private var selection: CellSelection?
+
     private static let dayWindow = 30
     private static let cellSize: CGFloat = 32
     private static let cellSpacing: CGFloat = 4
     private static let labelWidth: CGFloat = 130
     private static let headerHeight: CGFloat = 36
     private static let rowHeight: CGFloat = 32
+
+    struct CellSelection: Identifiable, Equatable {
+        let habit: Habit
+        let date: Date
+        let cell: DayCell
+
+        var id: String { "\(habit.id)-\(date.timeIntervalSince1970)" }
+    }
 
     var body: some View {
         NavigationStack {
@@ -74,13 +84,21 @@ struct OverviewView: View {
                 VStack(alignment: .leading, spacing: Self.cellSpacing) {
                     dayHeaderRow(days: days)
                     ForEach(rows, id: \.habit.id) { row in
-                        cellRow(row)
+                        cellRow(row, days: days)
                     }
                 }
             }
             .defaultScrollAnchor(.trailing)
         }
         .padding()
+        .popover(item: $selection) { sel in
+            CellPopoverContent(
+                habit: sel.habit,
+                date: sel.date,
+                cell: sel.cell
+            )
+            .presentationCompactAdaptation(.popover)
+        }
     }
 
     private func stickyLabelColumn(rows: [MatrixRow]) -> some View {
@@ -102,12 +120,22 @@ struct OverviewView: View {
         .frame(height: Self.headerHeight)
     }
 
-    private func cellRow(_ row: MatrixRow) -> some View {
-        HStack(spacing: Self.cellSpacing) {
-            ForEach(Array(row.days.enumerated()), id: \.offset) { _, cell in
-                MatrixCell(state: cell, color: row.habit.color, size: Self.cellSize)
+    private func cellRow(_ row: MatrixRow, days: [Date]) -> some View {
+        MatrixRowView(
+            habit: row.habit,
+            cells: row.days,
+            cellSize: Self.cellSize,
+            cellSpacing: Self.cellSpacing,
+            cellTap: { index in
+                guard days.indices.contains(index),
+                      row.days.indices.contains(index) else { return }
+                selection = CellSelection(
+                    habit: row.habit,
+                    date: days[index],
+                    cell: row.days[index]
+                )
             }
-        }
+        )
         .frame(height: Self.rowHeight)
     }
 

--- a/KadoTests/CloudKitShapeTests.swift
+++ b/KadoTests/CloudKitShapeTests.swift
@@ -12,33 +12,42 @@ import Testing
 /// first time `cloudKitDatabase:` is set — and only then; a
 /// local-only container happily mounts the same schema.
 ///
-/// These regression tests pin the current schema shape so a future
-/// commit adding a required relationship or a unique attribute
+/// These regression tests pin every shipped schema version so a
+/// future commit adding a required relationship or a unique attribute
 /// fails fast in CI instead of at first launch under CloudKit.
 @MainActor
 struct CloudKitShapeTests {
-    @Test("KadoSchemaV1: every relationship is optional")
+    private static func shippedSchemas() -> [(String, Schema)] {
+        [
+            ("V1", Schema(versionedSchema: KadoSchemaV1.self)),
+            ("V2", Schema(versionedSchema: KadoSchemaV2.self)),
+        ]
+    }
+
+    @Test("Every shipped schema keeps all relationships optional")
     func allRelationshipsOptional() {
-        let schema = Schema(versionedSchema: KadoSchemaV1.self)
-        for entity in schema.entities {
-            for relationship in entity.relationships {
-                #expect(
-                    relationship.isOptional,
-                    "\(entity.name).\(relationship.name) must be optional for CloudKit"
-                )
+        for (label, schema) in Self.shippedSchemas() {
+            for entity in schema.entities {
+                for relationship in entity.relationships {
+                    #expect(
+                        relationship.isOptional,
+                        "\(label) \(entity.name).\(relationship.name) must be optional for CloudKit"
+                    )
+                }
             }
         }
     }
 
-    @Test("KadoSchemaV1: no attribute is marked unique")
+    @Test("Every shipped schema keeps all attributes non-unique")
     func noUniqueAttributes() {
-        let schema = Schema(versionedSchema: KadoSchemaV1.self)
-        for entity in schema.entities {
-            for attribute in entity.attributes {
-                #expect(
-                    !attribute.isUnique,
-                    "\(entity.name).\(attribute.name) must not be @Attribute(.unique) for CloudKit"
-                )
+        for (label, schema) in Self.shippedSchemas() {
+            for entity in schema.entities {
+                for attribute in entity.attributes {
+                    #expect(
+                        !attribute.isUnique,
+                        "\(label) \(entity.name).\(attribute.name) must not be @Attribute(.unique) for CloudKit"
+                    )
+                }
             }
         }
     }
@@ -50,6 +59,8 @@ struct CloudKitShapeTests {
         #expect(record.frequency == .daily)
         #expect(record.type == .binary)
         #expect(record.archivedAt == nil)
+        #expect(record.color == .blue)
+        #expect(record.icon == HabitIcon.default)
         #expect(record.completions?.isEmpty ?? true)
     }
 

--- a/KadoTests/DevModeControllerTests.swift
+++ b/KadoTests/DevModeControllerTests.swift
@@ -13,7 +13,7 @@ struct DevModeControllerTests {
         let storeURL = tempDir.appendingPathComponent("KadoDev.sqlite")
 
         let factory: () -> ModelContainer = {
-            let schema = Schema(versionedSchema: KadoSchemaV1.self)
+            let schema = Schema(versionedSchema: KadoSchemaV2.self)
             return try! ModelContainer(
                 for: schema,
                 migrationPlan: KadoMigrationPlan.self,

--- a/KadoTests/HabitColorTests.swift
+++ b/KadoTests/HabitColorTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import Kado
+
+@Suite("HabitColor palette")
+struct HabitColorTests {
+    @Test("Palette exposes eight distinct cases")
+    func paletteSize() {
+        #expect(HabitColor.allCases.count == 8)
+        #expect(Set(HabitColor.allCases).count == 8)
+    }
+
+    @Test("Raw values match case names (stable for migration)")
+    func rawValuesStable() {
+        let expected: [(HabitColor, String)] = [
+            (.red, "red"),
+            (.orange, "orange"),
+            (.yellow, "yellow"),
+            (.green, "green"),
+            (.mint, "mint"),
+            (.teal, "teal"),
+            (.blue, "blue"),
+            (.purple, "purple"),
+        ]
+        for (value, raw) in expected {
+            #expect(value.rawValue == raw)
+        }
+    }
+}

--- a/KadoTests/HabitIconTests.swift
+++ b/KadoTests/HabitIconTests.swift
@@ -1,0 +1,15 @@
+import Testing
+@testable import Kado
+
+@Suite("HabitIcon catalog")
+struct HabitIconTests {
+    @Test("Curated list has no duplicate symbol names")
+    func noDuplicates() {
+        #expect(Set(HabitIcon.curated).count == HabitIcon.curated.count)
+    }
+
+    @Test("Curated list has at least 20 entries")
+    func minimumSize() {
+        #expect(HabitIcon.curated.count >= 20)
+    }
+}

--- a/KadoTests/KadoSchemaTests.swift
+++ b/KadoTests/KadoSchemaTests.swift
@@ -3,40 +3,73 @@ import Foundation
 import SwiftData
 @testable import Kado
 
-@Suite("KadoSchemaV1 + KadoMigrationPlan")
+@Suite("KadoSchema + KadoMigrationPlan")
 @MainActor
 struct KadoSchemaTests {
-    @Test("Schema version identifier is 1.0.0")
-    func schemaVersion() {
+    @Test("V1 version identifier is 1.0.0")
+    func v1Version() {
         #expect(KadoSchemaV1.versionIdentifier == Schema.Version(1, 0, 0))
     }
 
-    @Test("Schema declares HabitRecord and CompletionRecord")
-    func schemaModels() {
-        let modelTypes = KadoSchemaV1.models
-        #expect(modelTypes.contains { $0 == HabitRecord.self })
-        #expect(modelTypes.contains { $0 == CompletionRecord.self })
+    @Test("V2 version identifier is 2.0.0")
+    func v2Version() {
+        #expect(KadoSchemaV2.versionIdentifier == Schema.Version(2, 0, 0))
     }
 
-    @Test("Migration plan declares v1 with empty stages")
+    @Test("Migration plan declares V1 → V2 lightweight stage")
     func migrationPlanShape() {
-        #expect(KadoMigrationPlan.stages.isEmpty)
-        #expect(KadoMigrationPlan.schemas.count == 1)
+        #expect(KadoMigrationPlan.schemas.count == 2)
+        #expect(KadoMigrationPlan.stages.count == 1)
     }
 
-    @Test("In-memory ModelContainer constructs from the migration plan")
+    @Test("In-memory ModelContainer constructs from the current (V2) schema")
     func containerBuildsFromPlan() throws {
-        let schema = Schema(versionedSchema: KadoSchemaV1.self)
+        let schema = Schema(versionedSchema: KadoSchemaV2.self)
         let container = try ModelContainer(
             for: schema,
             migrationPlan: KadoMigrationPlan.self,
             configurations: ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         )
-        // Smoke test: the main context exists and accepts inserts.
         let habit = HabitRecord(name: "Smoke")
         container.mainContext.insert(habit)
         try container.mainContext.save()
         let fetched = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
         #expect(fetched.count == 1)
+    }
+
+    @Test("Lightweight migration from V1 populates default color and icon")
+    func v1ToV2Migration() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("migration-test-\(UUID().uuidString).store")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Step 1: open a V1 store at the temp URL and insert a habit.
+        do {
+            let schema = Schema(versionedSchema: KadoSchemaV1.self)
+            let config = ModelConfiguration(schema: schema, url: url)
+            let container = try ModelContainer(
+                for: schema,
+                migrationPlan: nil,
+                configurations: config
+            )
+            let habit = KadoSchemaV1.HabitRecord(name: "Pre-migration habit")
+            container.mainContext.insert(habit)
+            try container.mainContext.save()
+        }
+
+        // Step 2: reopen as V2 + migration plan; lightweight migration runs.
+        let schema = Schema(versionedSchema: KadoSchemaV2.self)
+        let config = ModelConfiguration(schema: schema, url: url)
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: KadoMigrationPlan.self,
+            configurations: config
+        )
+        let habits = try container.mainContext.fetch(FetchDescriptor<KadoSchemaV2.HabitRecord>())
+        #expect(habits.count == 1)
+        let habit = try #require(habits.first)
+        #expect(habit.name == "Pre-migration habit")
+        #expect(habit.color == .blue)
+        #expect(habit.icon == HabitIcon.default)
     }
 }

--- a/KadoTests/NewHabitFormModelTests.swift
+++ b/KadoTests/NewHabitFormModelTests.swift
@@ -288,4 +288,58 @@ struct NewHabitFormModelTests {
         #expect(all.count == 1)
         #expect(all.first?.id == saved.id)
     }
+
+    // MARK: - Appearance (color + icon)
+
+    @Test("Default color is .blue and default icon is the curated default")
+    func appearanceDefaults() {
+        let model = NewHabitFormModel()
+        #expect(model.color == .blue)
+        #expect(model.icon == HabitIcon.default)
+    }
+
+    @Test("build() carries the picked color and icon")
+    func buildCarriesAppearance() {
+        let model = NewHabitFormModel()
+        model.name = "Run"
+        model.color = .mint
+        model.icon = "figure.run"
+
+        let record = model.build()
+        #expect(record.color == .mint)
+        #expect(record.icon == "figure.run")
+    }
+
+    @Test("init(editing:) pre-fills color and icon from the record")
+    func editingInitAppearance() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let record = HabitRecord(name: "Read", color: .purple, icon: "book.fill")
+        container.mainContext.insert(record)
+
+        let model = NewHabitFormModel(editing: record)
+        #expect(model.color == .purple)
+        #expect(model.icon == "book.fill")
+    }
+
+    @Test("save(in:) on an editing model updates color and icon in place")
+    func editingSaveAppearance() throws {
+        let container = try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let original = HabitRecord(name: "Swim", color: .blue, icon: "circle")
+        container.mainContext.insert(original)
+        try container.mainContext.save()
+
+        let model = NewHabitFormModel(editing: original)
+        model.color = .teal
+        model.icon = "figure.pool.swim"
+        _ = model.save(in: container.mainContext)
+
+        #expect(original.color == .teal)
+        #expect(original.icon == "figure.pool.swim")
+    }
 }

--- a/KadoTests/OverviewMatrixTests.swift
+++ b/KadoTests/OverviewMatrixTests.swift
@@ -8,10 +8,6 @@ struct OverviewMatrixTests {
     private let calendar = TestCalendar.utc
     private let today = TestCalendar.day(0) // 2026-04-13, a Monday
 
-    private var scoreCalculator: DefaultHabitScoreCalculator {
-        DefaultHabitScoreCalculator(calendar: calendar)
-    }
-
     private var frequencyEvaluator: DefaultFrequencyEvaluator {
         DefaultFrequencyEvaluator(calendar: calendar)
     }
@@ -31,7 +27,6 @@ struct OverviewMatrixTests {
             days: days(offset: -6, count: 7),
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
         #expect(result.isEmpty)
@@ -58,7 +53,6 @@ struct OverviewMatrixTests {
             days: days(offset: -6, count: 7),
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
         #expect(result.map { $0.habit.id } == [older.id, newer.id])
@@ -85,7 +79,6 @@ struct OverviewMatrixTests {
             days: days(offset: -6, count: 7),
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
         #expect(result.count == 1)
@@ -106,7 +99,6 @@ struct OverviewMatrixTests {
             days: days(offset: 1, count: 3),
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
         let row = try #require(result.first)
@@ -129,7 +121,6 @@ struct OverviewMatrixTests {
             days: dayRange,
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
         let row = try #require(result.first)
@@ -142,8 +133,9 @@ struct OverviewMatrixTests {
         #expect(notDueCount == 6)
     }
 
-    @Test("Cell is .scored(s) where s matches scoreHistory on due days")
-    func scoredMatchesHistory() throws {
+    @Test("Scored cells reflect the day's completion value (not the EMA score)")
+    func scoredReflectsDailyValue() throws {
+        // Daily binary habit with a completion exactly two days ago.
         let habit = Habit(
             name: "Read",
             frequency: .daily,
@@ -152,10 +144,10 @@ struct OverviewMatrixTests {
         )
         let completion = Completion(
             habitID: habit.id,
-            date: TestCalendar.day(-3),
+            date: TestCalendar.day(-2),
             value: 1
         )
-        let dayRange = days(offset: -6, count: 7)
+        let dayRange = days(offset: -4, count: 5) // -4..0
 
         let result = OverviewMatrix.compute(
             habits: [habit],
@@ -163,24 +155,47 @@ struct OverviewMatrixTests {
             days: dayRange,
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
         let row = try #require(result.first)
 
-        // Independent computation from scoreHistory to compare against.
-        let history = scoreCalculator.scoreHistory(
-            for: habit,
-            completions: [completion],
-            from: try #require(dayRange.first),
-            to: try #require(dayRange.last)
-        )
-        let expected = Dictionary(uniqueKeysWithValues: history.map { ($0.date, $0.score) })
+        // Only the day with the completion should be scored 1.0; every
+        // other due day should be 0.0. This is the core contract: the
+        // matrix surfaces per-day completion, not smoothed history.
+        let values: [Double] = row.days.map { cell in
+            if case .scored(let v) = cell { v } else { -1 }
+        }
+        #expect(values == [0.0, 0.0, 1.0, 0.0, 0.0])
+    }
 
-        for (day, cell) in zip(dayRange, row.days) {
-            if case .scored(let s) = cell {
-                #expect(s == expected[day] ?? 0.0)
-            }
+    @Test("Counter habit scored cells use achieved/target fraction")
+    func counterPartialValue() throws {
+        let habit = Habit(
+            name: "Drink water",
+            frequency: .daily,
+            type: .counter(target: 8),
+            createdAt: TestCalendar.day(-5)
+        )
+        // Today: 6 of 8 → 0.75.
+        let completion = Completion(
+            habitID: habit.id,
+            date: TestCalendar.day(0),
+            value: 6
+        )
+        let result = OverviewMatrix.compute(
+            habits: [habit],
+            completions: [completion],
+            days: days(offset: 0, count: 1),
+            today: today,
+            calendar: calendar,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        let row = try #require(result.first)
+        let cell = try #require(row.days.first)
+        if case .scored(let v) = cell {
+            #expect(v == 0.75)
+        } else {
+            Issue.record("Expected .scored, got \(cell)")
         }
     }
 
@@ -200,7 +215,6 @@ struct OverviewMatrixTests {
             days: dayRange,
             today: today,
             calendar: calendar,
-            scoreCalculator: scoreCalculator,
             frequencyEvaluator: frequencyEvaluator
         )
         let row = try #require(result.first)

--- a/KadoTests/OverviewMatrixTests.swift
+++ b/KadoTests/OverviewMatrixTests.swift
@@ -1,0 +1,214 @@
+import Testing
+import Foundation
+@testable import Kado
+
+@Suite("OverviewMatrix")
+@MainActor
+struct OverviewMatrixTests {
+    private let calendar = TestCalendar.utc
+    private let today = TestCalendar.day(0) // 2026-04-13, a Monday
+
+    private var scoreCalculator: DefaultHabitScoreCalculator {
+        DefaultHabitScoreCalculator(calendar: calendar)
+    }
+
+    private var frequencyEvaluator: DefaultFrequencyEvaluator {
+        DefaultFrequencyEvaluator(calendar: calendar)
+    }
+
+    /// `count` consecutive day-anchors starting at `TestCalendar.day(start)`.
+    /// Each entry is `startOfDay` so comparisons against today are stable.
+    private func days(offset start: Int, count: Int) -> [Date] {
+        (0..<count).map { TestCalendar.day(start + $0) }
+            .map { calendar.startOfDay(for: $0) }
+    }
+
+    @Test("Empty habit list yields empty matrix")
+    func emptyHabits() {
+        let result = OverviewMatrix.compute(
+            habits: [],
+            completions: [],
+            days: days(offset: -6, count: 7),
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test("Matrix emits one row per non-archived habit, sorted by createdAt")
+    func rowOrder() {
+        let older = Habit(
+            name: "Older",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-10)
+        )
+        let newer = Habit(
+            name: "Newer",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-5)
+        )
+        // Pass newer first to verify the matrix re-sorts by createdAt.
+        let result = OverviewMatrix.compute(
+            habits: [newer, older],
+            completions: [],
+            days: days(offset: -6, count: 7),
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        #expect(result.map { $0.habit.id } == [older.id, newer.id])
+    }
+
+    @Test("Archived habits are excluded")
+    func archivedExcluded() {
+        let active = Habit(
+            name: "Active",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-10)
+        )
+        let archived = Habit(
+            name: "Archived",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-10),
+            archivedAt: TestCalendar.day(-2)
+        )
+        let result = OverviewMatrix.compute(
+            habits: [active, archived],
+            completions: [],
+            days: days(offset: -6, count: 7),
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        #expect(result.count == 1)
+        #expect(result.first?.habit.id == active.id)
+    }
+
+    @Test("Cell is .future for days beyond today")
+    func futureCells() throws {
+        let habit = Habit(
+            name: "Habit",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-10)
+        )
+        let result = OverviewMatrix.compute(
+            habits: [habit],
+            completions: [],
+            days: days(offset: 1, count: 3),
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        let row = try #require(result.first)
+        #expect(row.days.allSatisfy { $0 == .future })
+    }
+
+    @Test("Cell is .notDue when FrequencyEvaluator says the day is not due")
+    func notDueCells() throws {
+        // specific-days habit that only runs on Monday; 2026-04-13 is a Monday.
+        let habit = Habit(
+            name: "Gym",
+            frequency: .specificDays([.monday]),
+            type: .binary,
+            createdAt: TestCalendar.day(-10)
+        )
+        let dayRange = days(offset: -6, count: 7) // Tue..Mon
+        let result = OverviewMatrix.compute(
+            habits: [habit],
+            completions: [],
+            days: dayRange,
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        let row = try #require(result.first)
+        // Only today (Monday) is due; the prior six days are not-due.
+        let scoredCount = row.days.filter {
+            if case .scored = $0 { return true } else { return false }
+        }.count
+        let notDueCount = row.days.filter { $0 == .notDue }.count
+        #expect(scoredCount == 1)
+        #expect(notDueCount == 6)
+    }
+
+    @Test("Cell is .scored(s) where s matches scoreHistory on due days")
+    func scoredMatchesHistory() throws {
+        let habit = Habit(
+            name: "Read",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-10)
+        )
+        let completion = Completion(
+            habitID: habit.id,
+            date: TestCalendar.day(-3),
+            value: 1
+        )
+        let dayRange = days(offset: -6, count: 7)
+
+        let result = OverviewMatrix.compute(
+            habits: [habit],
+            completions: [completion],
+            days: dayRange,
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        let row = try #require(result.first)
+
+        // Independent computation from scoreHistory to compare against.
+        let history = scoreCalculator.scoreHistory(
+            for: habit,
+            completions: [completion],
+            from: try #require(dayRange.first),
+            to: try #require(dayRange.last)
+        )
+        let expected = Dictionary(uniqueKeysWithValues: history.map { ($0.date, $0.score) })
+
+        for (day, cell) in zip(dayRange, row.days) {
+            if case .scored(let s) = cell {
+                #expect(s == expected[day] ?? 0.0)
+            }
+        }
+    }
+
+    @Test("Cell is .notDue on days before the habit was created")
+    func preCreationIsNotDue() throws {
+        let habit = Habit(
+            name: "Habit",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-2) // created 2 days ago
+        )
+        // Range goes back 5 days, past creation.
+        let dayRange = days(offset: -5, count: 6) // -5 .. 0
+        let result = OverviewMatrix.compute(
+            habits: [habit],
+            completions: [],
+            days: dayRange,
+            today: today,
+            calendar: calendar,
+            scoreCalculator: scoreCalculator,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        let row = try #require(result.first)
+        let preCreation = row.days.prefix(3) // -5, -4, -3
+        let postCreation = row.days.suffix(3) // -2, -1, 0
+        #expect(preCreation.allSatisfy { $0 == .notDue })
+        #expect(postCreation.allSatisfy {
+            if case .scored = $0 { return true } else { return false }
+        })
+    }
+}

--- a/KadoTests/OverviewMatrixTests.swift
+++ b/KadoTests/OverviewMatrixTests.swift
@@ -234,12 +234,16 @@ struct OverviewMatrixTests {
         #expect(DayCell.notDue.colorOpacity == nil)
     }
 
-    @Test("DayCell.colorOpacity clamps scored to [0.08, 1.0]")
-    func opacityClampsScored() {
-        #expect(DayCell.scored(0.0).colorOpacity == 0.08)
-        #expect(DayCell.scored(-1.0).colorOpacity == 0.08)
-        #expect(DayCell.scored(0.5).colorOpacity == 0.5)
-        #expect(DayCell.scored(1.0).colorOpacity == 1.0)
-        #expect(DayCell.scored(2.0).colorOpacity == 1.0)
+    @Test("DayCell.colorOpacity maps scored linearly to [0.2, 1.0]")
+    func opacityMapsScoredLinearly() {
+        func approx(_ cell: DayCell, _ expected: Double) -> Bool {
+            guard let actual = cell.colorOpacity else { return false }
+            return abs(actual - expected) < 1e-9
+        }
+        #expect(approx(.scored(0.0), 0.2))
+        #expect(approx(.scored(-1.0), 0.2))
+        #expect(approx(.scored(0.5), 0.6))
+        #expect(approx(.scored(1.0), 1.0))
+        #expect(approx(.scored(2.0), 1.0))
     }
 }

--- a/KadoTests/OverviewMatrixTests.swift
+++ b/KadoTests/OverviewMatrixTests.swift
@@ -211,4 +211,21 @@ struct OverviewMatrixTests {
             if case .scored = $0 { return true } else { return false }
         })
     }
+
+    // MARK: - colorOpacity
+
+    @Test("DayCell.colorOpacity is nil for future and notDue")
+    func opacityNilForNonScored() {
+        #expect(DayCell.future.colorOpacity == nil)
+        #expect(DayCell.notDue.colorOpacity == nil)
+    }
+
+    @Test("DayCell.colorOpacity clamps scored to [0.08, 1.0]")
+    func opacityClampsScored() {
+        #expect(DayCell.scored(0.0).colorOpacity == 0.08)
+        #expect(DayCell.scored(-1.0).colorOpacity == 0.08)
+        #expect(DayCell.scored(0.5).colorOpacity == 0.5)
+        #expect(DayCell.scored(1.0).colorOpacity == 1.0)
+        #expect(DayCell.scored(2.0).colorOpacity == 1.0)
+    }
 }

--- a/KadoTests/PreviewContainerTests.swift
+++ b/KadoTests/PreviewContainerTests.swift
@@ -34,6 +34,6 @@ struct PreviewContainerTests {
         })
 
         let completions = try container.mainContext.fetch(FetchDescriptor<CompletionRecord>())
-        #expect(completions.count == 5 * 7) // 5 habits × 7 sample completions each
+        #expect(completions.count == 5 * DevModeSeed.completionsPerHabit)
     }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,8 +60,8 @@ DNA (habit score, offline, privacy) in place from the start.
 
 ## v0.2 — Visible iOS-native
 
-**Objective**: the iOS differentiators Loop lacks and that users see
-first.
+**Objective**: the iOS-native surfaces users see first — widgets, an
+at-a-glance overview, notifications, frictionless data portability.
 
 **Estimate**: 2-3 weeks.
 
@@ -71,6 +71,15 @@ first.
 - [ ] Large home screen widget: weekly view
 - [ ] Lock screen widget (rectangular, circular, inline)
 - [ ] App Group configured for data sharing
+
+### Multi-habit overview
+- [ ] New "Overview" tab: habits × days matrix, all habits on a shared
+      day axis (Loop / Way of Life pattern)
+- [ ] Cells encode completion with habit-score shading, not binary
+      checkmarks — keeps Kadō's score DNA visible at a glance
+- [ ] Horizontal scroll back through history; sticky habit-name column
+- [ ] Tap a cell to open the per-habit Detail for that date
+- [ ] Dark mode, Dynamic Type, VoiceOver labels for every cell
 
 ### Notifications
 - [ ] Reminders per habit, at fixed time
@@ -99,6 +108,8 @@ first.
 - [ ] An export followed by an import restores 100% of the data
       (automated test)
 - [ ] Notifications respect system settings (Focus, Do Not Disturb)
+- [ ] Overview shows ≥30 days of history for all habits legibly on
+      iPhone 16 Pro and iPad Air
 
 ---
 

--- a/docs/plans/2026-04/multi-habit-overview/compound.md
+++ b/docs/plans/2026-04/multi-habit-overview/compound.md
@@ -1,0 +1,239 @@
+# Compound — Multi-habit overview
+
+**Date**: 2026-04-17
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**PR**: [#12](https://github.com/scastiel/kado/pull/12)
+
+## Summary
+
+Built the v0.2 Overview tab: a habits × days matrix tinted by per-day
+completion value, bundled with `Habit.color` + `Habit.icon` (v0.1
+ROADMAP items that became load-bearing for the visual). Two
+post-build pivots dominated the lessons: **the cells were initially
+tinted by EMA score and looked uniform for daily habits — switched
+to per-day value**, and **the matrix layout went through four
+iterations of sticky / per-card / synced / overlay before landing
+on a full-width single scroll with a transparent label overlay**.
+
+## Decisions made
+
+- **Bundle schema + matrix in one PR**: uniform-color cells defeated
+  the visual, so `Habit.color/icon` had to land with the matrix
+  rather than as a precursor PR.
+- **Cells tint by per-day value, not EMA**: the EMA score is too
+  smooth for daily habits; users expect the Overview to answer "did
+  I do it that day?", not "what's the trend?"
+- **`DailyValue` namespace**: per-day value extracted as a shared
+  helper so the score calculator (EMA input) and the matrix (cell
+  tint) agree on one definition.
+- **Opacity floor 0.2, not 0.08**: 0.08 collapsed missed-due cells
+  into the gray of `.notDue`; 0.2 keeps them clearly colored. Linear
+  remap `0.2 + 0.8 × value` preserves counter/timer partial detail.
+- **Single horizontal `ScrollView` + transparent label overlay**:
+  after trying sticky-left, per-card, and synced `scrollPosition`,
+  one shared scroll is by construction synchronized. Labels sit in
+  a sibling overlay aligned to empty spacer rows inside the scroll.
+- **Per-cell `.popover(isPresented:)`**: anchors the popover to the
+  tapped cell. A single `.popover(item:)` at the view level anchored
+  to the whole matrix (always floats at the top).
+- **Dev sandbox wipe-and-retry on schema error**: disposable data +
+  schema bumps = transparent recovery. Explicitly NOT applied to
+  the production container.
+- **`colorRaw: String` workaround for `HabitColor`**: SwiftData's
+  `@Model` couldn't round-trip even a plain `String`-raw-value enum,
+  so the existing JSON-blob pattern (used for `Frequency`/`HabitType`)
+  extends to this simpler case.
+
+## Surprises and how we handled them
+
+### SwiftData enum round-trip ceiling
+
+- **What happened**: storing `var color: HabitColor = .blue` directly
+  on `@Model` crashed at load with `Could not cast Optional<Any> to
+  Kado.HabitColor`, despite `HabitColor` being a plain
+  `String`-raw-value, `Codable`, `Sendable` enum.
+- **What we did**: generalized the `Frequency`/`HabitType` workaround
+  — store raw `String` (`colorRaw: String = "blue"`), expose
+  `color: HabitColor` via computed accessor.
+- **Lesson**: on Xcode 26 / iOS 18, **any** custom enum type
+  (including `RawRepresentable` with primitive raw value) is
+  unreliable as a direct `@Model` stored property. CLAUDE.md only
+  flagged composite / associated-value enums; the constraint is
+  actually broader.
+
+### `@Model` macro rejects shorthand defaults
+
+- **What happened**: `var color: HabitColor = .blue` → "A default
+  value requires a fully qualified domain named value (from macro
+  'Model')". Also blew up the macro-generated code with "type
+  'Any?' has no member 'blue'".
+- **What we did**: `var color: HabitColor = HabitColor.blue`.
+- **Lesson**: SwiftData's `@Model` macro needs fully-qualified
+  enum defaults. Leading-dot shorthand breaks it. Applies to any
+  enum-typed stored property.
+
+### Stale dev sandbox broke launch
+
+- **What happened**: after bumping to V2, the pre-existing V1 sqlite
+  on the sim failed staged migration with "unknown model version".
+- **What we did**: added a wipe-and-retry to
+  `DevModeController.buildDevContainer`. Production container was
+  explicitly not touched — user data is never silently discarded.
+- **Lesson**: dev-sandbox containers deserve different resilience
+  than production. Make the distinction explicit in code.
+
+### EMA tinting hid daily variance
+
+- **What happened**: the first working build showed every cell for
+  every daily habit at roughly the same mid-opacity. Gym looked
+  varied only because `specificDays` produced mostly `.notDue` gray
+  cells next to scored ones.
+- **What we did**: pivoted cell encoding from EMA score to per-day
+  value (0 for missed, 1 for completed, `achieved/target` for
+  counter/timer). Repurposed `DailyValue` to be shared.
+- **Lesson**: "gradient tint" in a ROADMAP line can mean two
+  different things. Verify visually against real-looking seed data
+  before committing to the interpretation. Preview-backed review
+  during plan stage would have caught this.
+
+### `scrollPosition(id:)` sync across multiple scroll views
+
+- **What happened**: tried syncing independent card-level horizontal
+  `ScrollView`s via a shared `@State scrolledDay: Date?` binding
+  with `.scrollPosition(id:)`. Pans didn't propagate reliably
+  (likely compounded by `LazyVStack`'s late rendering overwriting
+  the binding in `.onAppear`).
+- **What we did**: collapsed to **one** `ScrollView(.horizontal)`
+  wrapping the full matrix. Labels live in a sibling overlay, not
+  inside separate scroll views.
+- **Lesson**: if you need synchronized horizontal motion across
+  many rows, prefer one scroll view over N with a shared binding.
+  Cross-ScrollView sync via `scrollPosition(id:)` is brittle in
+  practice on iOS 18.
+
+### Popover always anchored at view center
+
+- **What happened**: attaching `.popover(item: $selection)` to the
+  matrix container always floated the popover at roughly the center
+  of the view, not at the tapped cell.
+- **What we did**: moved the popover to each cell `Button` with a
+  per-cell `Binding<Bool>` derived from the shared `selection`
+  state.
+- **Lesson**: popover anchoring is tied to the view the modifier is
+  attached to. For item-driven popovers on grids, attach per-item,
+  even if it means N registered modifiers.
+
+### Swift switch-return rule bit twice
+
+- **What happened**: mixing single-expression arms with
+  multi-statement arms in a computed property's `switch` produced
+  the confusing "missing return in getter" error. Hit once in
+  `CellPopoverContent.statusLabel` and again in
+  `DayCell.colorOpacity` after adding a multi-step computation.
+- **What we did**: explicit `return` on every arm in both cases.
+- **Lesson**: CLAUDE.md already flags this. Worth re-reading when
+  editing any `switch`-returning computed property.
+
+### Float precision in tests
+
+- **What happened**: `DayCell.scored(0.5).colorOpacity` returned
+  `0.6000000000000001`, failing `== 0.6`.
+- **What we did**: replaced `==` with a small tolerance helper in
+  the opacity tests.
+- **Lesson**: never assert exact equality on computed Doubles, even
+  for "obvious" arithmetic like `0.2 + 0.8 * 0.5`.
+
+## What worked well
+
+- **TDD for `OverviewMatrix`**: writing red tests in one commit and
+  then turning them green in the next kept the service contract
+  crisp. Tests survived the per-day-value pivot with only one
+  assertion change.
+- **Conductor stages**: research caught the EMA vs per-day question
+  but mis-resolved it on my interpretation, not the user's. The
+  plan's open-questions section let design decisions queue up
+  cleanly. Compound is now naming what drifted so we can correct
+  for next time.
+- **Small, themed commits (23 total)**: every post-build pivot was
+  one focused commit, easy to review and revert. Review the branch
+  by oneline git log and the story reads itself.
+- **SwiftUI previews covering state space**: populated / empty /
+  dark / Dynamic Type XXXL on every new component. Caught rendering
+  issues without sim runs for most iterations.
+- **XcodeBuildMCP's `launch_app_logs_sim`**: one command surfaced
+  the `Could not cast Optional<Any> to Kado.HabitColor` crash. The
+  logs-on-launch flow is a strong debugging loop.
+
+## For the next person
+
+- The Overview's label overlay and scroll content **must** keep
+  their vertical heights in lockstep. Constants:
+  `headerHeight(40) + rowGap(12) + N × (labelHeight(28) +
+  labelBottomPadding(8) + cellSize(36) + optional rowGap)`. If you
+  change any constant in one, change it in both. There's no
+  regression test; rely on preview inspection.
+- **`DailyValue.compute` is the single definition** of per-day
+  value semantics. `DefaultHabitScoreCalculator` feeds it into the
+  EMA; `OverviewMatrix` uses it as the cell tint source. New habit
+  types must update it here.
+- The tap popover's arrow points at the cell because each cell
+  owns its own `.popover(isPresented:)` modifier. ~150 modifiers
+  register simultaneously for a full seed (5 habits × 30 days).
+  Performance is fine today; if perf shows up as an issue, consider
+  a custom popover surface rather than reshaping this.
+- `DevModeController.buildDevContainer` silently wipes the sandbox
+  on migration failure. This is by design and documented in the
+  method's comment. Do **not** copy this recovery into
+  `defaultProductionContainer()`; the opposite behavior (fatal
+  error + user-visible surfacing) is correct there.
+- Adding a new `@Model` property with a non-primitive type
+  (including `String`-raw-value enums) needs the JSON blob or raw
+  String workaround. Direct storage crashes at load on Xcode 26.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** Broaden the "Composite Codable workaround"
+  section: on Xcode 26 / iOS 18, even plain `RawRepresentable`
+  enums with primitive raw values don't round-trip reliably as
+  direct `@Model` stored properties. Store the raw value; expose a
+  computed accessor. `HabitColor` is the second canonical example
+  alongside `Frequency`/`HabitType`.
+- **[→ CLAUDE.md]** `@Model` macro default values must be
+  fully-qualified: `HabitColor.blue`, not `.blue`. Add a one-liner
+  to the SwiftData section.
+- **[→ CLAUDE.md]** `.scrollPosition(id:)` binding for
+  cross-`ScrollView` sync is unreliable on iOS 18 (especially inside
+  `LazyVStack`). When multiple rows need to scroll horizontally in
+  lockstep, collapse to one `ScrollView` and layer non-scrolling
+  content as overlays.
+- **[→ CLAUDE.md]** `.popover(item:)` anchors to its attached view.
+  For per-item popovers in a grid / list, attach per-item with
+  `.popover(isPresented:)` + a derived `Binding<Bool>` — even
+  though that means many registered modifiers.
+- **[local]** EMA is the right model for the habit score; the
+  overview surface is the wrong place to show it. Future "Stats"
+  tab should be where EMA becomes visible cross-habit.
+- **[local]** Overlay-label layout with matched heights is fragile.
+  A single-source-of-truth layout helper (or a `Grid` / `Layout`)
+  would be stronger if this gets extended.
+
+## Metrics
+
+- Tasks completed: 10 planned + 6 post-build fixes (per-day pivot,
+  opacity floor, vertical-cards restructure, overlay labels, popover
+  anchor, catalog additions)
+- Tests: 125 → 140 (+15)
+- Commits: 23 on `feature/multi-habit-overview`
+- Files touched: 36
+- Lines: +2271 / −113
+
+## References
+
+- Competitor survey (habit-tracker overview patterns):
+  [Loop](https://loophabits.org/) · [Way of Life](https://wayoflifeapp.com/)
+  · [HabitKit](https://www.habitkit.app/) ·
+  [Sweet Setup review](https://thesweetsetup.com/apps/best-habit-tracking-app-ios/)
+- CLAUDE.md's existing SwiftData / composite Codable workaround
+  (this PR is the reason to broaden it).

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -326,6 +326,22 @@ a cell surfaces an inline popover with that day's completion detail.
   color/icon rendering. Sim-based interaction verification is
   deferred until XcodeBuildMCP's `idb` or UI-automation workflow
   is configured on this machine.
+- **Post-build — cell encoding pivoted from EMA score to per-day
+  value**. First run of the feature exposed an interpretation
+  mismatch: the ROADMAP/plan said "gradient tint tied to habit-score
+  shading," which I read as the EMA, but for daily habits with
+  partial completion the EMA sits in a narrow 0.3–0.45 band across
+  the visible window, so every cell rendered at near-identical
+  opacity. `.specificDays` habits like Gym looked varied only
+  because most of their cells were `.notDue` (tertiary gray)
+  contrasting against any `.scored`. Fix: `OverviewMatrix.compute`
+  now tints cells by the day's raw completion value (binary 0/1,
+  counter/timer `achieved/target`), extracted into a new
+  `DailyValue` namespace shared with `DefaultHabitScoreCalculator`.
+  Matches the user's mental model ("did I do it that day?") and the
+  Detail view's calendar grid. Popover copy simplified to
+  Completed / Missed / partial %, dropping the ambiguous "score"
+  percentage.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -37,7 +37,7 @@ a cell surfaces an inline popover with that day's completion detail.
 - [x] Task 6: OverviewMatrix implementation (green)
 - [x] Task 7: Matrix UI primitives
 - [x] Task 8: OverviewView + tab integration
-- [ ] Task 9: Cell tap popover
+- [x] Task 9: Cell tap popover
 - [ ] Task 10: Accessibility + multi-size polish
 
 ## Task list

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -30,7 +30,7 @@ a cell surfaces an inline popover with that day's completion detail.
 ## Progress
 
 - [x] Task 1: HabitColor palette + icon catalog
-- [ ] Task 2: Schema V2 — color + icon fields
+- [x] Task 2: Schema V2 — color + icon fields
 - [ ] Task 3: Color + icon pickers in habit forms
 - [ ] Task 4: Color + icon surface in existing views
 - [ ] Task 5: OverviewMatrix tests (red)
@@ -297,6 +297,27 @@ a cell surfaces an inline popover with that day's completion detail.
       sleep, hygiene, creative).
 - [ ] **Cell opacity floor** (0.08 is a guess) — tune in Task 7
       once cells render against real backgrounds.
+
+## Notes during build
+
+- **Task 2 — SwiftData `@Model` macro rejects shorthand defaults**: writing
+  `var color: HabitColor = .blue` triggered "A default value requires a
+  fully qualified domain named value" from the macro. Using
+  `HabitColor.blue` (fully qualified) satisfies it — though see the
+  next note.
+- **Task 2 — SwiftData can't round-trip even a plain String-raw-value
+  enum on Xcode 26 / iOS 18**. `HabitColor` is just
+  `String`-`RawRepresentable` (no associated values), yet the app
+  crashed at load with `Could not cast Optional<Any> to Kado.HabitColor`.
+  The CLAUDE.md workaround for associated-value enums (store raw blob,
+  expose computed accessor) had to be generalized. Pattern in
+  `KadoSchemaV2.HabitRecord`: `private var colorRaw: String = "blue"`
+  backs `var color: HabitColor { get/set }`.
+- **Task 2 — stale dev sandbox broke launch after schema bump**. Prior
+  V1-shape sqlite on the sim failed SwiftData's staged migration with
+  "unknown model version". Added a wipe-and-retry to
+  `DevModeController.buildDevContainer` — valid for the dev sandbox
+  (disposable), explicitly NOT applied to the production container.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -35,7 +35,7 @@ a cell surfaces an inline popover with that day's completion detail.
 - [x] Task 4: Color + icon surface in existing views
 - [x] Task 5: OverviewMatrix tests (red)
 - [x] Task 6: OverviewMatrix implementation (green)
-- [ ] Task 7: Matrix UI primitives
+- [x] Task 7: Matrix UI primitives
 - [ ] Task 8: OverviewView + tab integration
 - [ ] Task 9: Cell tap popover
 - [ ] Task 10: Accessibility + multi-size polish

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -36,7 +36,7 @@ a cell surfaces an inline popover with that day's completion detail.
 - [x] Task 5: OverviewMatrix tests (red)
 - [x] Task 6: OverviewMatrix implementation (green)
 - [x] Task 7: Matrix UI primitives
-- [ ] Task 8: OverviewView + tab integration
+- [x] Task 8: OverviewView + tab integration
 - [ ] Task 9: Cell tap popover
 - [ ] Task 10: Accessibility + multi-size polish
 

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -1,7 +1,7 @@
 # Plan — Multi-habit overview
 
 **Date**: 2026-04-17
-**Status**: draft
+**Status**: in progress
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -26,6 +26,19 @@ a cell surfaces an inline popover with that day's completion detail.
   searchable SF Symbol grid
 - **Color palette**: 8 semantic named colors adapting to dark mode
   (exact palette locked in Task 1)
+
+## Progress
+
+- [x] Task 1: HabitColor palette + icon catalog
+- [ ] Task 2: Schema V2 — color + icon fields
+- [ ] Task 3: Color + icon pickers in habit forms
+- [ ] Task 4: Color + icon surface in existing views
+- [ ] Task 5: OverviewMatrix tests (red)
+- [ ] Task 6: OverviewMatrix implementation (green)
+- [ ] Task 7: Matrix UI primitives
+- [ ] Task 8: OverviewView + tab integration
+- [ ] Task 9: Cell tap popover
+- [ ] Task 10: Accessibility + multi-size polish
 
 ## Task list
 

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -32,7 +32,7 @@ a cell surfaces an inline popover with that day's completion detail.
 - [x] Task 1: HabitColor palette + icon catalog
 - [x] Task 2: Schema V2 — color + icon fields
 - [x] Task 3: Color + icon pickers in habit forms
-- [ ] Task 4: Color + icon surface in existing views
+- [x] Task 4: Color + icon surface in existing views
 - [ ] Task 5: OverviewMatrix tests (red)
 - [ ] Task 6: OverviewMatrix implementation (green)
 - [ ] Task 7: Matrix UI primitives

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -33,7 +33,7 @@ a cell surfaces an inline popover with that day's completion detail.
 - [x] Task 2: Schema V2 — color + icon fields
 - [x] Task 3: Color + icon pickers in habit forms
 - [x] Task 4: Color + icon surface in existing views
-- [ ] Task 5: OverviewMatrix tests (red)
+- [x] Task 5: OverviewMatrix tests (red)
 - [ ] Task 6: OverviewMatrix implementation (green)
 - [ ] Task 7: Matrix UI primitives
 - [ ] Task 8: OverviewView + tab integration

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -34,7 +34,7 @@ a cell surfaces an inline popover with that day's completion detail.
 - [x] Task 3: Color + icon pickers in habit forms
 - [x] Task 4: Color + icon surface in existing views
 - [x] Task 5: OverviewMatrix tests (red)
-- [ ] Task 6: OverviewMatrix implementation (green)
+- [x] Task 6: OverviewMatrix implementation (green)
 - [ ] Task 7: Matrix UI primitives
 - [ ] Task 8: OverviewView + tab integration
 - [ ] Task 9: Cell tap popover

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -31,7 +31,7 @@ a cell surfaces an inline popover with that day's completion detail.
 
 - [x] Task 1: HabitColor palette + icon catalog
 - [x] Task 2: Schema V2 — color + icon fields
-- [ ] Task 3: Color + icon pickers in habit forms
+- [x] Task 3: Color + icon pickers in habit forms
 - [ ] Task 4: Color + icon surface in existing views
 - [ ] Task 5: OverviewMatrix tests (red)
 - [ ] Task 6: OverviewMatrix implementation (green)

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -1,0 +1,297 @@
+# Plan — Multi-habit overview
+
+**Date**: 2026-04-17
+**Status**: draft
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Add an **Overview** tab that renders a habits × days matrix with
+score-tinted cells, each habit carrying its own color. The branch
+bundles a schema V2 migration adding `Habit.color` and `Habit.icon`
+(v0.1 ROADMAP items that are load-bearing for the matrix's visual
+identity). Cells are tinted by EMA score (gradient opacity); tapping
+a cell surfaces an inline popover with that day's completion detail.
+
+## Decisions locked in
+
+- **Cell encoding**: gradient opacity on habit color (0 = empty,
+  1 = full color)
+- **Schema scope**: bundled — one branch covers `Habit.color` +
+  `Habit.icon` + the matrix
+- **Default day window**: 30 days, scrolls left into past
+- **Tap behavior**: inline popover showing that day's completion
+- **Day order**: newest-on-right, initial scroll anchored at today
+- **Icon picker**: curated shortlist (~30 common habit icons), not
+  searchable SF Symbol grid
+- **Color palette**: 8 semantic named colors adapting to dark mode
+  (exact palette locked in Task 1)
+
+## Task list
+
+### Task 1: HabitColor palette + curated icon catalog
+
+**Goal**: foundation primitives the rest of the tasks depend on.
+
+**Changes**:
+- `Kado/Models/HabitColor.swift` — enum, 8 cases (e.g. `.red`,
+  `.orange`, `.yellow`, `.green`, `.mint`, `.teal`, `.blue`,
+  `.purple`), each resolving to a semantic `Color` adaptive to dark
+  mode. `Codable`, `Sendable`, `nonisolated` (Codable conformance
+  used off MainActor by SwiftData encoders).
+- `Kado/Models/HabitIcon.swift` — namespace with
+  `static let curated: [String]` (~30 SF Symbols: `book.fill`,
+  `figure.walk`, `dumbbell.fill`, `moon.zzz.fill`, `cup.and.saucer.fill`,
+  `drop.fill`, `figure.mind.and.body`, …).
+
+**Tests**:
+- `@Test("HabitColor all cases resolve to a non-clear Color")`
+- `@Test("HabitIcon.curated has no duplicate symbol names")`
+- `@Test("HabitIcon.curated has >= 20 entries")`
+
+**Commit**: `feat(habit): HabitColor palette and curated icon shortlist`
+
+---
+
+### Task 2: Schema V2 — color + icon fields
+
+**Goal**: persist color and icon on `HabitRecord` with clean migration.
+
+**Changes**:
+- `Kado/Models/Schema/KadoSchemaV2.swift` — mirror V1 models; add
+  `color: HabitColor = .blue` and `icon: String = "circle"` to
+  `HabitRecord`. Both defaulted (CloudKit shape).
+- `Kado/Models/Schema/KadoMigrationPlan.swift` — append
+  `.lightweight(fromVersion: KadoSchemaV1.self, toVersion: KadoSchemaV2.self)`
+  to `stages`.
+- Value-type `Habit` snapshot gains `color`, `icon`.
+- Update `HabitRecord.snapshot` and any `init(from snapshot:)` paths.
+
+**Tests**:
+- `KadoTests/CloudKitShapeTests.swift` — still green (new props
+  respect optional-or-defaulted + non-unique invariants).
+- `@Test("Habits migrated from V1 inherit default color and icon")`
+  (via in-memory container seeded with V1 data, migrated to V2).
+
+**Commit**: `feat(schema): add color and icon to Habit via V2 migration`
+
+---
+
+### Task 3: Color + icon pickers in habit forms
+
+**Goal**: let users pick color + icon when creating or editing.
+
+**Changes**:
+- `Kado/UIComponents/HabitColorPicker.swift` — swatch grid, selected
+  state visible.
+- `Kado/UIComponents/HabitIconPicker.swift` — icon grid from
+  `HabitIcon.curated`, tinted with the currently-selected color.
+- `Kado/ViewModels/NewHabitFormModel.swift` — add `color`, `icon`
+  with defaults (`.blue`, `"circle"`).
+- `Kado/Views/Habit/NewHabitFormView.swift` and any Edit form — wire
+  in both pickers. Picker rows follow the `Picker`-over-assoc-value
+  pattern already used for Frequency (see CLAUDE.md).
+- Localization: picker labels, accessibility labels.
+- Previews: each color represented; icon grid at Dynamic Type XXXL.
+
+**Tests**:
+- `NewHabitFormModelTests` — defaults hold; setting color/icon
+  round-trips into the saved Habit.
+
+**Commit**: `feat(habit-form): pick color and icon when creating a habit`
+
+---
+
+### Task 4: Color + icon surface in existing views
+
+**Goal**: every habit-display surface uses the new fields.
+
+**Changes**:
+- `Kado/UIComponents/HabitRowView.swift` — leading glyph = `habit.icon`,
+  tinted by `habit.color`.
+- `Kado/UIComponents/MonthlyCalendarView.swift` — completed cells
+  tint to `habit.color` instead of `.accentColor` (other states
+  unchanged).
+- `Kado/Services/DevModeSeed.swift` — set a distinct color + icon on
+  each seeded habit; bump completion density so previews look alive.
+
+**Tests**:
+- No new unit tests; visual via previews + `screenshot`.
+- Dev mode preview shows 5 distinctly-colored rows.
+
+**Commit**: `feat(habit-display): surface color and icon in rows and calendar`
+
+---
+
+### Task 5: OverviewMatrix tests (red)
+
+**Goal**: pin the matrix service contract before implementing.
+
+**Changes**:
+- `KadoTests/OverviewMatrixTests.swift` — tests for the free struct:
+  - rows one-per-non-archived-habit, sorted by createdAt
+  - archived habits excluded
+  - cell is `.future` beyond today
+  - cell is `.notDue` when `FrequencyEvaluator` says not due
+  - cell is `.scored(s)` where `s` matches `scoreHistory` on due days
+  - empty habit list → empty matrix
+
+**Verification**: `test_sim` — new tests fail (expected).
+
+**Commit**: `test(overview): OverviewMatrix service contract (red)`
+
+---
+
+### Task 6: OverviewMatrix implementation (green)
+
+**Goal**: make Task 5 green.
+
+**Changes**:
+- `Kado/Services/OverviewMatrix.swift` — free struct with
+  `static func compute(habits, completions, dayRange, calendar, scoreCalculator, frequencyEvaluator) -> [MatrixRow]`
+- Types: `MatrixRow(habit, days: [DayCell])`,
+  `DayCell { case future, notDue, scored(Double) }`.
+- Memoizes per-habit `scoreHistory` call; non-due days read through
+  from the score history (carries forward).
+
+**Verification**: `test_sim` — all green.
+
+**Commit**: `feat(overview): OverviewMatrix service`
+
+---
+
+### Task 7: Matrix UI primitives
+
+**Goal**: cell + header + row components.
+
+**Changes**:
+- `Kado/UIComponents/MatrixCell.swift` — takes `DayCell` +
+  `HabitColor`. `.scored(s)` renders habit color at
+  `max(0.08, s)` opacity (floor preserves perceptibility at low
+  scores). `.notDue` is a faint tertiary fill. `.future` is empty.
+- `Kado/UIComponents/DayColumnHeader.swift` — `Weekday.localizedShort`
+  letter on top, day-of-month number below.
+- `Kado/UIComponents/MatrixRowView.swift` — habit icon + name +
+  `LazyHStack` of `MatrixCell`s.
+- Previews across state space + full palette.
+
+**Tests**:
+- `@Test("MatrixCell scored opacity equals max(floor, score)")`
+
+**Commit**: `feat(overview): matrix cell, header, and row components`
+
+---
+
+### Task 8: OverviewView + tab integration
+
+**Goal**: shipping the Overview tab.
+
+**Changes**:
+- `Kado/Views/Overview/OverviewView.swift` — `@Query` for
+  non-archived habits; derive `dayRange` (last 30 days); call
+  `OverviewMatrix.compute`; render sticky-left habit column +
+  horizontally-scrollable day region (`ScrollView(.horizontal)` +
+  `LazyHStack`). Initial offset anchored at today's column.
+- `Kado/App/ContentView.swift` — third tab between Today and
+  Settings.
+- Empty state: `ContentUnavailableView` when no habits.
+- Localization: "Overview" tab label, empty state strings.
+- Previews: populated, empty, dark, iPad Air, Dynamic Type XXXL.
+
+**Verification**:
+- `build_sim` clean.
+- `screenshot` iPhone 17 Pro (light + dark), iPad.
+
+**Commit**: `feat(overview): add Overview tab with habits × days matrix`
+
+---
+
+### Task 9: Cell tap popover
+
+**Goal**: tapping a cell inspects that day.
+
+**Changes**:
+- Attach `.popover` to each cell with
+  `.presentationCompactAdaptation(.popover)` so iPhone keeps the
+  popover presentation rather than sheeting.
+- Popover content: habit name + icon, date formatted long, completion
+  value (if any), EMA score that day formatted as percent.
+- Localization: popover strings.
+
+**Verification**:
+- Manual: tap each state (scored, notDue, future) — popover content
+  matches.
+- VoiceOver: popover announces when presented.
+
+**Commit**: `feat(overview): tap a cell to inspect that day`
+
+---
+
+### Task 10: Accessibility + multi-size polish
+
+**Goal**: meet the "done" bar.
+
+**Changes**:
+- Per-cell accessibility label:
+  `"{habit}, {weekday} {day}, {state description}, score {pct}%"`.
+- Dynamic Type XXXL: habit-name column gets a max width and wraps.
+- iPad: cell size slightly larger if warranted.
+- Dark-mode pass on all new views.
+
+**Verification**:
+- VoiceOver spot check on iPhone 17 Pro.
+- `screenshot` at Dynamic Type XXXL.
+- iPad Air M2 (or M4 substitute) screenshot.
+
+**Commit**: `feat(overview): accessibility and multi-size polish`
+
+## Integration checkpoints
+
+- **SwiftData schema change** (Task 2): KadoSchemaV2 is the project's
+  first real schema bump. Verify migration locally on a device with
+  existing data before merging, even though v0.1 isn't released.
+- **CloudKit shape** (Task 2): regression test must pass with new
+  fields — both defaulted, neither `.unique`.
+- **ContentView tab addition** (Task 8): check that the existing
+  Dev-mode container swap (preserves view state across toggle) still
+  works with three tabs.
+
+## Risks and mitigation
+
+- **Scope growth**: if the branch balloons past ~1500 lines of diff,
+  split at the natural seam between Task 4 and Task 5. Tasks 1-4
+  form a valid precursor PR (color/icon for v0.1 displays); Tasks
+  5-10 form the matrix PR.
+- **Popover UX on iPhone**: SwiftUI popovers default to sheets on
+  compact width; we pin them via
+  `.presentationCompactAdaptation(.popover)`. If that feels wrong
+  for small cells, fall back to a custom inline chip or
+  `Menu`-based reveal in Task 9.
+- **Score computation cost**: 50 habits × 30 days = 1,500
+  evaluations. Memoize inside `OverviewView` with `.task(id:)` keyed
+  on habit IDs + date range; don't recompute on scroll.
+- **Icon picker height at XXXL**: a 30-icon grid may run tall. Test
+  with Dynamic Type XXXL early in Task 3 and cap grid columns to 5
+  if needed.
+
+## Open questions
+
+- [ ] **Exact color palette hex values** — resolve at Task 1 by
+      visually comparing candidate swatches in a preview.
+- [ ] **Exact curated icon list** — resolve at Task 1. 30 is a
+      starting target; the shortlist should reflect common habit
+      categories (movement, mindfulness, nutrition, learning,
+      sleep, hygiene, creative).
+- [ ] **Cell opacity floor** (0.08 is a guess) — tune in Task 7
+      once cells render against real backgrounds.
+
+## Out of scope
+
+- **Aggregate stats** (perfect days, average score across habits):
+  a future Stats tab, not this PR.
+- **Animated transitions** between tabs.
+- **Import/export of color/icon fields**: the CSV/JSON exporters
+  are their own v0.2 work; they'll travel with the field but format
+  stabilization is separate.
+- **Widget reuse of color**: home-screen widgets land later in v0.2.
+- **watchOS complication color**: v0.3.

--- a/docs/plans/2026-04/multi-habit-overview/plan.md
+++ b/docs/plans/2026-04/multi-habit-overview/plan.md
@@ -1,7 +1,7 @@
 # Plan — Multi-habit overview
 
 **Date**: 2026-04-17
-**Status**: in progress
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -38,7 +38,7 @@ a cell surfaces an inline popover with that day's completion detail.
 - [x] Task 7: Matrix UI primitives
 - [x] Task 8: OverviewView + tab integration
 - [x] Task 9: Cell tap popover
-- [ ] Task 10: Accessibility + multi-size polish
+- [x] Task 10: Accessibility + multi-size polish
 
 ## Task list
 
@@ -318,6 +318,14 @@ a cell surfaces an inline popover with that day's completion detail.
   "unknown model version". Added a wipe-and-retry to
   `DevModeController.buildDevContainer` — valid for the dev sandbox
   (disposable), explicitly NOT applied to the production container.
+- **Task 10 — Overview tab couldn't be reached via `screenshot`
+  alone**. XcodeBuildMCP's default install omits tap / UI-automation
+  primitives (`CLAUDE.md` already flags this), so visual verification
+  of the Overview view relied on SwiftUI previews (populated, empty,
+  dark, Dynamic Type XXXL) plus a Today-tab screenshot confirming
+  color/icon rendering. Sim-based interaction verification is
+  deferred until XcodeBuildMCP's `idb` or UI-automation workflow
+  is configured on this machine.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/multi-habit-overview/research.md
+++ b/docs/plans/2026-04/multi-habit-overview/research.md
@@ -1,0 +1,270 @@
+# Research — Multi-habit overview
+
+**Date**: 2026-04-17
+**Status**: draft
+**Related**:
+- `docs/ROADMAP.md` → v0.2 "Multi-habit overview" section (added this
+  branch)
+- `docs/habit-score.md` (EMA scoring that will drive cell tints)
+- `docs/PRODUCT.md` (Kadō's "score is central" DNA)
+
+## Problem
+
+Kadō's v0.1 surfaces are **Today** (only today's habits) and per-habit
+**Detail** (one habit at a time, with monthly calendar + score).
+Neither lets the user see progress across all their habits at once
+over time.
+
+Competitor survey (see References) shows the pattern is common but not
+universal:
+- **Loop** and **Way of Life** build their main screen around a
+  habits × days matrix.
+- **HabitKit** stacks per-habit heatmaps on the home screen.
+- Polished iOS-natives (**Streaks**, **Habitify**, **Productive**)
+  push cross-habit history to a dedicated **Stats** tab.
+
+Kadō's differentiator is the EMA-based habit score. A cross-habit view
+that surfaces the **score** — not just binary done/not-done — turns
+an abstract number into a lived visualization and keeps the score
+central to the app rather than buried in Detail.
+
+### What "done" looks like
+
+The user opens a new **Overview** tab and sees every non-archived
+habit as a row, with recent days as columns. Each cell is tinted by
+that habit's EMA score on that day. Tapping a cell jumps to the
+habit's Detail. Works on iPhone and iPad, light and dark, Dynamic
+Type XXXL, VoiceOver.
+
+## Current state of the codebase
+
+### Navigation
+- `ContentView` (Kado/App/ContentView.swift:9–19): TabView with two
+  tabs, Today + Settings. Adding a third tab is a one-line change.
+- `modelContainer` injection via `DevModeController` at
+  `KadoApp.swift:16`. No special treatment needed for a new tab.
+
+### Data
+- `HabitRecord` (SwiftData `@Model`) → `.snapshot` produces value-type
+  `Habit`. `TodayView` (Kado/Views/Today/TodayView.swift:11–15)
+  already queries non-archived habits sorted by `createdAt` — same
+  descriptor fits Overview.
+- `CompletionRecord` → value-type `Completion(habitID, date, value)`.
+  Lives on the habit relationship.
+- **`Habit` has no color or icon field today.** The v0.1 ROADMAP
+  scopes them, but they're unshipped. Matrix rows need visual
+  identity — either land color/icon first, or ship v1 with
+  app-accent-only rows. See Open questions.
+
+### Services (the good news)
+- `HabitScoreCalculating.scoreHistory(for:completions:from:to:)`
+  already returns `[DailyScore]` — one score per day, carrying
+  forward on non-due days. **Exact primitive the matrix needs. No
+  new business logic required.**
+- `FrequencyEvaluating.isDue(habit:on:completions:)` exists —
+  distinguishes "not due" from "due-but-missed" cells.
+- Env injection via hand-rolled `EnvironmentKey` pattern
+  (`App/EnvironmentValues+Services.swift`); newer entries use
+  `@Entry`. New services follow the existing pattern.
+
+### Existing UI primitives
+- `MonthlyCalendarView` (UIComponents/MonthlyCalendarView.swift, 241
+  lines) has a per-day cell state enum
+  `.future | .completed | .missed | .nonDue` and a secondary/tertiary
+  fill system. Close cousin to what we need, but cells are
+  month-anchored with day numbers; generalizing for a no-label,
+  score-tinted day cell is plausible but more refactor than reuse.
+- No existing `score → color` mapping function; would be new.
+
+### Tests
+- Swift Testing (`@Suite`, `@Test`). `TestCalendar` helper in
+  `KadoTests/Helpers/` pins to UTC Gregorian, reference date
+  2026-04-13 (a Monday).
+
+### Dev mode
+- `DevModeSeed` (Services/DevModeSeed.swift): 5 habits, ~7 completions
+  each over 14–60 days. Adequate for initial preview; may want to
+  enrich once the view lands.
+
+## Proposed approach
+
+**Add an "Overview" tab** between Today and Settings. It renders a
+scrollable matrix of non-archived habits (rows) × recent days
+(columns). Each cell is a score-tinted square computed from
+`scoreHistory`. Tapping a cell navigates to that habit's Detail.
+
+### Resolved design decisions
+- **Cell encoding: gradient tint.** `score ∈ [0, 1]` maps to opacity
+  over the habit's accent color. Non-due days render as empty/faint
+  placeholders; future days are empty. Surfaces Kadō's score DNA
+  directly; accepts the trade-off that a dense gradient is harder to
+  parse at a glance than discrete states.
+- **Scope: bundle `Habit.color` + `Habit.icon` with the matrix.** A
+  uniform-accent matrix is monotonous; per-habit color is load-bearing
+  for the visual. One cohesive PR covers the schema change, form
+  updates, and the matrix itself.
+
+### Key components
+
+**Schema (prerequisite, same branch):**
+- `Habit.color: HabitColor` + `Habit.icon: String` (SF Symbol name).
+  Extend `KadoSchemaV1` → `KadoSchemaV2`, append
+  `.lightweight(KadoSchemaV2.self)` stage to `KadoMigrationPlan`.
+- `HabitColor` enum (curated palette, ~8–10 semantic named colors
+  that adapt to dark mode — not raw hex).
+- New/Edit Habit forms: color swatch picker + SF Symbol icon picker.
+- `HabitRowView` and `MonthlyCalendarView` updated to respect the
+  new color.
+
+**Overview matrix:**
+- `OverviewView` (`Kado/Views/Overview/OverviewView.swift`) —
+  `@Query` for habits; hosts the matrix UI.
+- `OverviewMatrix` (free struct, `Kado/Services/OverviewMatrix.swift`)
+  — pure function: `(habits, completions, dayRange, calendar) →
+  [MatrixRow]` where `MatrixRow = (habit, [DayCell])` and `DayCell`
+  is `.future | .notDue | .scored(Double)`. Uses
+  `HabitScoreCalculating` + `FrequencyEvaluating`. **Tested in
+  isolation.**
+- `MatrixCell` (UIComponent) — one tinted square. Takes a `DayCell`
+  + habit color. `.scored(s)` renders the habit color at opacity
+  `s` (with a small floor so low-score cells stay perceptible).
+  Accessibility label composed per cell.
+- `DayColumnHeader` — weekday abbreviation + day number, respecting
+  `Weekday.localizedShort` pattern.
+
+### Layout sketch
+
+```
+┌──────────────────────────────────────────────────┐
+│  Overview                                        │
+├──────────────┬───────────────────────────────────┤
+│ 📖 Read      │   M   T   W   T   F   S   S   M  │
+│ 🏃 Exercise  │  ▓▓  ▓▓▓  ·  ▓▓▓ ▓▓▓ ▓▓▓  ·  ▓▓▓ │  ← scrolls to past
+│ 💧 Water     │  ▓▓  ▓▓▓ ▓▓  ▓▓▓  ·  ▓▓▓  ·  ▓▓▓ │
+│ 🧘 Meditate  │   ·   ·  ▓▓   ·   ·  ▓▓▓  ·  ▓▓▓ │
+└──────────────┴───────────────────────────────────┘
+     sticky                 scrollable →
+```
+
+Sticky left column (icon + name). Horizontally scrollable right
+region (day columns). Newest-on-right, initial scroll position
+anchored at today (Loop/Way of Life convention).
+
+### Data model changes
+
+- New fields on `HabitRecord`: `color: HabitColor` (default a neutral
+  case, e.g. `.blue`), `icon: String` (default a neutral SF Symbol,
+  e.g. `"circle"`). Both non-optional with defaults for CloudKit
+  shape compliance.
+- `KadoSchemaV2` adds these two fields; `KadoMigrationPlan` gets a
+  lightweight stage. Existing habits inherit the defaults; the
+  Edit Habit form lets the user set real values post-migration.
+- Value-type `Habit` snapshot mirrors the new fields.
+- Regression test: walk `Schema.entities` to confirm the new
+  properties remain optional-or-defaulted and non-unique
+  (CloudKit shape invariant — see `CloudKitShapeTests.swift`).
+
+### UI changes
+
+- New tab in `ContentView` → `OverviewView`.
+- New view file + a small handful of UIComponents.
+- Localization entries for "Overview" tab label, accessibility cell
+  labels, state descriptors.
+
+### Tests to write
+
+**Schema / migration:**
+- `@Test("KadoSchemaV2 migrates V1 habits with default color + icon")`
+- CloudKit shape regression test covers the new fields.
+
+**`OverviewMatrix` (free struct):**
+- `@Test("Matrix emits one row per non-archived habit, sorted by createdAt")`
+- `@Test("Archived habits are excluded")`
+- `@Test("Cell is .future for dates beyond today")`
+- `@Test("Cell is .notDue when FrequencyEvaluator says not due")`
+- `@Test("Cell is .scored(s) where s matches scoreHistory on due days")`
+- `@Test("Empty habit list yields empty matrix")`
+
+**Color helper:**
+- `@Test("Score 0 maps to transparent, score 1 maps to full habit color")`
+- `@Test("Score-0 cells respect a minimum opacity floor for perceptibility")`
+
+View-level previews cover the visual axes (single habit, many
+habits, iPad width, dark mode, Dynamic Type XXXL), plus one preview
+showing the full color palette.
+
+## Alternatives considered
+
+### Alternative A: segmented control on Today (Today / Overview toggle)
+- **Idea**: avoid a third tab; stay with the two-tab shell.
+- **Why not**: Overview is not "today's data in a different shape"
+  — it's cross-time, cross-habit. Conflating the two surfaces
+  obscures Today's role. Adding a tab matches Streaks, Habitify,
+  HabitKit and iOS users' mental model.
+
+### Alternative B: stacked per-habit heatmaps (HabitKit-style)
+- **Idea**: vertical list where each row is a full
+  GitHub-contribution grid for one habit.
+- **Why not**: doesn't support the cross-habit comparison the user
+  asked about — you can't easily see "did I hit everything on
+  Tuesday?" across habits. The matrix pattern answers that
+  directly.
+
+### Alternative C: aggregate stats dashboard (Streaks-style)
+- **Idea**: charts like "perfect days this month", "average score
+  across all habits", streak leaderboard.
+- **Why not**: valuable but distinct. A future Stats tab can layer
+  on top of the matrix later; matrix is the foundation.
+
+## Risks and unknowns
+
+- **Scroll performance** with many habits × wide day ranges: use
+  `LazyHStack`/`LazyHGrid` so cells materialize on demand. 50 habits
+  × 365 days eagerly is 18k views — unacceptable; 50 × 30 is fine.
+- **Score computation cost**: `scoreHistory` walks day-by-day. 50
+  habits × 30 days = 1,500 evaluations. Cheap, but memoize per view
+  render; don't recompute on every scroll offset change.
+- **Scope growth from bundling**: one PR now covers a schema
+  migration, form updates, and a new top-level tab. Higher review
+  load; mitigate by landing as a single branch with clearly
+  separated commits (schema → forms → matrix) so it's still
+  reviewable in sequence.
+- **Migration rollback**: v0.1 is still pre-release, so CloudKit
+  data loss on schema change is a non-issue. Verify locally on a
+  real device before merging anyway.
+- **iPad vs iPhone**: iPad easily fits 20+ day columns, iPhone ~7-10.
+  Lazy grid handles most of this; may want slightly larger cells
+  on iPad.
+- **Score-tint semantics at glance**: a dense gradient can be harder
+  to read than discrete states. Needs a visual test against users.
+
+## Open questions
+
+Resolved (2026-04-17):
+- [x] **Score encoding**: gradient tint.
+- [x] **Habit color prerequisite**: bundle `Habit.color` +
+      `Habit.icon` in the same PR as the matrix.
+
+Carried forward to plan stage:
+- [ ] **Default day window**: ~30 days (fills iPhone screen with
+      scroll), or ~7 days (simpler, current-week focus), or auto-fit
+      to available width?
+- [ ] **Tap behavior**: navigate to habit Detail (at that date), or
+      show an inline popover with the completion, or read-only?
+- [ ] **Day order**: newest-on-right scrolling into past (Loop
+      convention), or newest-on-left like a feed?
+- [ ] **Color palette shape**: how many colors, and what's the naming
+      convention? (e.g. `.blue | .mint | .red | ...` à la Apple
+      Reminders, or something more distinctive?)
+- [ ] **Icon picker**: SF Symbol search via Apple's built-in picker
+      (iOS 18 has no public API for this — custom grid needed), or
+      a curated shortlist of ~30 common habit icons?
+
+## References
+
+- Competitor landscape:
+  [Loop](https://loophabits.org/) · [Way of Life](https://wayoflifeapp.com/)
+  · [HabitKit](https://www.habitkit.app/) ·
+  [Sweet Setup review](https://thesweetsetup.com/apps/best-habit-tracking-app-ios/)
+- Kadō ROADMAP v0.2 entry: `docs/ROADMAP.md`
+- Kadō habit score spec: `docs/habit-score.md`


### PR DESCRIPTION
## Why?

- Kadō's v0.1 surfaces (Today, per-habit Detail) don't show cross-habit progress over time.
- The habit score is currently buried in Detail; users want a view that answers "did I do my habits this week?"
- Competitor survey: Loop and Way of Life build their main screen around a habits × days matrix; HabitKit stacks per-habit heatmaps; Streaks/Habitify defer to a Stats tab. Kadō lands a dedicated Overview tab that sits between those.

## What?

- New **Overview** tab: every non-archived habit as a row × the last 30 days as columns.
- Cells tinted by **per-day completion value** (binary 0/1, counter/timer `achieved/target`) on a `0.2 → 1.0` opacity ramp over the habit's color. Missed-due cells stay clearly colored; not-due days render as tertiary gray; future days are empty.
- **Single full-width horizontal scroll** anchored at today. Habit names + icons live in a transparent overlay, so they stay put while cells pan.
- **Scrolling date-header row** above the grid (weekday + day-of-month, today highlighted).
- **Tap a cell → inline popover** anchored to that cell, showing date, status, and percent.
- **Per-habit `color` + `icon`** landed alongside (from v0.1 ROADMAP scope): new color-swatch + curated SF Symbol pickers in the New/Edit Habit form, surfaced in Today rows and the Monthly calendar.

## How?

- Schema bumped to `KadoSchemaV2` with `color: HabitColor` + `icon: String` fields via a lightweight migration. CloudKit-shape regression test parameterized over all shipped schemas.
- `DailyValue` namespace (extracted from `DefaultHabitScoreCalculator`) defines per-day value semantics once; consumed by the EMA calculator and the Overview matrix.
- `OverviewMatrix` free struct turns habits + completions + days into `[MatrixRow]`, tested in isolation with red → green TDD.
- Layout: `ScrollView(.vertical)` → `ZStack` wrapping one full-width `ScrollView(.horizontal)` for the cell grid + a transparent sibling overlay for habit labels with `allowsHitTesting(false)` so taps pass through.
- Per-cell `.popover(isPresented:)` bound to a derived `Binding<Bool>` from a shared `selection` state — anchors the popover arrow at the tapped cell rather than the view center.
- `DevModeController.buildDevContainer` wipes + retries on schema-load failure. Dev sandbox is disposable; the production container explicitly does NOT get this behavior.

## Tests

- 125 → 140 (+15). Covers: schema V1→V2 migration, CloudKit shape per version, OverviewMatrix contract, per-day value semantics, form color/icon round-trip.

## Lessons propagated to `CLAUDE.md`

- Broadened the SwiftData enum-storage workaround: **any** custom enum (including String-raw-value) needs a raw-blob + computed accessor on `@Model`, not just associated-value ones. Canonical: `HabitColor` in V2.
- `@Model` macro requires **fully-qualified** default-arg values (`HabitColor.blue`, not `.blue`).

## Artifacts

- `docs/ROADMAP.md` — v0.2 Overview section added
- `docs/plans/2026-04/multi-habit-overview/research.md`
- `docs/plans/2026-04/multi-habit-overview/plan.md`
- `docs/plans/2026-04/multi-habit-overview/compound.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)