### PR TITLE
feat(site): add marketing webpage for GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,49 @@
+name: Deploy marketing site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - 'branding/**'
+      - 'docs/screenshots/iphone-67-appstore/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assemble site
+        run: make -C site build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ secrets.plist
 
 # Logs
 *.log
+
+# Marketing site — assets/ is populated at deploy time from branding/ and
+# docs/screenshots/iphone-67-appstore/. See .github/workflows/pages.yml.
+site/assets/

--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+getkado.app

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,0 +1,39 @@
+# Makefile for the Kadō marketing site.
+#
+# Run from the `site/` directory with `make <target>`, or from the repo
+# root with `make -C site <target>`. The GitHub Pages workflow calls
+# `make -C site build` before uploading the artifact.
+
+SITE_DIR  := $(CURDIR)
+REPO_ROOT := $(abspath $(SITE_DIR)/..)
+
+BRANDING_SRC    := $(REPO_ROOT)/branding
+SCREENSHOTS_SRC := $(REPO_ROOT)/docs/screenshots/iphone-67-appstore
+
+ASSETS             := $(SITE_DIR)/assets
+BRANDING_DST       := $(ASSETS)/branding
+SCREENSHOTS_EN_DST := $(ASSETS)/screenshots/en
+SCREENSHOTS_FR_DST := $(ASSETS)/screenshots/fr
+
+PORT ?= 8000
+
+.PHONY: build assets clean serve help
+.DEFAULT_GOAL := help
+
+build: assets ## Populate site/assets from branding/ and docs/screenshots/
+
+assets:
+	@mkdir -p $(BRANDING_DST) $(SCREENSHOTS_EN_DST) $(SCREENSHOTS_FR_DST)
+	cp $(BRANDING_SRC)/*.svg $(BRANDING_DST)/
+	cp $(SCREENSHOTS_SRC)/en/*.png $(SCREENSHOTS_EN_DST)/
+	cp $(SCREENSHOTS_SRC)/fr/*.png $(SCREENSHOTS_FR_DST)/
+
+clean: ## Remove site/assets/
+	rm -rf $(ASSETS)
+
+serve: build ## Build and serve the site locally on PORT (default 8000)
+	@echo "Kadō site → http://localhost:$(PORT)"
+	@cd $(SITE_DIR) && python3 -m http.server $(PORT)
+
+help: ## List available targets
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[1m%-10s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kadō — Un suivi d'habitudes respectueux de la vie privée, pour iPhone et iPad</title>
+  <meta name="description" content="Kadō est un suivi d'habitudes respectueux de la vie privée pour iPhone et iPad. Score non binaire, hors ligne, open source. Sans compte, sans abonnement, sans télémétrie.">
+  <meta name="theme-color" content="#FBF8F2" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#121513" media="(prefers-color-scheme: dark)">
+  <link rel="icon" type="image/svg+xml" href="/assets/branding/kado-app-icon.svg">
+  <link rel="alternate" hreflang="en" href="https://getkado.app/">
+  <link rel="alternate" hreflang="fr" href="https://getkado.app/fr/">
+  <link rel="alternate" hreflang="x-default" href="https://getkado.app/">
+  <link rel="canonical" href="https://getkado.app/fr/">
+  <link rel="stylesheet" href="/styles.css">
+  <meta property="og:title" content="Kadō — Un suivi d'habitudes respectueux de la vie privée">
+  <meta property="og:description" content="Score d'habitude non binaire. Hors ligne. Open source. Sans compte, sans abonnement, sans télémétrie.">
+  <meta property="og:image" content="https://getkado.app/assets/screenshots/fr/01-today.png">
+  <meta property="og:url" content="https://getkado.app/fr/">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="fr_FR">
+  <meta name="twitter:card" content="summary_large_image">
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav">
+      <a href="/fr/" class="brand" aria-label="Kadō, accueil">
+        <img src="/assets/branding/kado-mark.svg" alt="" class="brand-mark">
+        <span class="brand-name">Kadō</span>
+        <span class="brand-tag" aria-hidden="true">稼働 · in operation</span>
+      </a>
+      <nav>
+        <a href="#features">Fonctionnalités</a>
+        <a href="#faq">FAQ</a>
+        <a href="https://github.com/scastiel/kado" target="_blank" rel="noopener">GitHub</a>
+        <a href="/" class="lang-switch" hreflang="en">EN</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <img src="/assets/branding/kado-app-icon.svg" alt="" class="app-icon" width="96" height="96">
+      <h1>Des habitudes qui ne te punissent pas d'être humain.</h1>
+      <p class="lede">
+        Un suivi d'habitudes respectueux de ta vie privée, pour iPhone et iPad.
+        Un score d'habitude non binaire plutôt qu'une série fragile. Hors ligne.
+        Open source. Sans compte, sans abonnement, sans télémétrie.
+      </p>
+      <div class="cta">
+        <span class="btn btn--soon" aria-label="Bientôt sur l'App Store">
+          <span class="badge">Bientôt</span>
+          Bientôt sur l'App Store
+        </span>
+        <a class="btn btn-secondary" href="https://github.com/scastiel/kado" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.91c.58.1.79-.25.79-.55v-1.94c-3.2.69-3.87-1.54-3.87-1.54-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.27.73-1.56-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.3-.52-1.47.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.58.23 2.75.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.39-5.26 5.68.41.36.77 1.05.77 2.12v3.14c0 .3.21.66.8.55A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5z"/></svg>
+          Code source sur GitHub
+        </a>
+      </div>
+      <p class="hero-note">
+        v0.2 livrée · première version publique en revue App Store · bêta TestFlight en cours
+      </p>
+    </section>
+
+    <section id="screenshots" class="screenshots" aria-label="Captures d'écran">
+      <div class="screenshot-rail">
+        <figure><img src="/assets/screenshots/fr/01-today.png" alt="Vue Aujourd'hui avec les habitudes du jour" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/fr/02-habit-detail.png" alt="Détail d'une habitude avec calendrier mensuel et popover du score" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/fr/03-overview.png" alt="Matrice d'aperçu multi-habitudes" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/fr/04-new-habit.png" alt="Formulaire de création d'habitude" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/fr/06-today-dark.png" alt="Vue Aujourd'hui en mode sombre" loading="lazy" decoding="async"></figure>
+      </div>
+    </section>
+
+    <section id="features" class="block">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-kicker">Fonctionnalités</div>
+          <h2>Tout ce qu'il te faut. Rien de plus.</h2>
+          <p>L'ambition de Kadō est simple : t'aider à construire des habitudes durables sur iOS, avec des surfaces natives Apple et sans coûts cachés.</p>
+        </div>
+
+        <div class="feature-grid">
+          <article>
+            <h3>Un score, pas une série</h3>
+            <p>Le score d'habitude de Kadō est une moyenne mobile exponentielle de tes complétions, inspirée de Loop Habit Tracker. Une journée manquée fait légèrement baisser le score — elle n'efface pas des mois de progrès.</p>
+          </article>
+          <article>
+            <h3>Tes données t'appartiennent</h3>
+            <p>Aucun compte. Aucune analytique. Aucun SDK tiers. Le stockage est local ; la synchronisation est optionnelle et passe par ton propre conteneur CloudKit privé.</p>
+          </article>
+          <article>
+            <h3>Natif Apple</h3>
+            <p>SwiftUI, SwiftData, CloudKit, WidgetKit, App Intents. Widgets d'écran d'accueil et d'écran verrouillé. Pensé pour ressembler à une app Apple, pas à un portage multiplateforme.</p>
+          </article>
+          <article>
+            <h3>Horaires flexibles</h3>
+            <p>Quotidien, N jours par semaine, jours précis, ou tous les N jours. Habitudes binaires, compteurs, ou chronométrées — change de mode sans perdre ce que tu as déjà saisi.</p>
+          </article>
+          <article>
+            <h3>Aperçu d'un coup d'œil</h3>
+            <p>Une matrice habitudes × jours avec des cellules teintées selon le score — le motif Loop / Way of Life avec l'ADN du score de Kadō. Défile dans l'historique, touche une cellule pour ouvrir la journée.</p>
+          </article>
+          <article>
+            <h3>Des rappels sans bruit</h3>
+            <p>Notifications locales par habitude avec horaires récurrents et actions rapides "faire" / "passer". Planifiées sur l'appareil, rien ne passe par un serveur.</p>
+          </article>
+          <article>
+            <h3>Importe, exporte, quitte</h3>
+            <p>L'import/export JSON sans perte est déjà livré. L'export CSV et l'import depuis Loop, Streaks, ou CSV générique arriveront peu après la v0.2. Anti-enfermement dès le départ.</p>
+          </article>
+          <article>
+            <h3>Accessible par défaut</h3>
+            <p>Dynamic Type jusqu'à XXXL, étiquettes VoiceOver sur chaque surface, Dark Mode, et couleurs sémantiques qui s'adaptent au mode Augmenter le contraste.</p>
+          </article>
+          <article>
+            <h3>Anglais et français natif</h3>
+            <p>Traduit par une personne francophone, pas par une machine. <code>tu</code>, <code>série</code>, <code>habitude</code> — ça sonne juste, pas traduit.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="block">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-kicker">FAQ</div>
+          <h2>Questions fréquentes</h2>
+        </div>
+
+        <div class="faq-list">
+          <details class="faq-item">
+            <summary>Quelle est la différence entre un score d'habitude et une série ?</summary>
+            <div class="faq-answer">
+              <p>Une série tombe à zéro à la moindre journée manquée, ce qui peut rendre tout le suivi pesant. Le score d'habitude de Kadō est une moyenne mobile exponentielle de tes complétions récentes : une journée ratée fait doucement reculer le score, une journée réussie le fait avancer, et des semaines de régularité pèsent plus qu'un mauvais après-midi. Les séries restent affichées — elles ne sont simplement plus le seul indicateur.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Combien coûte Kadō ?</summary>
+            <div class="faq-answer">
+              <p>L'app est gratuite et open source sous licence MIT. Aucun abonnement, aucune publicité, aucune fonctionnalité essentielle payante. Un pourboire optionnel — et éventuellement une version "Pro" cosmétique plus tard, pour des thèmes supplémentaires — sont les seules pistes de monétisation envisagées.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Kadō collecte-t-il des données ?</summary>
+            <div class="faq-answer">
+              <p>Non. Aucune analytique, aucune télémétrie, aucun rapport de plantage, aucun SDK tiers. Si tu actives la synchronisation iCloud, tes données passent par la base de données privée CloudKit d'Apple — elles vivent dans ton propre iCloud, et le développeur n'y a pas accès. Politique complète : <a href="https://github.com/scastiel/kado/blob/main/PRIVACY.md">PRIVACY.md</a>.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Faut-il un compte pour l'utiliser ?</summary>
+            <div class="faq-answer">
+              <p>Non. Kadō fonctionne entièrement hors ligne, sans inscription. La synchronisation iCloud est optionnelle et s'appuie sur l'identifiant Apple déjà configuré sur ton appareil.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Puis-je synchroniser entre mon iPhone et mon iPad ?</summary>
+            <div class="faq-answer">
+              <p>Oui — via iCloud, si tu l'actives. La synchronisation passe par la base de données privée CloudKit d'Apple, donc tes données ne touchent aucun serveur tiers. Testée entre iPhone et iPad, et désactivée par défaut.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Y a-t-il une app Apple Watch ?</summary>
+            <div class="faq-answer">
+              <p>Pas encore. Une app Apple Watch native est prévue pour la v0.3, avec les App Intents / raccourcis Siri, l'auto-complétion HealthKit, et les Live Activities avec l'îlot dynamique. Voir la <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">feuille de route</a>.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Puis-je importer mes habitudes depuis une autre app ?</summary>
+            <div class="faq-answer">
+              <p>L'import/export JSON est livré et testé en aller-retour. L'export CSV, l'import CSV générique, et l'import direct depuis Loop Habit Tracker et Streaks sont sur la feuille de route à court terme. Tu ne devrais jamais te sentir coincé dans une app.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Quels appareils et versions d'iOS sont pris en charge ?</summary>
+            <div class="faq-answer">
+              <p>iPhone et iPad sous iOS 18 ou plus récent. Le support watchOS, de l'îlot dynamique, et de macOS est prévu mais pas encore livré.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Le code source est-il vraiment ouvert ?</summary>
+            <div class="faq-answer">
+              <p>Oui. Tout le code est sous licence MIT sur <a href="https://github.com/scastiel/kado">github.com/scastiel/kado</a>. Les tickets, rapports de bugs et pull requests sont bienvenus. Claude Code est utilisé comme partenaire de programmation — le fichier <a href="https://github.com/scastiel/kado/blob/main/CLAUDE.md">CLAUDE.md</a> est la convention de travail du projet et s'applique autant aux humains qu'à l'IA.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Que veut dire "Kadō" ?</summary>
+            <div class="faq-answer">
+              <p>Kadō (稼働) veut dire "en opération" ou "en fonctionnement" en japonais — l'état d'un système qui fait son travail discrètement, jour après jour. Un nom qui va bien à une habitude qui tient dans la durée. C'est un nom de travail ; le nom public définitif sera confirmé avant la v1.0.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="block">
+      <div class="container">
+        <div class="next">
+          <div class="section-kicker">La suite</div>
+          <h2>v0.3 : Siri, HealthKit, Watch</h2>
+          <p>App Intents et raccourcis Siri, auto-complétion HealthKit, Live Activities avec îlot dynamique, et une app Apple Watch native. <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">Voir la feuille de route →</a></p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-grid">
+      <div>
+        <strong>Kadō</strong>
+        <p>Un suivi d'habitudes respectueux de la vie privée, pour iPhone et iPad. Sous licence MIT, open source. Construit au grand jour.</p>
+      </div>
+      <nav aria-label="Liens">
+        <a href="https://github.com/scastiel/kado">Code source</a>
+        <a href="https://github.com/scastiel/kado/blob/main/PRIVACY.md">Vie privée</a>
+        <a href="https://github.com/scastiel/kado/blob/main/LICENSE">Licence</a>
+        <a href="https://github.com/scastiel/kado/issues">Contact</a>
+      </nav>
+      <div class="lang-foot" aria-label="Langue">
+        <a href="/" hreflang="en">English</a>
+        <a href="/fr/" aria-current="page">Français</a>
+      </div>
+    </div>
+    <p class="foot-bottom">© 2026 Sébastien Castiel · Kadō n'est pas affilié à Apple Inc. App Store est une marque déposée d'Apple Inc.</p>
+  </footer>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kadō — A privacy-first habit tracker for iPhone and iPad</title>
+  <meta name="description" content="Kadō is a privacy-first habit tracker for iPhone and iPad. Non-binary habit score, offline-first, open source. No account, no subscription, no telemetry.">
+  <meta name="theme-color" content="#FBF8F2" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#121513" media="(prefers-color-scheme: dark)">
+  <link rel="icon" type="image/svg+xml" href="/assets/branding/kado-app-icon.svg">
+  <link rel="alternate" hreflang="en" href="https://getkado.app/">
+  <link rel="alternate" hreflang="fr" href="https://getkado.app/fr/">
+  <link rel="alternate" hreflang="x-default" href="https://getkado.app/">
+  <link rel="canonical" href="https://getkado.app/">
+  <link rel="stylesheet" href="/styles.css">
+  <meta property="og:title" content="Kadō — A privacy-first habit tracker">
+  <meta property="og:description" content="Non-binary habit score. Offline-first. Open source. No account, no subscription, no telemetry.">
+  <meta property="og:image" content="https://getkado.app/assets/screenshots/en/01-today.png">
+  <meta property="og:url" content="https://getkado.app/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+</head>
+<body>
+  <header class="site-header">
+    <div class="nav">
+      <a href="/" class="brand" aria-label="Kadō home">
+        <img src="/assets/branding/kado-mark.svg" alt="" class="brand-mark">
+        <span class="brand-name">Kadō</span>
+        <span class="brand-tag" aria-hidden="true">稼働 · in operation</span>
+      </a>
+      <nav>
+        <a href="#features">Features</a>
+        <a href="#faq">FAQ</a>
+        <a href="https://github.com/scastiel/kado" target="_blank" rel="noopener">GitHub</a>
+        <a href="/fr/" class="lang-switch" hreflang="fr">FR</a>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <img src="/assets/branding/kado-app-icon.svg" alt="" class="app-icon" width="96" height="96">
+      <h1>Habits that don't punish you for being human.</h1>
+      <p class="lede">
+        A privacy-first habit tracker for iPhone and iPad. A non-binary habit
+        score instead of a fragile streak. Offline-first. Open source. No
+        account, no subscription, no telemetry.
+      </p>
+      <div class="cta">
+        <span class="btn btn--soon" aria-label="Coming soon to the App Store">
+          <span class="badge">Soon</span>
+          Coming to the App Store
+        </span>
+        <a class="btn btn-secondary" href="https://github.com/scastiel/kado" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5A11.5 11.5 0 0 0 .5 12a11.5 11.5 0 0 0 7.86 10.91c.58.1.79-.25.79-.55v-1.94c-3.2.69-3.87-1.54-3.87-1.54-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.71 1.26 3.37.96.1-.75.4-1.27.73-1.56-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.19-3.1-.12-.3-.52-1.47.11-3.05 0 0 .97-.31 3.18 1.18a11 11 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.58.23 2.75.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.42-2.69 5.39-5.26 5.68.41.36.77 1.05.77 2.12v3.14c0 .3.21.66.8.55A11.5 11.5 0 0 0 23.5 12 11.5 11.5 0 0 0 12 .5z"/></svg>
+          Source on GitHub
+        </a>
+      </div>
+      <p class="hero-note">
+        v0.2 shipped · first public build in App Store review · TestFlight beta live
+      </p>
+    </section>
+
+    <section id="screenshots" class="screenshots" aria-label="Screenshots">
+      <div class="screenshot-rail">
+        <figure><img src="/assets/screenshots/en/01-today.png" alt="Today view with habits due today" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/en/02-habit-detail.png" alt="Habit detail with monthly calendar and habit score popover" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/en/03-overview.png" alt="Multi-habit overview matrix" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/en/04-new-habit.png" alt="New habit creation form" loading="lazy" decoding="async"></figure>
+        <figure><img src="/assets/screenshots/en/06-today-dark.png" alt="Today view in dark mode" loading="lazy" decoding="async"></figure>
+      </div>
+    </section>
+
+    <section id="features" class="block">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-kicker">Features</div>
+          <h2>Everything you need. Nothing you don't.</h2>
+          <p>Kadō's ambition is narrow: help you build long-term habits on iOS, with Apple-native surfaces and no hidden costs.</p>
+        </div>
+
+        <div class="feature-grid">
+          <article>
+            <h3>A score, not a streak</h3>
+            <p>Kadō's habit score is an exponential moving average of your completions, inspired by Loop Habit Tracker. One missed day nudges the number down — it doesn't wipe months of progress.</p>
+          </article>
+          <article>
+            <h3>Your data stays yours</h3>
+            <p>No account. No analytics. No third-party SDKs. Storage is local; sync is optional through your own iCloud, in your private CloudKit container.</p>
+          </article>
+          <article>
+            <h3>Native to Apple</h3>
+            <p>SwiftUI, SwiftData, CloudKit, WidgetKit, App Intents. Home-screen and lock-screen widgets. Designed to feel like a first-party iOS app, not a cross-platform port.</p>
+          </article>
+          <article>
+            <h3>Flexible schedules</h3>
+            <p>Daily, N days per week, specific weekdays, or every N days. Binary, counter, or timer habit types — switch without losing what you already entered.</p>
+          </article>
+          <article>
+            <h3>Overview at a glance</h3>
+            <p>A habits × days matrix with score-shaded cells — the Loop / Way of Life pattern with Kadō's score DNA. Scroll back through history, tap any cell to open its day.</p>
+          </article>
+          <article>
+            <h3>Reminders without noise</h3>
+            <p>Per-habit local notifications with recurring schedules and check / skip quick actions. Scheduled on-device; nothing routes through a server.</p>
+          </article>
+          <article>
+            <h3>Import, export, leave</h3>
+            <p>Lossless JSON round-trip is shipped. CSV export and import from Loop, Streaks, and generic CSV arrive shortly after v0.2. Anti-lock-in from day one.</p>
+          </article>
+          <article>
+            <h3>Accessible by default</h3>
+            <p>Full Dynamic Type up to XXXL, VoiceOver labels on every surface, Dark Mode, and semantic colors that adapt to Increase Contrast.</p>
+          </article>
+          <article>
+            <h3>English and native French</h3>
+            <p>Translated by a French speaker, not a machine. <code>tu</code>, <code>série</code>, <code>habitude</code> — it reads right, not translated.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="faq" class="block">
+      <div class="container">
+        <div class="section-head">
+          <div class="section-kicker">FAQ</div>
+          <h2>Frequently asked</h2>
+        </div>
+
+        <div class="faq-list">
+          <details class="faq-item">
+            <summary>What's the difference between a habit score and a streak?</summary>
+            <div class="faq-answer">
+              <p>A streak resets to zero the moment you miss a day, which can make the whole tracker feel punishing. Kadō's habit score is an exponential moving average of your recent completions: a missed day gently nudges the number down, a successful day nudges it up, and weeks of consistency outweigh a single bad afternoon. Streaks are still shown — they're just not the only signal.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>How much does Kadō cost?</summary>
+            <div class="faq-answer">
+              <p>The app is free and open source under the MIT license. No subscription, no ads, no paywalled core features. A one-time tip jar — and possibly an optional cosmetic "Pro" tier later, for things like extra themes — are the only monetization paths ever considered.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Does Kadō collect any data?</summary>
+            <div class="faq-answer">
+              <p>No. There is no analytics, no telemetry, no crash reporter, and no third-party SDK. If you enable iCloud sync, your data goes through Apple's CloudKit private database — it lives in your own iCloud, and the developer cannot see it. Full policy: <a href="https://github.com/scastiel/kado/blob/main/PRIVACY.md">PRIVACY.md</a>.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Do I need an account to use it?</summary>
+            <div class="faq-answer">
+              <p>No. Kadō works fully offline with zero sign-up. iCloud sync is optional and piggybacks on the Apple ID you already have on your device.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Can I sync between my iPhone and iPad?</summary>
+            <div class="faq-answer">
+              <p>Yes — through iCloud, if you opt in. Sync uses Apple's CloudKit private database, so your data never touches a third-party server. It's been tested across iPhone and iPad, and it's off by default.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Is there an Apple Watch app?</summary>
+            <div class="faq-answer">
+              <p>Not yet. A native Apple Watch app is planned for v0.3, alongside App Intents / Siri support, HealthKit auto-completion, and Live Activities with Dynamic Island. See the <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">roadmap</a>.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Can I import my habits from another tracker?</summary>
+            <div class="faq-answer">
+              <p>JSON import/export is shipped and round-trip tested. CSV export, generic CSV import, and direct import from Loop Habit Tracker and Streaks are on the short-term roadmap. You should never feel stuck in an app.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>What devices and iOS versions are supported?</summary>
+            <div class="faq-answer">
+              <p>iPhone and iPad on iOS 18 or later. watchOS, Dynamic Island, and macOS support are planned but not shipped yet.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>Is the source really open?</summary>
+            <div class="faq-answer">
+              <p>Yes. The full source is MIT-licensed at <a href="https://github.com/scastiel/kado">github.com/scastiel/kado</a>. Issues, bug reports, and pull requests are welcome. Claude Code is used as a pair programmer — the <a href="https://github.com/scastiel/kado/blob/main/CLAUDE.md">CLAUDE.md</a> file is the project's working agreement and applies equally to human contributors.</p>
+            </div>
+          </details>
+
+          <details class="faq-item">
+            <summary>What does "Kadō" mean?</summary>
+            <div class="faq-answer">
+              <p>Kadō (稼働) is Japanese for "in operation" or "running" — the state of a system that's quietly doing its job, day after day. A fitting name for a habit that keeps going. It's a working name; the final public name will be confirmed before v1.0.</p>
+            </div>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <section class="block">
+      <div class="container">
+        <div class="next">
+          <div class="section-kicker">What's next</div>
+          <h2>v0.3: Siri, HealthKit, Watch</h2>
+          <p>App Intents and Siri shortcuts, HealthKit auto-completion, Live Activities with Dynamic Island, and a native Apple Watch app. <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">See the roadmap →</a></p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="footer-grid">
+      <div>
+        <strong>Kadō</strong>
+        <p>A privacy-first habit tracker for iPhone and iPad. MIT-licensed, open source. Built in the open.</p>
+      </div>
+      <nav aria-label="Links">
+        <a href="https://github.com/scastiel/kado">Source code</a>
+        <a href="https://github.com/scastiel/kado/blob/main/PRIVACY.md">Privacy</a>
+        <a href="https://github.com/scastiel/kado/blob/main/LICENSE">License</a>
+        <a href="https://github.com/scastiel/kado/issues">Contact</a>
+      </nav>
+      <div class="lang-foot" aria-label="Language">
+        <a href="/" aria-current="page">English</a>
+        <a href="/fr/" hreflang="fr">Français</a>
+      </div>
+    </div>
+    <p class="foot-bottom">© 2026 Sébastien Castiel · Kadō is not affiliated with Apple Inc. App Store is a trademark of Apple Inc.</p>
+  </footer>
+</body>
+</html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,460 @@
+:root {
+  --bg: #FBF8F2;
+  --bg-deep: #F0E8D8;
+  --surface: #FFFFFF;
+  --ink: #1A1F1C;
+  --ink-soft: #5a625c;
+  --ink-faint: #9aa19c;
+  --accent: #355944;
+  --accent-strong: #244031;
+  --accent-soft: rgba(53, 89, 68, 0.08);
+  --accent-border: rgba(53, 89, 68, 0.2);
+  --hairline: rgba(26, 31, 28, 0.08);
+  --shadow: 0 1px 2px rgba(26, 31, 28, 0.04), 0 12px 40px rgba(26, 31, 28, 0.08);
+  --serif: ui-serif, "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+  --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --mono: ui-monospace, "SF Mono", Menlo, Monaco, Consolas, monospace;
+  --radius: 14px;
+  --phone-radius: 40px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #121513;
+    --bg-deep: #0C0E0D;
+    --surface: #1A1F1C;
+    --ink: #ECE8DE;
+    --ink-soft: #a8a9a3;
+    --ink-faint: #6b6d66;
+    --accent: #8fb8a0;
+    --accent-strong: #b6d3bf;
+    --accent-soft: rgba(143, 184, 160, 0.1);
+    --accent-border: rgba(143, 184, 160, 0.24);
+    --hairline: rgba(236, 232, 222, 0.1);
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 20px 48px rgba(0, 0, 0, 0.5);
+  }
+}
+
+* { box-sizing: border-box; }
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+  scroll-padding-top: 80px;
+}
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.55;
+  color: var(--ink);
+  background:
+    radial-gradient(ellipse at top, var(--bg-deep) 0%, var(--bg) 55%) no-repeat,
+    var(--bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { color: var(--accent-strong); text-decoration: underline; text-underline-offset: 3px; }
+
+img, svg { max-width: 100%; display: block; }
+
+h1, h2, h3 {
+  font-family: var(--serif);
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  line-height: 1.15;
+  margin: 0 0 0.5em;
+}
+
+h1 { font-size: clamp(2.25rem, 4.2vw + 1rem, 3.75rem); }
+h2 { font-size: clamp(1.625rem, 1.5vw + 1rem, 2.25rem); margin-bottom: 0.75em; }
+h3 { font-size: 1.125rem; font-weight: 600; font-family: var(--sans); letter-spacing: -0.005em; }
+
+p { margin: 0 0 1em; color: var(--ink-soft); }
+
+code {
+  font-family: var(--mono);
+  font-size: 0.92em;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+
+/* Layout */
+.container {
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: color-mix(in srgb, var(--bg) 85%, transparent);
+  -webkit-backdrop-filter: saturate(1.8) blur(20px);
+  backdrop-filter: saturate(1.8) blur(20px);
+  border-bottom: 1px solid var(--hairline);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 24px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink);
+  line-height: 1;
+}
+.brand:hover { color: var(--ink); text-decoration: none; }
+
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  color: var(--ink);
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.brand-name {
+  font-family: var(--serif);
+  font-size: 1.5rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.brand-tag {
+  font-family: var(--serif);
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+  letter-spacing: 0.14em;
+  white-space: nowrap;
+  margin-left: 4px;
+  transform: translateY(calc(0.55em - 3px));
+}
+
+@media (max-width: 560px) {
+  .brand-tag { display: none; }
+}
+
+.nav nav {
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 2vw, 28px);
+  font-size: 0.95rem;
+}
+.nav nav a { color: var(--ink-soft); }
+.nav nav a:hover { color: var(--ink); text-decoration: none; }
+.nav .lang-switch {
+  padding: 4px 10px;
+  border: 1px solid var(--accent-border);
+  border-radius: 999px;
+  color: var(--accent);
+  font-variant: small-caps;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+.nav .lang-switch:hover { background: var(--accent-soft); text-decoration: none; }
+
+@media (max-width: 640px) {
+  .nav nav a:not(.lang-switch) { display: none; }
+}
+
+/* Hero */
+.hero {
+  text-align: center;
+  padding: clamp(48px, 8vw, 96px) 24px clamp(32px, 5vw, 56px);
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.hero .app-icon {
+  width: 96px;
+  height: 96px;
+  border-radius: 22px;
+  box-shadow: var(--shadow);
+  margin: 0 auto 32px;
+  background: var(--surface);
+}
+
+.hero h1 {
+  max-width: 18ch;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero .lede {
+  font-size: clamp(1.05rem, 0.5vw + 1rem, 1.25rem);
+  color: var(--ink-soft);
+  max-width: 56ch;
+  margin: 0 auto 2rem;
+}
+
+.hero-note {
+  margin-top: 24px;
+  font-size: 0.9rem;
+  color: var(--ink-faint);
+}
+
+.cta {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-weight: 500;
+  font-size: 0.98rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.15s;
+}
+.btn:hover { text-decoration: none; transform: translateY(-1px); }
+.btn-primary { background: var(--accent); color: var(--bg); }
+.btn-primary:hover { background: var(--accent-strong); color: var(--bg); }
+.btn-secondary {
+  background: transparent;
+  color: var(--ink);
+  border-color: var(--hairline);
+}
+.btn-secondary:hover { background: var(--accent-soft); color: var(--ink); border-color: var(--accent-border); }
+.btn--soon {
+  background: var(--surface);
+  color: var(--ink-soft);
+  border-color: var(--hairline);
+  cursor: default;
+  pointer-events: none;
+}
+.btn--soon .badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: var(--accent);
+  color: var(--bg);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.btn svg { width: 18px; height: 18px; }
+
+/* Screenshot rail */
+.screenshots {
+  padding: 24px 0 72px;
+  overflow: hidden;
+}
+
+.screenshot-rail {
+  display: flex;
+  gap: 20px;
+  padding: 32px 24px 48px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+}
+.screenshot-rail::-webkit-scrollbar { display: none; }
+
+.screenshot-rail figure {
+  margin: 0;
+  flex: 0 0 auto;
+  scroll-snap-align: center;
+  width: clamp(220px, 28vw, 300px);
+}
+
+.screenshot-rail img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--phone-radius);
+  box-shadow: var(--shadow);
+  border: 1px solid var(--hairline);
+  background: var(--surface);
+}
+
+@media (min-width: 900px) {
+  .screenshot-rail {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+/* Sections */
+section.block {
+  padding: clamp(48px, 7vw, 88px) 0;
+  border-top: 1px solid var(--hairline);
+}
+
+.section-head {
+  text-align: center;
+  max-width: 48rem;
+  margin: 0 auto clamp(32px, 4vw, 56px);
+}
+.section-head p {
+  font-size: 1.05rem;
+  color: var(--ink-soft);
+}
+.section-kicker {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  margin-bottom: 12px;
+}
+
+/* Feature grid */
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.feature-grid article {
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: var(--radius);
+  padding: 24px;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.feature-grid article:hover {
+  border-color: var(--accent-border);
+  transform: translateY(-2px);
+}
+.feature-grid h3 { color: var(--ink); margin-bottom: 8px; }
+.feature-grid p { margin: 0; font-size: 0.98rem; }
+
+/* FAQ */
+.faq-list {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+details.faq-item {
+  border-bottom: 1px solid var(--hairline);
+  padding: 20px 0;
+}
+details.faq-item:first-child { border-top: 1px solid var(--hairline); }
+
+details.faq-item summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  font-size: 1.05rem;
+  font-weight: 500;
+  color: var(--ink);
+  padding-right: 4px;
+}
+details.faq-item summary::-webkit-details-marker { display: none; }
+
+details.faq-item summary::after {
+  content: "+";
+  font-weight: 400;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--accent);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+details.faq-item[open] summary::after {
+  content: "−";
+}
+
+details.faq-item .faq-answer {
+  margin-top: 12px;
+  color: var(--ink-soft);
+}
+details.faq-item .faq-answer p:last-child { margin-bottom: 0; }
+
+/* Next */
+.next {
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+/* Footer */
+footer {
+  margin-top: 0;
+  padding: 48px 0 32px;
+  border-top: 1px solid var(--hairline);
+  background: var(--bg-deep);
+  color: var(--ink-soft);
+  font-size: 0.92rem;
+}
+@media (prefers-color-scheme: dark) {
+  footer { background: var(--bg-deep); }
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 32px;
+  padding: 0 24px;
+  max-width: 1100px;
+  margin: 0 auto 24px;
+}
+
+.footer-grid strong {
+  color: var(--ink);
+  display: block;
+  margin-bottom: 8px;
+  font-family: var(--serif);
+  font-size: 1.1rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.footer-grid nav, .footer-grid .lang-foot {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.footer-grid nav a, .footer-grid .lang-foot a {
+  color: var(--ink-soft);
+}
+.footer-grid nav a:hover, .footer-grid .lang-foot a:hover { color: var(--accent); text-decoration: none; }
+
+.foot-bottom {
+  text-align: center;
+  padding: 24px 24px 0;
+  color: var(--ink-faint);
+  font-size: 0.85rem;
+  margin: 0;
+  border-top: 1px solid var(--hairline);
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (max-width: 700px) {
+  .footer-grid { grid-template-columns: 1fr; gap: 24px; }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  * { transition: none !important; animation: none !important; scroll-behavior: auto !important; }
+}


### PR DESCRIPTION
## Why?

- Kadō has no marketing surface outside the repo README. A proper landing page on `getkado.app` gives TestFlight/App Store visitors somewhere to land, share, and get the pitch in 15 seconds.
- Needed before the App Store launch is announced.

## What?

- New static site under `site/`, deployed to GitHub Pages at the `getkado.app` custom domain (`site/CNAME`).
- Hero (app icon + tagline + "Coming soon" / GitHub CTA + status line), screenshot rail, nine-feature grid, ten-item FAQ, "what's next" block, and footer.
- **EN + FR** both shipped from day one — FR authored natively (respects the project's `tu` / `série` / `habitude` conventions from CLAUDE.md).
- Single cream/sage palette pulled from the existing brand mark. Full dark mode via `prefers-color-scheme`. `prefers-reduced-motion` respected.

## How?

- Pure HTML + CSS, no JS, no build system, no external fonts. Zero dependencies — consistent with the app's zero-third-party stance.
- `site/Makefile` with `build` / `clean` / `serve` targets copies `branding/*.svg` and `docs/screenshots/iphone-67-appstore/{en,fr}/*.png` into `site/assets/` (gitignored) before publishing. Local preview is `make -C site serve`.
- `.github/workflows/pages.yml` invokes the same `make -C site build` target before handing the artifact to `actions/deploy-pages@v4`. Pipeline and local preview share one code path.
- Header brand composed via flexbox (`[mark.svg] Kadō 稼働 · in operation`) rather than a monolithic SVG wordmark — this sidesteps font-metric variability in fallback rendering and gives clean responsive behavior (tagline hides below 560px).

## Next steps

- [ ] Flip Settings → Pages → Source to **GitHub Actions** in the repo settings.
- [ ] Add the four apex `A` records for `getkado.app` at the registrar (plus matching AAAA), then verify the custom domain in Pages and enable HTTPS.
- [ ] Swap the "Coming soon" badge for the official Apple App Store badge + URL once the app ships.
- [ ] Optional: pre-render `@2x` / `@1x` screenshot variants in the workflow (current PNGs are 1284×2778 ≈ 1 MB each) via `sips` or `vips` to speed up the homepage on cellular.
- [ ] Optional: add an Open Graph / Twitter preview image (currently reuses the Today screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)