### PR TITLE
fix(site): inline brand mark SVG so it tracks dark mode

### DIFF
--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -31,7 +31,10 @@
   <header class="site-header">
     <div class="nav">
       <a href="/fr/" class="brand" aria-label="Kadō, accueil">
-        <img src="/assets/branding/kado-mark.svg" alt="" class="brand-mark">
+        <svg class="brand-mark" viewBox="0 0 120 120" fill="none" aria-hidden="true" focusable="false">
+          <path d="M 92 30 C 102 44, 102 68, 90 82 C 78 96, 56 100, 38 92 C 20 84, 12 64, 18 46 C 24 28, 44 18, 62 22 C 74 24, 82 28, 88 34" stroke="currentColor" stroke-width="10" stroke-linecap="round" fill="none" opacity="0.95"/>
+          <circle cx="92" cy="30" r="5" fill="currentColor" opacity="0.95"/>
+        </svg>
         <span class="brand-name">Kadō</span>
         <span class="brand-tag" aria-hidden="true">稼働 · in operation</span>
       </a>

--- a/site/index.html
+++ b/site/index.html
@@ -30,7 +30,10 @@
   <header class="site-header">
     <div class="nav">
       <a href="/" class="brand" aria-label="Kadō home">
-        <img src="/assets/branding/kado-mark.svg" alt="" class="brand-mark">
+        <svg class="brand-mark" viewBox="0 0 120 120" fill="none" aria-hidden="true" focusable="false">
+          <path d="M 92 30 C 102 44, 102 68, 90 82 C 78 96, 56 100, 38 92 C 20 84, 12 64, 18 46 C 24 28, 44 18, 62 22 C 74 24, 82 28, 88 34" stroke="currentColor" stroke-width="10" stroke-linecap="round" fill="none" opacity="0.95"/>
+          <circle cx="92" cy="30" r="5" fill="currentColor" opacity="0.95"/>
+        </svg>
         <span class="brand-name">Kadō</span>
         <span class="brand-tag" aria-hidden="true">稼働 · in operation</span>
       </a>


### PR DESCRIPTION
## Why?

- Closes #27 — the top-left logo is black on an almost-black background in dark mode, making it nearly invisible.

## What?

- The brand mark in the site header now follows the page's light/dark theme, matching the "Kadō" title next to it.
- Both the English (`site/index.html`) and French (`site/fr/index.html`) pages.

## How?

- Root cause: an SVG loaded via `<img src=…>` is isolated from the parent document's CSS, so `stroke="currentColor"` resolves against the SVG's own root (black) regardless of the page's `color` value.
- Fix: inline the SVG directly in the HTML with `class="brand-mark"`, so `currentColor` inherits from `.brand-mark { color: var(--ink); }` and tracks light/dark mode automatically.
- No change to `branding/kado-mark.svg` or to `styles.css`.

## Next steps

- None. `site/assets/branding/kado-mark.svg` is still referenced by `index.html` as the favicon and the build copy step remains valid; only the header usage changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)