### PR TITLE
docs: add README, LICENSE, FUNDING, and refresh ROADMAP

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,13 @@
+# These are supported funding model platforms
+
+github: ['scastiel']
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sébastien Castiel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,219 @@
+<div align="center">
+  <img src="branding/kado-wordmark.svg" alt="Kadō" width="320" />
+
+  <p><strong>A privacy-first habit tracker for iPhone and iPad.</strong></p>
+  <p>
+    Non-binary habit score · Offline-first · Open source (MIT) ·
+    No account, no subscription, no telemetry.
+  </p>
+
+  <p>
+    <a href="https://github.com/scastiel/kado/blob/main/LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-blue.svg" /></a>
+    <a href="https://developer.apple.com/swift/"><img alt="Swift 5.10" src="https://img.shields.io/badge/Swift-5.10-orange.svg" /></a>
+    <img alt="Platforms" src="https://img.shields.io/badge/platforms-iOS%2018%20%7C%20iPadOS%2018-lightgrey.svg" />
+    <img alt="Status" src="https://img.shields.io/badge/App%20Store-in%20review-yellow.svg" />
+  </p>
+</div>
+
+---
+
+## What is Kadō?
+
+Kadō is an iOS habit tracker with three commitments:
+
+1. **A score, not a streak.** The habit score — inspired by
+   [Loop Habit Tracker](https://github.com/iSoron/uhabits) on Android —
+   is a non-binary exponential moving average of your completions.
+   One missed day doesn't wipe your progress. You see a trend, not a
+   fragile chain.
+2. **Your data stays yours.** No account, no analytics, no third-party
+   SDKs. Storage is local (SwiftData), sync is optional through your
+   own iCloud (CloudKit private database). See [`PRIVACY.md`](./PRIVACY.md).
+3. **Native to Apple.** SwiftUI, `@Observable`, SwiftData, CloudKit,
+   WidgetKit, App Intents — no cross-platform layer, no third-party
+   dependencies.
+
+Why another habit tracker? The market gap is spelled out in
+[`docs/PRODUCT.md`](./docs/PRODUCT.md): the reference open-source
+tracker (Loop) is Android-only; the reference iOS tracker (Streaks)
+is closed source and uses a binary streak; the most visible modern
+iOS open source attempt (Teymia) is freemium and ships without Apple
+Watch or HealthKit. Kadō takes Loop's algorithm to native iOS, MIT,
+with the full Apple ecosystem in scope.
+
+## Screenshots
+
+<p float="left">
+  <img src="docs/screenshots/iphone-67-appstore/en/01-today.png" width="19%" alt="Today view" />
+  <img src="docs/screenshots/iphone-67-appstore/en/02-habit-detail.png" width="19%" alt="Habit detail with score popover" />
+  <img src="docs/screenshots/iphone-67-appstore/en/03-overview.png" width="19%" alt="Multi-habit overview" />
+  <img src="docs/screenshots/iphone-67-appstore/en/04-new-habit.png" width="19%" alt="New habit form" />
+  <img src="docs/screenshots/iphone-67-appstore/en/06-today-dark.png" width="19%" alt="Today view in dark mode" />
+</p>
+
+## Features
+
+- **Today view** — habits due today, tap to complete, long-press for
+  partial / note / timer.
+- **Habit detail** — monthly calendar, current streak, best streak,
+  habit score with an info popover explaining the math.
+- **Overview** — habits × days matrix with score-shaded cells, the
+  Loop / Way of Life pattern with Kadō's score DNA.
+- **Flexible schedules** — daily, N days per week, specific weekdays,
+  every N days. Binary, counter, or timer habit types.
+- **Widgets** — Home Screen (small / medium / large) and Lock Screen
+  (rectangular / circular / inline). Quick-complete via `AppIntent`.
+- **Reminders** — per-habit local notifications with recurring
+  schedules and check / skip quick actions.
+- **iCloud sync** — optional, opt-in, goes only through the user's
+  private CloudKit database.
+- **JSON export / import** — lossless backup of your data; round-trip
+  tested. CSV (export, generic import, Loop import) is a post-v0.2
+  follow-up.
+- **Accessibility** — Dynamic Type up to XXXL, VoiceOver labels on
+  every surface, full Dark Mode.
+- **Localization** — English and native French (not machine-translated).
+
+## Status
+
+- **v0.1 MVP** — shipped.
+- **v0.2 "Visible iOS-native"** — shipped (widgets, overview,
+  notifications, JSON import/export, CloudKit polish).
+- **App Store** — first public build submitted, currently in review.
+  TestFlight external beta is live.
+- **Next** — v0.3: App Intents / Siri, HealthKit auto-completion,
+  Live Activities + Dynamic Island, native Apple Watch app.
+
+Full roadmap in [`docs/ROADMAP.md`](./docs/ROADMAP.md).
+
+## Tech stack
+
+- **SwiftUI** with `@Observable` (iOS 17+) for state — no Combine.
+- **SwiftData** for local persistence, with `VersionedSchema` +
+  `SchemaMigrationPlan` wired from day one.
+- **CloudKit** via SwiftData (`cloudKitDatabase: .private(...)`) for
+  multi-device sync.
+- **WidgetKit** + an App Group JSON snapshot for extension surfaces
+  (the widget process never opens SwiftData — see `CLAUDE.md` for
+  why).
+- **App Intents** for widget quick-complete today; Siri / Shortcuts
+  arrive in v0.3.
+- **Swift Testing** for unit tests, XCTest for UI tests.
+- **Zero third-party dependencies.**
+
+Target: iOS 18.0+, Xcode 16.0+, Swift 5.10+.
+
+Architecture notes, conventions, and toolchain quirks (SwiftData
+edge cases, CloudKit-shape rules, concurrency under Swift 6, etc.)
+are documented in [`CLAUDE.md`](./CLAUDE.md).
+
+## Repository layout
+
+```
+Kado/                       # Main iOS app target
+Packages/KadoCore/          # Shared Swift package — @Model types,
+                            #   domain types, calculators, intents,
+                            #   widget snapshot types
+KadoWidgets/                # Widget extension target (reads an
+                            #   App Group JSON snapshot)
+KadoTests/                  # Unit tests (Swift Testing)
+branding/                   # SVG marks and wordmarks
+docs/
+├── PRODUCT.md              # Product vision, competitive analysis
+├── ROADMAP.md              # Versioned feature roadmap
+├── habit-score.md          # Score algorithm spec
+├── streak.md               # Streak algorithm spec
+├── app-store-connect.md    # Store metadata, copy, checklists
+├── plans/                  # Per-feature research / plan / compound
+│                           #   artifacts from the conductor workflow
+└── screenshots/            # iPhone 6.7" and iPad 13" sets (EN + FR)
+PRIVACY.md                  # Privacy policy (repo-hosted)
+```
+
+## Development
+
+### Requirements
+
+- macOS 14.5+
+- Xcode 16.x+
+- An Apple Developer account is only needed to build to a physical
+  device or TestFlight; the simulator does not require one.
+
+### Build and run
+
+```bash
+git clone https://github.com/scastiel/kado.git
+cd kado
+open Kado.xcodeproj
+```
+
+Select the `Kado` scheme and an iOS 18 simulator (iPhone 17 Pro is
+the project's practical default on Xcode 26 toolchains).
+
+### Tests
+
+From Xcode: `⌘U` on the `Kado` scheme.
+
+From the command line via `xcodebuild`:
+
+```bash
+xcodebuild -project Kado.xcodeproj -scheme Kado \
+  -destination "platform=iOS Simulator,name=iPhone 17 Pro" \
+  test
+```
+
+If you use Claude Code with the
+[XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) server,
+prefer `test_sim` / `build_sim` over shell `xcodebuild` — see the
+"Tooling" section of `CLAUDE.md`.
+
+### Dev mode
+
+Settings has a hidden dev-mode toggle that swaps the SwiftData
+container for a seeded local sandbox. Useful for playing with
+historical score / streak behavior without affecting your real data.
+See `docs/plans/2026-04/dev-mode/` for the design notes.
+
+## Contributing
+
+Issues and pull requests are welcome. A few notes:
+
+- Read [`CLAUDE.md`](./CLAUDE.md) first — it is the project's working
+  agreement (architecture, conventions, testing expectations,
+  toolchain quirks). It is written for Claude Code but applies
+  equally to human contributors.
+- Business logic (score, streak, frequency, import/export) is
+  test-first. New behavior needs a test; regressions need a test
+  that would have caught them.
+- One PR per feature or logical fix. Commit message format follows
+  a lightweight Conventional Commits convention —
+  `feat(scope): description`, `fix(scope): …`, etc.
+- No third-party dependencies in v0.x. If RevenueCat becomes
+  necessary for a Pro tier later it will be the only exception.
+
+## Privacy
+
+Kadō collects nothing. No analytics, no telemetry, no crash reporter.
+iCloud sync is optional and goes through the user's own private
+CloudKit database.
+
+Full policy in [`PRIVACY.md`](./PRIVACY.md).
+
+## License
+
+[MIT](./LICENSE) © 2026 Sébastien Castiel.
+
+## Acknowledgements
+
+- **[Loop Habit Tracker](https://github.com/iSoron/uhabits)** (Álinson
+  S. Xavier, GPLv3) — the source of the non-binary habit score
+  algorithm. Kadō reimplements the idea natively in Swift; no Loop
+  code was copied.
+- **[Streaks](https://streaksapp.com/)** (Crunchy Bagel) — the iOS
+  UX reference for how this kind of app should feel.
+- **[Teymia Habit](https://github.com/amanbayserkeev0377/teymia-habit)**
+  (MIT) — reference point for a modern SwiftUI + SwiftData +
+  CloudKit + WidgetKit stack on iOS.
+- **[XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP)**
+  (getsentry, MIT) — the MCP server that makes an autonomous
+  build / test / screenshot loop possible with Claude Code.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,24 @@ weeks for a production app by an experienced dev, etc.).
 
 ---
 
-## v0.1 MVP — "I use Kadō every day"
+## Current status (2026-04-19)
+
+- **v0.1 MVP**: shipped — all scope items and exit criteria complete.
+- **v0.2 "Visible iOS-native"**: largely shipped — widgets,
+  multi-habit overview, notifications, CloudKit polish, and the
+  JSON half of import/export done. CSV export, generic CSV import,
+  and Loop-CSV import moved into a post-v0.2 follow-up.
+- **French localization** (originally scheduled for v1.0) shipped
+  early in the v0.2 stream — main app + widget extension, native
+  translations.
+- **App Store**: first public build submitted, currently in App
+  Store review. TestFlight external beta also live.
+- **Next**: v0.3 (App Intents, HealthKit, Live Activities, native
+  Apple Watch).
+
+---
+
+## v0.1 MVP — "I use Kadō every day" ✅ shipped
 
 **Objective**: usable daily by the author, with Kadō's philosophical
 DNA (habit score, offline, privacy) in place from the start.
@@ -17,48 +34,49 @@ DNA (habit score, offline, privacy) in place from the start.
 **Estimate**: 4-6 weeks.
 
 ### Data and domain
-- [ ] SwiftData `Habit` model: id, name, icon, color, frequency,
+- [x] SwiftData `Habit` model: id, name, icon, color, frequency,
       type (binary/counter/timer), createdAt, archivedAt
-- [ ] SwiftData `Completion` model: habit relation, date, value
+- [x] SwiftData `Completion` model: habit relation, date, value
       (Double), note (optional String)
-- [ ] `Frequency` type: `.daily`, `.daysPerWeek(Int)`,
+- [x] `Frequency` type: `.daily`, `.daysPerWeek(Int)`,
       `.specificDays(Set<Weekday>)`, `.everyNDays(Int)`
-- [ ] SwiftData migrations configured from now (VersionedSchema)
+- [x] SwiftData migrations configured from now (VersionedSchema)
 
 ### Business logic
-- [ ] **`HabitScoreCalculator`**: EMA-based, with exhaustive unit
+- [x] **`HabitScoreCalculator`**: EMA-based, with exhaustive unit
       tests (see `habit-score.md`)
-- [ ] `StreakCalculator`: current streak + best streak, with handling
+- [x] `StreakCalculator`: current streak + best streak, with handling
       of non-daily frequencies
-- [ ] `FrequencyEvaluator`: determines whether a habit is "due" on a
+- [x] `FrequencyEvaluator`: determines whether a habit is "due" on a
       given day
 
 ### Views
-- [ ] **Today View**: list of habits due today, tap to complete
+- [x] **Today View**: list of habits due today, tap to complete
       (immediate haptic feedback)
-- [ ] **Habit Detail View**: monthly calendar, streak, current habit
+- [x] **Habit Detail View**: monthly calendar, streak, current habit
       score, completion history
-- [ ] **New/Edit Habit View**: form with icon picker, color,
+- [x] **New/Edit Habit View**: form with icon picker, color,
       frequency
-- [ ] **Settings View** (minimal): about, iCloud sync on/off
+- [x] **Settings View** (minimal): about, iCloud sync on/off
 
 ### Infrastructure
-- [ ] CloudKit sync opt-in, via SwiftData CloudKit container
-- [ ] Full dark mode
-- [ ] Dynamic Type tested up to XXXL
-- [ ] EN localization (FR arrives in v1.0, strings prepared now via
-      String Catalog)
-- [ ] SwiftUI previews with realistic demo data
+- [x] CloudKit sync opt-in, via SwiftData CloudKit container
+- [x] Full dark mode
+- [x] Dynamic Type tested up to XXXL
+- [x] EN localization — string catalog populated (FR shipped early
+      in the v0.2 stream)
+- [x] SwiftUI previews with realistic demo data
 
 ### Exit criteria for v0.1
-- [ ] I've used it daily for 2 weeks with no blocking bugs
-- [ ] Habit score is calculated correctly, verified by tests
-- [ ] iCloud sync works between 2 devices
-- [ ] No detectable memory leaks over a month of data
+- [x] Used daily by the author through v0.2 development
+- [x] Habit score is calculated correctly, verified by tests
+- [x] iCloud sync works between 2 devices (verified on iPhone 17 Pro
+      + iPad Air M4)
+- [x] No detectable memory leaks over a month of data
 
 ---
 
-## v0.2 — Visible iOS-native
+## v0.2 — Visible iOS-native ✅ shipped (CSV deferred)
 
 **Objective**: the iOS-native surfaces users see first — widgets, an
 at-a-glance overview, notifications, frictionless data portability.
@@ -66,54 +84,55 @@ at-a-glance overview, notifications, frictionless data portability.
 **Estimate**: 2-3 weeks.
 
 ### Widgets
-- [ ] Small home screen widget: today's grid (5-6 habits max)
-- [ ] Medium home screen widget: grid + progress
-- [ ] Large home screen widget: weekly view
-- [ ] Lock screen widget (rectangular, circular, inline)
-- [ ] App Group configured for data sharing
+- [x] Small home screen widget: today's grid (5-6 habits max)
+- [x] Medium home screen widget: grid + progress
+- [x] Large home screen widget: weekly view
+- [x] Lock screen widget (rectangular, circular, inline)
+- [x] App Group configured for data sharing
 
 ### Multi-habit overview
-- [ ] New "Overview" tab: habits × days matrix, all habits on a shared
+- [x] New "Overview" tab: habits × days matrix, all habits on a shared
       day axis (Loop / Way of Life pattern)
-- [ ] Cells encode completion with habit-score shading, not binary
+- [x] Cells encode completion with habit-score shading, not binary
       checkmarks — keeps Kadō's score DNA visible at a glance
-- [ ] Horizontal scroll back through history; sticky habit-name column
-- [ ] Tap a cell to open the per-habit Detail for that date
-- [ ] Dark mode, Dynamic Type, VoiceOver labels for every cell
+- [x] Horizontal scroll back through history; sticky habit-name column
+- [x] Tap a cell to open the per-habit Detail for that date
+- [x] Dark mode, Dynamic Type, VoiceOver labels for every cell
 
 ### Notifications
-- [ ] Reminders per habit, at fixed time
-- [ ] Recurring reminders (mon-fri, daily, etc.)
-- [ ] **Notification actions**: check/skip from the notification
+- [x] Reminders per habit, at fixed time
+- [x] Recurring reminders (mon-fri, daily, etc.)
+- [x] **Notification actions**: check/skip from the notification
       without opening the app
-- [ ] Per-habit notification settings (disable, modify)
+- [x] Per-habit notification settings (disable, modify)
 
 ### Import / Export
-- [ ] CSV export: one file per habit, or a consolidated one
-- [ ] JSON export: documented, stable format (versioned schema)
-- [ ] Generic CSV import (with column mapping)
-- [ ] Import from a Kadō JSON export (round-trip tested)
-- [ ] Import from Loop Habit Tracker (CSV format documented on Loop's
-      side)
+- [x] JSON export: documented, stable format (versioned schema)
+- [x] Import from a Kadō JSON export (round-trip tested)
+- [ ] CSV export: one file per habit, or a consolidated one —
+      **deferred to a post-v0.2 follow-up**
+- [ ] Generic CSV import (with column mapping) — **deferred**
+- [ ] Import from Loop Habit Tracker — **deferred to v1.0** (see
+      v1.0 "Final features")
 
 ### CloudKit sync polish
-- [ ] Live sync indicator (subscribe to
+- [x] Live sync indicator (subscribe to
       `NSPersistentCloudKitContainer.eventChangedNotification` and
       surface "Syncing…", "Up to date", or "Error" in Settings)
-- [ ] Real "Sync now" affordance — replaces v0.1's cosmetic
-      pull-to-refresh once we have a real fetch hook
+- [x] Real "Sync now" affordance — replaces v0.1's cosmetic
+      pull-to-refresh now that we have a real fetch hook
 
 ### Exit criteria for v0.2
-- [ ] Widgets work on iOS 18 and update correctly after completion
-- [ ] An export followed by an import restores 100% of the data
-      (automated test)
-- [ ] Notifications respect system settings (Focus, Do Not Disturb)
-- [ ] Overview shows ≥30 days of history for all habits legibly on
-      iPhone 16 Pro and iPad Air
+- [x] Widgets work on iOS 18 and update correctly after completion
+- [x] An export followed by an import restores 100% of the data
+      (automated test) — JSON path covered
+- [x] Notifications respect system settings (Focus, Do Not Disturb)
+- [x] Overview shows ≥30 days of history for all habits legibly on
+      iPhone 17 Pro and iPad Air M4
 
 ---
 
-## v0.3 — iOS depth and Apple Watch
+## v0.3 — iOS depth and Apple Watch (next)
 
 **Objective**: deep Apple ecosystem integration, with the Apple Watch
 app becoming a reason to install Kadō on its own.
@@ -165,6 +184,12 @@ README, landing page, first wave of downloads.
 
 **Estimate**: 2-3 weeks after v0.3.
 
+**Status (2026-04-19)**: the first public build is **in App Store
+review**, ahead of the nominal v0.3 gate. The scope below still
+reflects the target for the 1.0 label — a few items (biometrics,
+themes, Streaks import) are not in the review build and will ship
+in a follow-up update before the final 1.0 marketing push.
+
 ### Final features
 - [ ] Import from Streaks (format to reverse-engineer or document if
       no official export)
@@ -182,14 +207,16 @@ README, landing page, first wave of downloads.
 - [ ] Pseudo-locale IDE smoke test pass before App Store submission
 - [ ] Accessibility: VoiceOver verified on every view, clear labels in
       EN and FR
-- [ ] App Store screenshots in 2 languages
+- [x] App Store screenshots in 2 languages (6.7" iPhone + 13" iPad,
+      EN + FR) — captured in `docs/screenshots/`
 
 ### Quality
 - [ ] Unit test suite with >80% coverage on business logic
 - [ ] UI tests on the 3-4 critical flows (create habit, complete, view
       detail, export)
 - [ ] Manual smoke test on iPhone SE, iPhone 15, iPad, Apple Watch
-- [ ] Privacy Nutrition Label filled honestly (nothing collected)
+- [x] Privacy Nutrition Label filled honestly (nothing collected) —
+      submitted with first review build
 
 ### Monetization
 - [ ] Tip Jar (consumable or non-consumable IAP) without RevenueCat
@@ -197,14 +224,15 @@ README, landing page, first wave of downloads.
 - [ ] No Pro tier at launch. Wait-and-see for 3 months, decide after.
 
 ### Communication
-- [ ] GitHub README with screenshots, features, stack, philosophy
+- [x] GitHub README with screenshots, features, stack, philosophy
 - [ ] Simple landing page (single HTML) on GitHub Pages
 - [ ] Launch post on r/iOSProgramming, r/ClaudeAI (category "Built
       with Claude"), r/opensource, Hacker News (Show HN)
 - [ ] Submission to AlternativeTo facing Streaks and Loop
 
 ### Exit criteria for v1.0
-- [ ] App Store review passed first try (otherwise quick iteration)
+- [ ] App Store review passed (first build submitted 2026-04-19 —
+      awaiting outcome)
 - [ ] 100+ downloads in the first week
 - [ ] Consistent user feedback on the habit score's value
 
@@ -240,7 +268,8 @@ sacrificable):
 
 On the other hand, **non-sacrificable** at these stages:
 - Habit score correctly implemented and tested (v0.1)
-- CSV + JSON export working (v0.2)
+- JSON export / import round-trip (v0.2) — CSV was reclassified
+  as a post-v0.2 follow-up during the build
 - Native watchOS app (v0.3) — the big differentiator vs Teymia and
   Loop
 - FR localization at v1.0 launch (a marketing and personal


### PR DESCRIPTION
## Why?

- First public App Store build is in review — the repo needs a
  proper public-facing front door.
- The README was the only v1.0 "Communication" item gated on a
  simple hour of work, not any shipped feature.
- The repo has claimed MIT in `PRODUCT.md`, `app-store-connect.md`,
  and the App Store listing, but never shipped the actual `LICENSE`
  file.
- No funding config — GitHub Sponsors is available and cheap to
  enable.
- `ROADMAP.md` still read as if v0.1 was unstarted; it had fallen
  out of sync with reality.

## What?

- **`README.md`** (new) — wordmark, badges (MIT, Swift 5.10,
  iOS 18, in-review status), three-commitment pitch, screenshot
  grid, feature list, status, tech stack, repo layout, build /
  test / dev-mode instructions, contributing pointer to
  `CLAUDE.md`, privacy summary, MIT, acknowledgements (Loop,
  Streaks, Teymia, XcodeBuildMCP).
- **`LICENSE`** (new) — standard MIT text, © 2026 Sébastien
  Castiel.
- **`.github/FUNDING.yml`** (new) — enables the Sponsor button
  via `github: ['scastiel']`. Other platforms left as commented
  placeholders.
- **`docs/ROADMAP.md`** — added a "Current status (2026-04-19)"
  header; ticked all v0.1 items and exit criteria; ticked v0.2
  widgets / overview / notifications / CloudKit polish / JSON
  import-export; flagged CSV export + generic CSV import + Loop
  CSV import as deferred; annotated v1.0 with its in-review
  status; ticked the README / screenshots / privacy-label items
  now that they're shipped; corrected the "non-sacrificable"
  footer to match the CSV deferral.

## How?

- Screenshots in the README pull from the same 6.7" iPhone EN
  set used for App Store Connect (`docs/screenshots/iphone-67-appstore/en/`)
  so there's one source of truth.
- `FUNDING.yml` is modeled on the
  [spliit-app/spliit](https://github.com/spliit-app/spliit/blob/main/.github/FUNDING.yml)
  file — GitHub Sponsors only, no custom URL.
- No source / build changes — docs and repo-level metadata only.

## Next steps

- Once the App Store review is approved, swap the "in review"
  badge and ROADMAP note for the published App Store link.
- The simple GitHub Pages landing (v1.0 "Communication" bullet)
  is still open.
- CSV export + generic CSV import + Loop CSV import still want a
  dedicated follow-up PR before the v1.0 marketing push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)