### PR TITLE
docs: add PRIVACY.md at repo root

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,33 @@
+# Kadō — Privacy Policy
+
+Kadō does not collect any personal data.
+
+## What Kadō stores
+
+Your habits, completions, reminders, and settings are stored locally
+on your device using Apple's SwiftData framework.
+
+## iCloud sync (optional)
+
+If you enable iCloud sync, your data is replicated across your own
+Apple devices using Apple's CloudKit framework. It is stored in your
+private iCloud container — neither the app's developer nor any third
+party has access to it.
+
+## HealthKit (optional, future releases)
+
+If you grant HealthKit permission, Kadō reads activity data to
+auto-complete habits. HealthKit data stays on your device. Kadō never
+writes to HealthKit and never transmits HealthKit data anywhere.
+
+## Third-party services
+
+Kadō uses no third-party analytics, advertising, or crash reporting
+SDKs.
+
+## Contact
+
+Questions? Open an issue at https://github.com/scastiel/kado/issues or
+email sebastien@castiel.me.
+
+Last updated: 2026-04-19


### PR DESCRIPTION
## Summary

- Adds `PRIVACY.md` at the repo root so the Privacy Policy URL entered in App Store Connect (`https://github.com/scastiel/kado/blob/main/PRIVACY.md`) actually resolves.
- Content matches the draft under `docs/app-store-connect.md` → *Privacy Policy draft* — no data collection, CloudKit/HealthKit stay in the user's own containers, no third-party SDKs.

## Test plan

- [ ] Once merged, open https://github.com/scastiel/kado/blob/main/PRIVACY.md and confirm it renders.
- [ ] Paste that URL into App Store Connect → App Information → Privacy Policy URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)