### PR TITLE
feat(site): add Plausible analytics snippet

### DIFF
--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -20,6 +20,12 @@
   <meta property="og:type" content="website">
   <meta property="og:locale" content="fr_FR">
   <meta name="twitter:card" content="summary_large_image">
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-moBSRloSqeIUwwpx4WSpw.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
   <header class="site-header">

--- a/site/index.html
+++ b/site/index.html
@@ -19,6 +19,12 @@
   <meta property="og:url" content="https://getkado.app/">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary_large_image">
+  <!-- Privacy-friendly analytics by Plausible -->
+  <script async src="https://plausible.io/js/pa-moBSRloSqeIUwwpx4WSpw.js"></script>
+  <script>
+    window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+    plausible.init()
+  </script>
 </head>
 <body>
   <header class="site-header">


### PR DESCRIPTION
## Why?

- Measure baseline traffic on the marketing site (getkado.app) without compromising the privacy-first stance.

## What?

- Embed the Plausible script on both language variants of the marketing page (EN + FR).

## How?

- Add the Plausible `pa-*.js` loader and init snippet inside `<head>` of `site/index.html` and `site/fr/index.html`.
- Plausible is cookieless and GDPR-compliant — no personal data, no cross-site tracking.

## Next steps

- Update `PRIVACY.md` to mention that the marketing website uses Plausible analytics, so the \"no telemetry\" line in README/landing copy doesn't read as a contradiction. (App itself remains analytics-free.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)