### PR TITLE
feat(habit-detail): edit past-day completions from calendar

### DIFF
--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -320,6 +320,23 @@
         }
       }
     },
+    "%lld of %lld min" : {
+      "comment" : "Stepper label in the past-day edit popover for timer habits. First arg: current minutes logged. Second arg: target minutes.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld of %2$lld min"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld sur %2$lld min"
+          }
+        }
+      }
+    },
     "%lld of %lld done today" : {
       "comment" : "Inline lock widget summary. Arg 1 completed, arg 2 total.",
       "extractionState" : "stale",
@@ -645,6 +662,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vérification iCloud…"
+          }
+        }
+      }
+    },
+    "Clear" : {
+      "comment" : "Destructive action in the past-day edit popover that clears the logged value for counter and timer habits (deletes the completion).",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer"
           }
         }
       }
@@ -1648,6 +1682,40 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Marquer comme non fait"
+          }
+        }
+      }
+    },
+    "Mark as not slipped" : {
+      "comment" : "Primary button in the past-day edit popover for a negative habit when a slip is already recorded for the selected day. Activating it removes the slip.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as not slipped"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme non raté"
+          }
+        }
+      }
+    },
+    "Mark as slipped" : {
+      "comment" : "Primary button in the past-day edit popover for a negative habit when no slip is recorded for the selected day. Activating it records a slip on that day.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mark as slipped"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Marquer comme raté"
           }
         }
       }

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -925,6 +925,23 @@
         }
       }
     },
+    "Double-tap to edit this day." : {
+      "comment" : "VoiceOver hint on past/today cells in the habit detail calendar; announces that activating the cell opens an editor for that day.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double-tap to edit this day."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyer deux fois pour modifier ce jour."
+          }
+        }
+      }
+    },
     "Edit" : {
       "comment" : "Primary toolbar button on habit detail that opens the edit form.",
       "localizations" : {

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -5,11 +5,12 @@ import KadoCore
 /// Renders as a 7-column `LazyVGrid` with weekday headers and
 /// leading blanks that align the first day of the month to its
 /// weekday column.
-struct MonthlyCalendarView: View {
+struct MonthlyCalendarView<PopoverContent: View>: View {
     let habit: Habit
     let completions: [Completion]
     var month: Date = .now
-    var onTapDay: ((Date) -> Void)? = nil
+    @Binding var selectedDay: Date?
+    @ViewBuilder var popoverContent: (Date) -> PopoverContent
     @Environment(\.calendar) private var calendar
 
     var body: some View {
@@ -107,10 +108,29 @@ struct MonthlyCalendarView: View {
         if isInteractive {
             visual
                 .accessibilityHint(Text("Double-tap to edit this day."))
-                .onTapGesture { onTapDay?(day) }
+                .onTapGesture { selectedDay = day }
+                .popover(isPresented: popoverBinding(for: day)) {
+                    popoverContent(day)
+                }
         } else {
             visual
         }
+    }
+
+    private func popoverBinding(for day: Date) -> Binding<Bool> {
+        Binding(
+            get: {
+                guard let selectedDay else { return false }
+                return calendar.isDate(selectedDay, inSameDayAs: day)
+            },
+            set: { newValue in
+                if newValue {
+                    selectedDay = day
+                } else {
+                    selectedDay = nil
+                }
+            }
+        )
     }
 
     private enum CellState {
@@ -191,6 +211,26 @@ struct MonthlyCalendarView: View {
             return "\(dateString), today, \(stateString)"
         }
         return "\(dateString), \(stateString)"
+    }
+}
+
+extension MonthlyCalendarView where PopoverContent == EmptyView {
+    /// Convenience init for read-only callers (previews, any future
+    /// surface that shows the grid without edit affordances). Cells
+    /// remain tappable but selection goes to a discarded binding, so
+    /// no popover is attached.
+    init(
+        habit: Habit,
+        completions: [Completion],
+        month: Date = .now
+    ) {
+        self.init(
+            habit: habit,
+            completions: completions,
+            month: month,
+            selectedDay: .constant(nil),
+            popoverContent: { _ in EmptyView() }
+        )
     }
 }
 

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -9,6 +9,7 @@ struct MonthlyCalendarView: View {
     let habit: Habit
     let completions: [Completion]
     var month: Date = .now
+    var onTapDay: ((Date) -> Void)? = nil
     @Environment(\.calendar) private var calendar
 
     var body: some View {
@@ -83,8 +84,9 @@ struct MonthlyCalendarView: View {
         let state = state(for: day)
         let isToday = calendar.isDateInToday(day)
         let dayNumber = calendar.component(.day, from: day)
+        let isInteractive = state != .future
 
-        ZStack {
+        let visual = ZStack {
             RoundedRectangle(cornerRadius: 8)
                 .fill(fill(for: state))
                 .overlay(
@@ -98,8 +100,17 @@ struct MonthlyCalendarView: View {
                 .font(.caption.weight(state == .completed ? .bold : .regular))
                 .foregroundStyle(foreground(for: state))
         }
+        .contentShape(Rectangle())
         .accessibilityElement()
         .accessibilityLabel(accessibilityLabel(for: day, state: state, isToday: isToday))
+
+        if isInteractive {
+            visual
+                .accessibilityHint(Text("Double-tap to edit this day."))
+                .onTapGesture { onTapDay?(day) }
+        } else {
+            visual
+        }
     }
 
     private enum CellState {

--- a/Kado/Views/HabitDetail/DayEditPopover.swift
+++ b/Kado/Views/HabitDetail/DayEditPopover.swift
@@ -124,7 +124,7 @@ struct DayEditPopover: View {
                     .monospacedDigit()
                     .foregroundStyle(counterValue >= target ? Color.accentColor : Color.primary)
             }
-            actionRow(canClear: isRecorded)
+            clearButton(shown: counterValue > 0)
         }
     }
 
@@ -146,34 +146,24 @@ struct DayEditPopover: View {
                     .monospacedDigit()
                     .foregroundStyle(timerMinutes >= targetMinutes ? Color.accentColor : Color.primary)
             }
-            actionRow(canClear: isRecorded)
+            clearButton(shown: timerMinutes > 0)
         }
     }
 
-    private func actionRow(canClear: Bool) -> some View {
-        HStack(spacing: 10) {
-            if canClear {
-                Button(role: .destructive) {
-                    onClear()
-                    dismiss()
-                } label: {
-                    Text("Clear")
-                        .font(.body.weight(.medium))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 8)
-                }
-                .buttonStyle(.bordered)
-                .tint(.red)
-            }
-            Button {
+    @ViewBuilder
+    private func clearButton(shown: Bool) -> some View {
+        if shown {
+            Button(role: .destructive) {
+                onClear()
                 dismiss()
             } label: {
-                Text("Done")
-                    .font(.body.weight(.semibold))
+                Text("Clear")
+                    .font(.body.weight(.medium))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 8)
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.bordered)
+            .tint(.red)
         }
     }
 
@@ -189,12 +179,10 @@ struct DayEditPopover: View {
         switch habit.type {
         case .counter:
             counterValue = Int(currentValue.rounded())
-        case .timer(let seconds):
-            if currentValue > 0 {
-                timerMinutes = max(1, Int((currentValue / 60).rounded()))
-            } else {
-                timerMinutes = max(1, Int((seconds / 60).rounded()))
-            }
+        case .timer:
+            timerMinutes = currentValue > 0
+                ? max(1, Int((currentValue / 60).rounded()))
+                : 0
         case .binary, .negative:
             break
         }

--- a/Kado/Views/HabitDetail/DayEditPopover.swift
+++ b/Kado/Views/HabitDetail/DayEditPopover.swift
@@ -1,0 +1,317 @@
+import SwiftUI
+import KadoCore
+
+/// Anchored popover that edits one day's completion for a habit from
+/// the detail view's monthly calendar. Branches on `habit.type`:
+/// single toggle for binary / negative, stepper for counter, minute
+/// stepper for timer. Counter / timer also offer a `Clear` action
+/// that sets the value to 0 (deleting the record via the logger).
+struct DayEditPopover: View {
+    let habit: Habit
+    let date: Date
+    let currentValue: Double
+    let onToggle: () -> Void
+    let onSetCounter: (Double) -> Void
+    let onSetTimerSeconds: (TimeInterval) -> Void
+    let onClear: () -> Void
+
+    @Environment(\.calendar) private var calendar
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var counterValue: Int = 0
+    @State private var timerMinutes: Int = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            content
+        }
+        .padding()
+        .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
+        .onAppear { seedLocalState() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(systemName: habit.icon)
+                    .foregroundStyle(habit.color.color)
+                Text(habit.name)
+                    .font(.headline)
+            }
+            Text(formattedDate)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch habit.type {
+        case .binary:
+            binaryToggle
+        case .negative:
+            negativeToggle
+        case .counter(let target):
+            counterControl(target: Int(target))
+        case .timer(let seconds):
+            timerControl(targetMinutes: max(1, Int((seconds / 60).rounded())))
+        }
+    }
+
+    private var isRecorded: Bool { currentValue > 0 }
+
+    private var binaryToggle: some View {
+        Button {
+            onToggle()
+            dismiss()
+        } label: {
+            toggleLabel(
+                title: isRecorded
+                    ? String(localized: "Mark as not done")
+                    : String(localized: "Mark as done"),
+                systemImage: isRecorded ? "xmark.circle" : "checkmark.circle.fill",
+                active: !isRecorded
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var negativeToggle: some View {
+        Button {
+            onToggle()
+            dismiss()
+        } label: {
+            toggleLabel(
+                title: isRecorded
+                    ? String(localized: "Mark as not slipped")
+                    : String(localized: "Mark as slipped"),
+                systemImage: isRecorded ? "xmark.circle" : "hand.raised.fill",
+                active: !isRecorded
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func toggleLabel(title: String, systemImage: String, active: Bool) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.body.weight(.semibold))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(active ? Color.accentColor : Color.kadoBackgroundSecondary)
+            )
+            .foregroundStyle(active ? Color.white : Color.primary)
+    }
+
+    private func counterControl(target: Int) -> some View {
+        let maxValue = max(target * 3, 99)
+        return VStack(alignment: .leading, spacing: 12) {
+            Stepper(
+                value: Binding(
+                    get: { counterValue },
+                    set: { newValue in
+                        counterValue = newValue
+                        onSetCounter(Double(newValue))
+                    }
+                ),
+                in: 0...maxValue,
+                step: 1
+            ) {
+                Text("\(counterValue) of \(target)")
+                    .font(.title3.weight(.semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(counterValue >= target ? Color.accentColor : Color.primary)
+            }
+            actionRow(canClear: isRecorded)
+        }
+    }
+
+    private func timerControl(targetMinutes: Int) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Stepper(
+                value: Binding(
+                    get: { timerMinutes },
+                    set: { newValue in
+                        timerMinutes = newValue
+                        onSetTimerSeconds(TimeInterval(newValue) * 60)
+                    }
+                ),
+                in: 0...480,
+                step: 1
+            ) {
+                Text("\(timerMinutes) of \(targetMinutes) min")
+                    .font(.title3.weight(.semibold))
+                    .monospacedDigit()
+                    .foregroundStyle(timerMinutes >= targetMinutes ? Color.accentColor : Color.primary)
+            }
+            actionRow(canClear: isRecorded)
+        }
+    }
+
+    private func actionRow(canClear: Bool) -> some View {
+        HStack(spacing: 10) {
+            if canClear {
+                Button(role: .destructive) {
+                    onClear()
+                    dismiss()
+                } label: {
+                    Text("Clear")
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+            }
+            Button {
+                dismiss()
+            } label: {
+                Text("Done")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateStyle = .full
+        return formatter.string(from: date)
+    }
+
+    private func seedLocalState() {
+        switch habit.type {
+        case .counter:
+            counterValue = Int(currentValue.rounded())
+        case .timer(let seconds):
+            if currentValue > 0 {
+                timerMinutes = max(1, Int((currentValue / 60).rounded()))
+            } else {
+                timerMinutes = max(1, Int((seconds / 60).rounded()))
+            }
+        case .binary, .negative:
+            break
+        }
+    }
+}
+
+#Preview("Binary — not done") {
+    DayEditPopover(
+        habit: Habit(
+            name: "Morning meditation",
+            frequency: .daily,
+            type: .binary,
+            createdAt: .now,
+            color: .purple,
+            icon: "figure.mind.and.body"
+        ),
+        date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!,
+        currentValue: 0,
+        onToggle: {},
+        onSetCounter: { _ in },
+        onSetTimerSeconds: { _ in },
+        onClear: {}
+    )
+}
+
+#Preview("Binary — done") {
+    DayEditPopover(
+        habit: Habit(
+            name: "Morning meditation",
+            frequency: .daily,
+            type: .binary,
+            createdAt: .now,
+            color: .purple,
+            icon: "figure.mind.and.body"
+        ),
+        date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!,
+        currentValue: 1,
+        onToggle: {},
+        onSetCounter: { _ in },
+        onSetTimerSeconds: { _ in },
+        onClear: {}
+    )
+}
+
+#Preview("Negative — not slipped") {
+    DayEditPopover(
+        habit: Habit(
+            name: "No smoking",
+            frequency: .daily,
+            type: .negative,
+            createdAt: .now,
+            color: .red,
+            icon: "smoke.fill"
+        ),
+        date: Calendar.current.date(byAdding: .day, value: -1, to: .now)!,
+        currentValue: 0,
+        onToggle: {},
+        onSetCounter: { _ in },
+        onSetTimerSeconds: { _ in },
+        onClear: {}
+    )
+}
+
+#Preview("Counter — partial") {
+    DayEditPopover(
+        habit: Habit(
+            name: "Drink water",
+            frequency: .daily,
+            type: .counter(target: 8),
+            createdAt: .now,
+            color: .blue,
+            icon: "drop.fill"
+        ),
+        date: Calendar.current.date(byAdding: .day, value: -2, to: .now)!,
+        currentValue: 5,
+        onToggle: {},
+        onSetCounter: { _ in },
+        onSetTimerSeconds: { _ in },
+        onClear: {}
+    )
+}
+
+#Preview("Timer — empty") {
+    DayEditPopover(
+        habit: Habit(
+            name: "Read",
+            frequency: .daily,
+            type: .timer(targetSeconds: 30 * 60),
+            createdAt: .now,
+            color: .orange,
+            icon: "book.fill"
+        ),
+        date: Calendar.current.date(byAdding: .day, value: -3, to: .now)!,
+        currentValue: 0,
+        onToggle: {},
+        onSetCounter: { _ in },
+        onSetTimerSeconds: { _ in },
+        onClear: {}
+    )
+}
+
+#Preview("Counter — partial · Dark") {
+    DayEditPopover(
+        habit: Habit(
+            name: "Drink water",
+            frequency: .daily,
+            type: .counter(target: 8),
+            createdAt: .now,
+            color: .blue,
+            icon: "drop.fill"
+        ),
+        date: Calendar.current.date(byAdding: .day, value: -2, to: .now)!,
+        currentValue: 5,
+        onToggle: {},
+        onSetCounter: { _ in },
+        onSetTimerSeconds: { _ in },
+        onClear: {}
+    )
+    .preferredColorScheme(.dark)
+}

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -19,15 +19,9 @@ struct HabitDetailView: View {
     @State private var showingArchiveConfirmation = false
     @State private var showingTimerSheet = false
     @State private var showingScoreInfo = false
-    @State private var editingDay: EditingDay? = nil
+    @State private var editingDay: Date? = nil
 
     private var isArchived: Bool { habit.archivedAt != nil }
-
-    /// `.popover(item:)` needs `Identifiable`; `Date` isn't.
-    private struct EditingDay: Identifiable, Equatable {
-        let id: Date
-        var date: Date { id }
-    }
 
     var body: some View {
         ScrollView {
@@ -38,22 +32,20 @@ struct HabitDetailView: View {
                 MonthlyCalendarView(
                     habit: habit.snapshot,
                     completions: (habit.completions ?? []).map(\.snapshot),
-                    onTapDay: isArchived ? nil : { day in
-                        editingDay = EditingDay(id: day)
+                    selectedDay: isArchived ? .constant(nil) : $editingDay,
+                    popoverContent: { day in
+                        DayEditPopover(
+                            habit: habit.snapshot,
+                            date: day,
+                            currentValue: currentValue(on: day),
+                            onToggle: { toggle(on: day) },
+                            onSetCounter: { value in setCounter(value, on: day) },
+                            onSetTimerSeconds: { seconds in setTimerSeconds(seconds, on: day) },
+                            onClear: { clear(on: day) }
+                        )
+                        .presentationCompactAdaptation(.popover)
                     }
                 )
-                .popover(item: $editingDay) { editing in
-                    DayEditPopover(
-                        habit: habit.snapshot,
-                        date: editing.date,
-                        currentValue: currentValue(on: editing.date),
-                        onToggle: { toggle(on: editing.date) },
-                        onSetCounter: { value in setCounter(value, on: editing.date) },
-                        onSetTimerSeconds: { seconds in setTimerSeconds(seconds, on: editing.date) },
-                        onClear: { clear(on: editing.date) }
-                    )
-                    .presentationCompactAdaptation(.popover)
-                }
                 CompletionHistoryList(habit: habit)
             }
             .padding()

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -19,8 +19,15 @@ struct HabitDetailView: View {
     @State private var showingArchiveConfirmation = false
     @State private var showingTimerSheet = false
     @State private var showingScoreInfo = false
+    @State private var editingDay: EditingDay? = nil
 
     private var isArchived: Bool { habit.archivedAt != nil }
+
+    /// `.popover(item:)` needs `Identifiable`; `Date` isn't.
+    private struct EditingDay: Identifiable, Equatable {
+        let id: Date
+        var date: Date { id }
+    }
 
     var body: some View {
         ScrollView {
@@ -30,8 +37,23 @@ struct HabitDetailView: View {
                 quickLogSection
                 MonthlyCalendarView(
                     habit: habit.snapshot,
-                    completions: (habit.completions ?? []).map(\.snapshot)
+                    completions: (habit.completions ?? []).map(\.snapshot),
+                    onTapDay: isArchived ? nil : { day in
+                        editingDay = EditingDay(id: day)
+                    }
                 )
+                .popover(item: $editingDay) { editing in
+                    DayEditPopover(
+                        habit: habit.snapshot,
+                        date: editing.date,
+                        currentValue: currentValue(on: editing.date),
+                        onToggle: { toggle(on: editing.date) },
+                        onSetCounter: { value in setCounter(value, on: editing.date) },
+                        onSetTimerSeconds: { seconds in setTimerSeconds(seconds, on: editing.date) },
+                        onClear: { clear(on: editing.date) }
+                    )
+                    .presentationCompactAdaptation(.popover)
+                }
                 CompletionHistoryList(habit: habit)
             }
             .padding()
@@ -132,6 +154,52 @@ struct HabitDetailView: View {
 
     private func decrementCounter() {
         CompletionLogger(calendar: calendar).decrementCounter(for: habit, in: modelContext)
+        try? modelContext.save()
+        WidgetReloader.reloadAll(using: modelContext)
+    }
+
+    // MARK: - Past-day popover mutations
+
+    private func currentValue(on day: Date) -> Double {
+        habit.completions?
+            .first { calendar.isDate($0.date, inSameDayAs: day) }?
+            .value ?? 0
+    }
+
+    private func toggle(on day: Date) {
+        CompletionToggler(calendar: calendar).toggleToday(for: habit, on: day, in: modelContext)
+        try? modelContext.save()
+        WidgetReloader.reloadAll(using: modelContext)
+    }
+
+    private func setCounter(_ value: Double, on day: Date) {
+        CompletionLogger(calendar: calendar).setCounter(for: habit, on: day, to: value, in: modelContext)
+        try? modelContext.save()
+        WidgetReloader.reloadAll(using: modelContext)
+    }
+
+    private func setTimerSeconds(_ seconds: TimeInterval, on day: Date) {
+        // logTimerSession would create a zero-value record for 0 seconds;
+        // route "stepped to 0" through clear() so the day returns to missed.
+        if seconds <= 0 {
+            clear(on: day)
+            return
+        }
+        CompletionLogger(calendar: calendar).logTimerSession(
+            for: habit,
+            seconds: seconds,
+            on: day,
+            in: modelContext
+        )
+        try? modelContext.save()
+        WidgetReloader.reloadAll(using: modelContext)
+    }
+
+    private func clear(on day: Date) {
+        guard let existing = habit.completions?.first(where: {
+            calendar.isDate($0.date, inSameDayAs: day)
+        }) else { return }
+        CompletionLogger(calendar: calendar).delete(existing, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }

--- a/KadoTests/CompletionLoggerTests.swift
+++ b/KadoTests/CompletionLoggerTests.swift
@@ -192,6 +192,67 @@ struct CompletionLoggerTests {
         #expect(habit.completions?.first?.id == c2.id)
     }
 
+    @Test("setCounter on a past day preserves other days' values")
+    func setCounterPastDayPreservesOthers() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        let d3 = CompletionRecord(date: TestCalendar.day(-3), value: 2, habit: habit)
+        let d1 = CompletionRecord(date: TestCalendar.day(-1), value: 4, habit: habit)
+        container.mainContext.insert(d3)
+        container.mainContext.insert(d1)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.setCounter(for: habit, on: TestCalendar.day(-2), to: 6, in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions?.count == 3)
+        let newRecord = habit.completions?.first {
+            TestCalendar.utc.isDate($0.date, inSameDayAs: TestCalendar.day(-2))
+        }
+        #expect(newRecord?.value == 6)
+        #expect(habit.completions?.first { $0.id == d3.id }?.value == 2)
+        #expect(habit.completions?.first { $0.id == d1.id }?.value == 4)
+    }
+
+    @Test("logTimerSession on a past day targets the correct day")
+    func timerPastDayTargetsCorrectDay() throws {
+        let habit = HabitRecord(type: .timer(targetSeconds: 30 * 60))
+        container.mainContext.insert(habit)
+        let todaySession = CompletionRecord(date: TestCalendar.day(0), value: 10 * 60, habit: habit)
+        container.mainContext.insert(todaySession)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.logTimerSession(for: habit, seconds: 25 * 60, on: TestCalendar.day(-2), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions?.count == 2)
+        let past = habit.completions?.first {
+            TestCalendar.utc.isDate($0.date, inSameDayAs: TestCalendar.day(-2))
+        }
+        #expect(past?.value == Double(25 * 60))
+        #expect(habit.completions?.first { $0.id == todaySession.id }?.value == Double(10 * 60))
+    }
+
+    @Test("setCounter to 0 on a past day deletes only that day's record")
+    func setCounterPastDayZeroDeletesOnlyThatDay() throws {
+        let habit = HabitRecord(type: .counter(target: 8))
+        container.mainContext.insert(habit)
+        let todayValue = CompletionRecord(date: TestCalendar.day(0), value: 3, habit: habit)
+        let pastValue = CompletionRecord(date: TestCalendar.day(-3), value: 2, habit: habit)
+        container.mainContext.insert(todayValue)
+        container.mainContext.insert(pastValue)
+        try container.mainContext.save()
+
+        let logger = CompletionLogger(calendar: TestCalendar.utc)
+        logger.setCounter(for: habit, on: TestCalendar.day(-3), to: 0, in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions?.count == 1)
+        #expect(habit.completions?.first?.id == todayValue.id)
+    }
+
     @Test("Incrementing on two consecutive days creates two records")
     func incrementSpanningDays() throws {
         let habit = HabitRecord(type: .counter(target: 8))

--- a/KadoTests/CompletionTogglerTests.swift
+++ b/KadoTests/CompletionTogglerTests.swift
@@ -79,6 +79,39 @@ struct CompletionTogglerTests {
         #expect(habit.completions?.isEmpty ?? true)
     }
 
+    @Test("Toggle on a past day inserts a record on that day, not today")
+    func pastDayInsertsOnThatDay() throws {
+        let habit = HabitRecord(name: "Meditate", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        try container.mainContext.save()
+
+        let toggler = CompletionToggler(calendar: TestCalendar.utc)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(-3), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions?.count == 1)
+        let stored = try #require(habit.completions?.first)
+        #expect(TestCalendar.utc.isDate(stored.date, inSameDayAs: TestCalendar.day(-3)))
+        #expect(!TestCalendar.utc.isDate(stored.date, inSameDayAs: TestCalendar.day(0)))
+    }
+
+    @Test("Toggle on a past day twice leaves today's record intact")
+    func pastDayRoundTripPreservesToday() throws {
+        let habit = HabitRecord(name: "Meditate", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        let todayRecord = CompletionRecord(date: TestCalendar.day(0), value: 1, habit: habit)
+        container.mainContext.insert(todayRecord)
+        try container.mainContext.save()
+
+        let toggler = CompletionToggler(calendar: TestCalendar.utc)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(-3), in: container.mainContext)
+        toggler.toggleToday(for: habit, on: TestCalendar.day(-3), in: container.mainContext)
+        try container.mainContext.save()
+
+        #expect(habit.completions?.count == 1)
+        #expect(habit.completions?.first?.id == todayRecord.id)
+    }
+
     @Test("Toggle uses the injected calendar for day comparison across timezones")
     func calendarIsolation() throws {
         // Paris calendar: a completion at 23:30 UTC is already "tomorrow"

--- a/docs/plans/2026-04/past-completion-editing/compound.md
+++ b/docs/plans/2026-04/past-completion-editing/compound.md
@@ -1,0 +1,197 @@
+---
+name: Compound — Past-completion editing
+description: Retrospective on the past-day popover feature — decisions, surprises, and lessons that generalize.
+type: project
+---
+
+# Compound — Past-completion editing
+
+**Date**: 2026-04-20
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: `feature/past-completion-editing` · [PR #29](https://github.com/scastiel/kado/pull/29)
+
+## Summary
+
+Shipped a per-cell popover that lets users log or clear past-day
+completions from the habit detail calendar. Service layer was already
+date-parameterized, so the change was UI-only: a tap gesture on past /
+today cells + a branching popover (`binary`, `negative`, `counter`,
+`timer`). Two visual regressions missed by previews and tests were
+caught by the user's screenshot feedback loop and fixed before merge.
+Headline lesson: for calendar-style grids, popovers must anchor
+per-cell — `.popover(item:)` at the parent anchors to the parent's
+frame.
+
+## Decisions made
+
+- **Per-cell `.popover(isPresented:)`** on `MonthlyCalendarView`: the
+  view takes a generic `PopoverContent: View` + a `@Binding var
+  selectedDay: Date?` + `@ViewBuilder popoverContent: (Date) -> …`.
+  Mirrors the Overview's `CellPopoverContent` pattern.
+- **No `Identifiable` wrapper** on the selection: per-cell popovers
+  use `calendar.isDate(selected, inSameDayAs: day)` so raw `Date?`
+  works directly.
+- **Convenience init** `where PopoverContent == EmptyView` keeps the
+  nine existing read-only previews working without surface changes.
+- **Scope = all four habit types** in the MVP (not binary / negative
+  only).
+- **Tap-on-today opens the popover** too — consistent behavior with
+  past cells; inline quick-log above the grid is preserved as a
+  second path.
+- **Archived habits pass `.constant(nil)`** as the selection binding,
+  so taps fire but nothing opens. Simpler than branching the view.
+- **Stepper seeds to 0** when a day has no record (not to the
+  habit's target). Users explicitly enter a value.
+- **Clear button tracks live stepper value** (`counterValue /
+  timerMinutes`), not the saved-at-open snapshot, so stepping up from
+  0 reveals Clear immediately.
+- **No Done button**: every stepper tick writes through. Binary /
+  negative actions and Clear auto-dismiss; otherwise the user taps
+  outside.
+- **Timer `clear` routes through `logger.delete(existing)`** because
+  `CompletionLogger.logTimerSession(seconds: 0)` inserts a zero-value
+  record rather than deleting (asymmetric with `setCounter(to: 0)`).
+
+## Surprises and how we handled them
+
+### Popover anchoring
+
+- **What happened**: First pass attached `.popover(item:)` at the
+  whole-calendar level. In the sim, the popover's arrow pointed to the
+  top of the grid regardless of which cell was tapped. Docs note on
+  `.popover(item:)` was not enough — anchor is the modified view's
+  frame.
+- **What we did**: Lifted the selection + content closure down into
+  `MonthlyCalendarView`, introduced a generic `PopoverContent: View`,
+  attached `.popover(isPresented:)` per cell. Commit `d073fe0`.
+- **Lesson**: For grids where any cell can be a popover source, use
+  per-cell `.popover(isPresented:)`. Parent-level `.popover(item:)` is
+  fine only when the anchor *is* the parent.
+
+### Timer popover looked already-complete on open
+
+- **What happened**: Seeding `timerMinutes` to the habit's target on
+  empty days made the popover read "30 of 30 min" before any user
+  action. Looked like the day was already logged.
+- **What we did**: Seed to 0. Fixed in `1af83d3`.
+- **Lesson**: When a popover edits a value, its default should read
+  "nothing entered," not "the target." Default matters more than
+  convenience.
+
+### Clear button hidden after stepping up
+
+- **What happened**: `clearButton(canClear: isRecorded)` where
+  `isRecorded = currentValue > 0` used the saved-at-open snapshot.
+  Stepping up from 0 never revealed Clear.
+- **What we did**: Gate on the live stepper state
+  (`counterValue > 0` / `timerMinutes > 0`). Same commit.
+- **Lesson**: Local `@State` and passed-in snapshots diverge the
+  moment the user interacts. If an action's availability depends on
+  "current value," make sure that reflects *current*, not *initial*.
+
+### XcodeBuildMCP has no tap primitives
+
+- **What happened**: `build_run_sim` launched the app but there was
+  no way to drive a tap on a calendar cell to verify the popover
+  opened, its content, or the save path. `CLAUDE.md` already flags
+  this, but it bit us mid-feature.
+- **What we did**: User drove the sim manually and shared
+  screenshots. Two rounds of screenshots surfaced both the anchoring
+  bug and the UX regressions.
+- **Lesson**: Tests + previews verify correctness and compile-cleanliness.
+  They don't verify "does this actually look right when tapped."
+  Build a screenshot feedback loop into UI-feature workflows.
+
+## What worked well
+
+- **Service layer was already date-parameterized.** The research pass
+  surfaced this early — `CompletionToggler.toggleToday(on:)` and
+  `CompletionLogger.setCounter(on:)` both took a `date` parameter.
+  Meant zero schema change, zero service API change, and tests mostly
+  passed green as regressions rather than as new coverage.
+- **Convenience init on a generic view.** `extension MonthlyCalendarView
+  where PopoverContent == EmptyView { init(...) }` let us introduce
+  a generic type parameter without breaking any of the nine existing
+  call sites and previews.
+- **Conductor staging.** Research → plan → build → compound kept
+  scope tight: four commit-sized tasks, each leaving the tree green,
+  plus two clearly-scoped follow-ups when visual testing surfaced
+  issues. The plan doc needed mid-flight updates but stayed a useful
+  artifact throughout.
+- **Regression tests over green services.** Adding "toggle past day,
+  today intact" regressions even though the service already did the
+  right thing is cheap insurance against a future "simplification"
+  that hardcodes `.now`.
+
+## For the next person
+
+- `MonthlyCalendarView` is **generic** on `PopoverContent`. New
+  read-only callers should use the convenience init
+  (`MonthlyCalendarView(habit:completions:month:)`); edit-capable
+  callers pass `selectedDay:` and `popoverContent:`.
+- Selection comparison uses `calendar.isDate(a, inSameDayAs: b)`.
+  Both the view and the services must get the *same* `Calendar`
+  instance — pulled from `@Environment(\.calendar)` at the use site.
+  Pinning `.current` anywhere would silently desync around DST.
+- `CompletionLogger.logTimerSession(seconds: 0, …)` does **not**
+  delete. If you add a new caller that wants "clear to zero" semantics
+  for a timer habit, route through `logger.delete(existing)` after
+  looking up the record — see `HabitDetailView.clear(on:)` for the
+  pattern. Better long-term: normalize `logTimerSession` to match
+  `setCounter`'s delete-on-zero contract.
+- Every stepper tick saves + reloads widgets. If performance ever
+  matters here, debounce at the view layer — but do it consistently
+  with the existing `CounterQuickLogView` + `TimerLogSheet` save
+  patterns, don't make this one popover the odd one out.
+- Archived habits: the detail view passes `.constant(nil)` as
+  `selectedDay`. Taps on cells fire `selectedDay = day` against the
+  constant binding, which SwiftUI discards — so no popover opens.
+  Slightly "wasted motion" but correct; could be replaced with an
+  `isInteractive: Bool` flag on the view if someone cares.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** When attaching a popover to one of many identical
+  cells, use per-cell `.popover(isPresented:)` owned by the cell, not
+  `.popover(item:)` on the parent. The parent-level modifier anchors
+  to the parent's frame, not the cell the user interacted with —
+  visible regression, not caught by tests or previews.
+- **[→ CLAUDE.md]** A popover that auto-saves on every change does
+  **not** need a "Done" button. Dismissing is the user's job
+  (tap-outside). Adding Done creates a no-op affordance that looks
+  important.
+- **[→ CLAUDE.md]** `CompletionLogger.logTimerSession(seconds: 0)`
+  inserts a zero-value record rather than deleting — asymmetric with
+  `setCounter(to: 0)`. Callers wanting "clear" semantics must route
+  through `logger.delete(existing)`. Normalize this in a follow-up so
+  the service is self-consistent.
+- **[→ CLAUDE.md]** For UI features that depend on tap gestures, a
+  build is not complete until a human-driven sim pass happens.
+  `test_sim` + `build_sim` + previews will not catch regressions like
+  mis-anchored popovers, wrong initial values, or affordance glitches.
+  Bake a "screenshot loop with user" step into the build stage for
+  any UI-only feature.
+- **[local]** `MonthlyCalendarView` is generic on `PopoverContent: View`
+  with an `EmptyView` convenience init. Keep the convenience init in
+  place — nine callers depend on it, removing it would break previews
+  across four habit types.
+
+## Metrics
+
+- Tasks completed: 4 planned + 2 follow-ups (anchoring fix, UX fixes)
+- Tests added: 5 (`CompletionTogglerTests` ×2, `CompletionLoggerTests` ×3)
+- Commits: 8 (4 tasks + 2 follow-ups + 2 doc syncs)
+- Files touched: 8 (3 prod code, 1 catalog, 2 test files, 3 docs)
+- Lines added: ~1,100 (of which ~540 are docs)
+
+## References
+
+- Existing popover precedent that informed the per-cell approach:
+  `Kado/Views/Overview/OverviewView.swift` + `CellPopoverContent.swift`
+- Service entry points used unchanged:
+  `Packages/KadoCore/Sources/KadoCore/Services/CompletionToggler.swift`,
+  `Kado/Services/CompletionLogger.swift`
+- Test pattern for calendar-aware service mutations:
+  `KadoTests/Helpers/TestCalendar.swift`

--- a/docs/plans/2026-04/past-completion-editing/plan.md
+++ b/docs/plans/2026-04/past-completion-editing/plan.md
@@ -7,7 +7,7 @@ type: project
 # Plan — Past-completion editing
 
 **Date**: 2026-04-20
-**Status**: in progress (manual visual verification pending)
+**Status**: done (visual verification passed; ready for compound)
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -32,15 +32,25 @@ API change; purely UI wiring + a new popover view.
 - Future cells: non-interactive. No popover.
 - Binary / negative flow: tap the action, popover auto-dismisses.
 - Counter / timer flow: popover stays open while the user adjusts
-  the value; dismiss on tap-outside or explicit "Done."
-- "Clear" in counter / timer popovers sets value to 0, which deletes
-  the `CompletionRecord` via the existing logger contract.
+  the value. Every stepper tick writes through immediately, so
+  there is **no "Done" button** — the user dismisses by tapping
+  outside or with a destructive `Clear` action.
+- `Clear` appears only when the **live** stepper value is > 0 (not
+  the saved-at-open snapshot). That way, stepping up from 0 reveals
+  Clear immediately; stepping back to 0 hides it.
+- Counter/timer defaults: when the tapped day has no record, the
+  stepper seeds to **0** — not to the target. Users explicitly enter
+  a value.
+- Popover anchoring: **per-cell** via `.popover(isPresented:)` owned
+  by each cell inside `MonthlyCalendarView`. The calendar view
+  takes a generic `PopoverContent: View` + a `@Binding var
+  selectedDay: Date?` + a `@ViewBuilder popoverContent: (Date) ->
+  PopoverContent`. Mirrors the Overview pattern. A convenience init
+  (`where PopoverContent == EmptyView`) keeps all existing read-only
+  previews working.
 - Popover presentation: `.presentationCompactAdaptation(.popover)`
-  so iPhone gets the anchored popover look. Adapt to a sheet only
-  under accessibility Dynamic Type (XXXL and above) where the
-  popover body can't fit — flag as a task 4 decision once measured.
-- Use an `Identifiable` wrapper (`EditingDay`) for `.popover(item:)`
-  since `Date` isn't `Identifiable`.
+  on iPhone so it stays a floating anchored popover rather than
+  adapting to a sheet.
 - Mutations go through existing services with `@Environment(\.calendar)`
   injected — same calendar drives cell classification and write
   path, avoiding day-boundary drift.
@@ -53,6 +63,8 @@ API change; purely UI wiring + a new popover view.
 - [x] Task 2 — Tappable past / today cells in `MonthlyCalendarView` (56a35b4)
 - [x] Task 3 — `DayEditPopover` view + localization (d2693ec)
 - [x] Task 4 — Wire popover into `HabitDetailView` (41463b2)
+- [x] Follow-up A — Per-cell popover anchoring (d073fe0)
+- [x] Follow-up B — UX fixes: seed timer to 0, drop Done, live Clear (1af83d3)
 
 ### Task 1: Regression tests for past-day service mutations
 
@@ -243,8 +255,12 @@ existing services. Archived habits stay non-interactive.
   for today's value. **Mitigation**: both call the same services;
   `@Query`-driven `HabitRecord.completions` re-renders both
   affordances in step. Verify during task 4 manual.
-- **`.popover(item:)` requires `Identifiable`** — `Date` isn't.
-  **Mitigation**: private `EditingDay` wrapper in the detail view.
+- **Popover anchoring precision** — `.popover(item:)` attached at the
+  whole-calendar level visibly mis-anchored in manual testing (points
+  to the top of the grid regardless of which cell was tapped).
+  **Resolution**: switched to per-cell `.popover(isPresented:)` with
+  a `calendar.isDate(selected, inSameDayAs: day)` comparison —
+  mirrors the Overview pattern. No `Identifiable` wrapper needed.
 
 ## Open questions
 
@@ -264,25 +280,32 @@ existing services. Archived habits stay non-interactive.
   **not** delete — it inserts a zero-value record. Routing the
   "stepped timer down to 0" path through `clear()` (which calls
   `logger.delete(existing)` after looking up the record) avoids
-  leaving phantom records. Consider normalizing `logTimerSession`'s
-  0-seconds behavior in a follow-up so the service API is consistent
-  with `setCounter`'s delete-on-zero contract.
-- **Popover anchoring**: Attached to `MonthlyCalendarView` as a whole
-  (not per-cell) because routing popover content down into the view
-  would require a generic type parameter. The popover's header shows
-  the formatted date so there's no ambiguity, but the anchor point is
-  the calendar's center, not the tapped cell. If that feels wrong in
-  manual testing, two options: (a) lift the `@State` selection into
-  `MonthlyCalendarView` and attach `.popover(isPresented:)` per cell
-  with a generic `popoverContent: (Date) -> some View` closure (mirrors
-  the Overview pattern); (b) adopt `.popoverAttachmentAnchor` with a
-  `PopoverAttachmentAnchor.rect(…)` computed from the tapped cell's
-  frame.
+  leaving phantom records. Follow-up: normalize `logTimerSession`'s
+  0-seconds behavior so the service API is consistent with
+  `setCounter`'s delete-on-zero contract; the view-side workaround
+  can then go away.
+- **Follow-up A (popover anchoring)**: First pass attached the
+  popover at the whole-calendar level. Manual run on the sim showed
+  the popover arrow pointing to the top of the grid regardless of
+  which cell was tapped. Lifted the selection + content down into
+  `MonthlyCalendarView` (generic `PopoverContent`, `@Binding
+  selectedDay`), attached `.popover(isPresented:)` per cell. A
+  convenience init preserves read-only callers.
+- **Follow-up B (popover UX)**: First pass (a) seeded the timer
+  stepper to the habit's target when the day had no record, so the
+  popover opened looking already-complete at "30 of 30 min"; (b)
+  gated `Clear` on the saved-at-open `currentValue`, so stepping up
+  from 0 never revealed it; (c) offered a `Done` button that did
+  nothing more than dismiss. Fixed: seed to 0 when no record, track
+  the live `counterValue` / `timerMinutes` for Clear visibility,
+  removed `Done` entirely (tap-outside dismisses; every step already
+  writes through).
 - **UI-automation limitation**: Tap primitives aren't available in the
   default XcodeBuildMCP install (`CLAUDE.md` flags this), so the
-  simulator run only exercises the Today view — the popover itself
-  needs a human visual pass. The SwiftUI previews compile successfully
-  across all four habit types plus dark mode.
+  iterative visual pass depended on the user driving the sim and
+  sharing screenshots. That loop worked well — two rounds of
+  screenshots surfaced both the anchoring and UX regressions that
+  neither tests nor previews caught.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/past-completion-editing/plan.md
+++ b/docs/plans/2026-04/past-completion-editing/plan.md
@@ -7,7 +7,7 @@ type: project
 # Plan — Past-completion editing
 
 **Date**: 2026-04-20
-**Status**: ready to build
+**Status**: in progress (manual visual verification pending)
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -48,6 +48,11 @@ API change; purely UI wiring + a new popover view.
   after every mutation, mirroring the today quick-log pattern.
 
 ## Task list
+
+- [x] Task 1 — Regression tests for past-day service mutations (bbd4baa)
+- [x] Task 2 — Tappable past / today cells in `MonthlyCalendarView` (56a35b4)
+- [x] Task 3 — `DayEditPopover` view + localization (d2693ec)
+- [x] Task 4 — Wire popover into `HabitDetailView` (41463b2)
 
 ### Task 1: Regression tests for past-day service mutations
 
@@ -246,6 +251,38 @@ existing services. Archived habits stay non-interactive.
 - [ ] Month navigation is out of scope — if users reach for it once
       past-day editing exists, prioritize it in a follow-up. No
       action for this plan.
+
+## Notes during build
+
+- **Task 1**: The existing tests already passed with the new cases (no
+  red first). Intentional — the services' date API is already correct;
+  these are regressions against a hypothetical future "simplification."
+- **Task 3**: SwiftUI `Text("\(Int) of \(Int) min")` interpolation
+  needed a new catalog key `%lld of %lld min`; the counter control
+  reuses the existing `%lld of %lld` key.
+- **Task 4**: `CompletionLogger.logTimerSession(seconds: 0, …)` does
+  **not** delete — it inserts a zero-value record. Routing the
+  "stepped timer down to 0" path through `clear()` (which calls
+  `logger.delete(existing)` after looking up the record) avoids
+  leaving phantom records. Consider normalizing `logTimerSession`'s
+  0-seconds behavior in a follow-up so the service API is consistent
+  with `setCounter`'s delete-on-zero contract.
+- **Popover anchoring**: Attached to `MonthlyCalendarView` as a whole
+  (not per-cell) because routing popover content down into the view
+  would require a generic type parameter. The popover's header shows
+  the formatted date so there's no ambiguity, but the anchor point is
+  the calendar's center, not the tapped cell. If that feels wrong in
+  manual testing, two options: (a) lift the `@State` selection into
+  `MonthlyCalendarView` and attach `.popover(isPresented:)` per cell
+  with a generic `popoverContent: (Date) -> some View` closure (mirrors
+  the Overview pattern); (b) adopt `.popoverAttachmentAnchor` with a
+  `PopoverAttachmentAnchor.rect(…)` computed from the tapped cell's
+  frame.
+- **UI-automation limitation**: Tap primitives aren't available in the
+  default XcodeBuildMCP install (`CLAUDE.md` flags this), so the
+  simulator run only exercises the Today view — the popover itself
+  needs a human visual pass. The SwiftUI previews compile successfully
+  across all four habit types plus dark mode.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/past-completion-editing/plan.md
+++ b/docs/plans/2026-04/past-completion-editing/plan.md
@@ -7,7 +7,7 @@ type: project
 # Plan — Past-completion editing
 
 **Date**: 2026-04-20
-**Status**: done (visual verification passed; ready for compound)
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -264,9 +264,10 @@ existing services. Archived habits stay non-interactive.
 
 ## Open questions
 
-- [ ] Month navigation is out of scope — if users reach for it once
-      past-day editing exists, prioritize it in a follow-up. No
-      action for this plan.
+- [x] Month navigation — deferred. Out of scope for this feature;
+      the grid still shows only the current month, so past-day
+      editing is limited to that window. Revisit if user feedback
+      asks for it.
 
 ## Notes during build
 

--- a/docs/plans/2026-04/past-completion-editing/plan.md
+++ b/docs/plans/2026-04/past-completion-editing/plan.md
@@ -1,0 +1,261 @@
+---
+name: Plan — Past-completion editing
+description: Ordered task breakdown for the past-day popover in habit detail.
+type: project
+---
+
+# Plan — Past-completion editing
+
+**Date**: 2026-04-20
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Let users check / uncheck a habit on a past or today cell by tapping
+that cell in the habit detail's monthly calendar. A popover anchored
+to the cell shows the right affordance per habit type (binary,
+negative, counter, timer) and writes through the existing
+`CompletionToggler` / `CompletionLogger` services — both already
+accept an arbitrary `date` parameter. No schema change, no service
+API change; purely UI wiring + a new popover view.
+
+## Decisions locked in
+
+- Scope: all four habit types (binary, negative, counter, timer) in
+  the MVP.
+- Tap-on-today: opens the popover, same as past days. Inline
+  quick-log above the grid stays as a second path for today.
+- Discoverability: ship silent. Accessibility hint only — no visible
+  helper text.
+- Archived habits: cells are non-interactive. No popover at all.
+- Future cells: non-interactive. No popover.
+- Binary / negative flow: tap the action, popover auto-dismisses.
+- Counter / timer flow: popover stays open while the user adjusts
+  the value; dismiss on tap-outside or explicit "Done."
+- "Clear" in counter / timer popovers sets value to 0, which deletes
+  the `CompletionRecord` via the existing logger contract.
+- Popover presentation: `.presentationCompactAdaptation(.popover)`
+  so iPhone gets the anchored popover look. Adapt to a sheet only
+  under accessibility Dynamic Type (XXXL and above) where the
+  popover body can't fit — flag as a task 4 decision once measured.
+- Use an `Identifiable` wrapper (`EditingDay`) for `.popover(item:)`
+  since `Date` isn't `Identifiable`.
+- Mutations go through existing services with `@Environment(\.calendar)`
+  injected — same calendar drives cell classification and write
+  path, avoiding day-boundary drift.
+- Widget refresh: call `WidgetReloader.reloadAll(using: modelContext)`
+  after every mutation, mirroring the today quick-log pattern.
+
+## Task list
+
+### Task 1: Regression tests for past-day service mutations
+
+**Goal**: Lock in the invariant that `CompletionToggler` and
+`CompletionLogger` write to the injected `date`, not `.now`, under
+a fixed-calendar test. These should pass green on the current
+service layer; they're insurance against a future "simplification"
+that hardcodes `.now`.
+
+**Changes**:
+- `KadoTests/CompletionTogglerTests.swift` — add:
+  - `@Test("Toggle on a past day inserts on that day, not today")`
+    with `now = 2026-04-15` and `date = 2026-04-12`.
+  - `@Test("Toggle on a past day twice deletes, leaving today intact")`
+    with a today record pre-seeded.
+- `KadoTests/CompletionLoggerTests.swift` — add:
+  - `@Test("setCounter on past day preserves other days' values")`
+    — seed days D-3 and D-1, set D-2, verify only D-2 changed.
+  - `@Test("logTimerSession on past day targets the correct day")`
+    — mirror the toggler test for timer values.
+  - `@Test("setCounter to 0 on past day deletes the record")`.
+
+**Tests / verification**:
+- All new tests pass: `test_sim` scheme Kado.
+- No warnings introduced.
+
+**Commit**: `test(completions): lock in past-day service invariants`
+
+---
+
+### Task 2: Tappable past / today cells in `MonthlyCalendarView`
+
+**Goal**: The calendar view exposes a tap callback for past and
+today cells (future remains non-interactive). The view stays pure
+presentation — it doesn't know what happens on tap.
+
+**Changes**:
+- `Kado/UIComponents/MonthlyCalendarView.swift`:
+  - Add `var onTapDay: ((Date) -> Void)? = nil` property (default
+    nil preserves all existing callers / previews).
+  - In `cell(for:)`, attach `.onTapGesture { onTapDay?(day) }` only
+    when `state(for: day) != .future`. Future cells remain
+    non-interactive.
+  - Add `.accessibilityHint(Text("Double-tap to edit this day."))`
+    on non-future cells. Gate so VoiceOver doesn't announce a hint
+    on future cells.
+  - Add `.contentShape(Rectangle())` on the cell so the whole cell
+    area (not just filled pixels) is hittable.
+  - Add `.sensoryFeedback(.selection, trigger: lastTappedDay)` at
+    the grid scope if we track the last-tapped day; optional — can
+    also live on the detail view. Keep here if it's clean.
+
+**Tests / verification**:
+- Existing previews still render without callbacks wired.
+- Build cleanly: `build_sim`.
+- Manual: run the app, confirm future cells don't respond to taps;
+  past cells trigger the callback (temporarily print `onTapDay` in
+  a preview harness to verify).
+
+**Commit**: `feat(calendar): expose per-day tap callback on past cells`
+
+---
+
+### Task 3: `DayEditPopover` view + localization
+
+**Goal**: Standalone SwiftUI view that, given a habit and a date,
+renders the right edit control for that habit's type. Full preview
+coverage for all four types + a dark preview. Not yet integrated
+into `HabitDetailView`.
+
+**Changes**:
+- New file `Kado/Views/HabitDetail/DayEditPopover.swift`:
+  - Inputs: `habit: Habit` (snapshot for display), `date: Date`,
+    `currentValue: Double` (0 if no record), callbacks for each
+    habit type's mutation (`onToggle`, `onSetCounter(Double)`,
+    `onSetTimerSeconds(TimeInterval)`, `onClear`).
+  - Layout mirrors `CellPopoverContent`: header (icon + name),
+    date subtitle, then the type-specific control.
+  - Binary / negative: a primary button ("Mark complete" / "Mark
+    missed" / "Unmark" — copy inverted for negative) that calls
+    `onToggle` and auto-dismisses.
+  - Counter: stepper + "Clear" button. Cap max at `target × 3` or
+    99, whichever is lower, to avoid runaway.
+  - Timer: minute stepper (1-min increments, default to a useful
+    max like 180 min) + "Clear" button.
+  - Use semantic colors (`Color.primary`, `.secondary`, tint
+    derived from habit color on action buttons).
+- Localization: add catalog entries in
+  `Kado/Resources/Localizable.xcstrings` with EN + hand-translated
+  FR (per `docs/plans/2026-04/french-translations/` conventions —
+  `tu`, `habitude` grammar):
+  - "Mark complete" / "Marquer comme fait"
+  - "Unmark" / "Annuler"
+  - "Mark missed" / "Marquer comme raté" (negative habit)
+  - "Unmark missed" / "Annuler" (negative habit)
+  - "Clear" / "Effacer"
+  - "Done" / "Terminé"
+  - "Minutes" / "Minutes"
+  - Any other copy introduced by the popover.
+
+**Tests / verification**:
+- Previews: one per habit type + one dark preview (pick the
+  counter-partial state as the demanding one).
+- `LocalizationCoverageTests` passes (FR parity enforced).
+- `build_sim` clean; no unused-string warnings.
+
+**Commit**: `feat(habit-detail): add DayEditPopover view`
+
+---
+
+### Task 4: Wire popover into `HabitDetailView`
+
+**Goal**: Tapping a past or today cell in the detail view opens the
+popover; actions in the popover mutate the habit's completions via
+existing services. Archived habits stay non-interactive.
+
+**Changes**:
+- `Kado/Views/HabitDetail/HabitDetailView.swift`:
+  - Add `@State private var editingDay: EditingDay? = nil` where
+    `EditingDay` is a private `Identifiable` wrapper on `Date`.
+  - Pass `onTapDay:` to `MonthlyCalendarView`, setting
+    `editingDay = .init(date: day)` — but only when `!isArchived`.
+  - Attach `.popover(item: $editingDay, attachmentAnchor: …)` (or
+    anchor via `.overlay`/`PopoverAnchor`) rendering `DayEditPopover`.
+    Use `.presentationCompactAdaptation(.popover)` to force popover
+    on iPhone.
+  - Compute `currentValue` for the tapped day from
+    `habit.completions`.
+  - Implement callback bodies:
+    - Binary / negative → `CompletionToggler(calendar: calendar).toggleToday(for: habit, on: date, in: modelContext)`.
+    - Counter → `CompletionLogger(calendar: calendar).setCounter(for: habit, on: date, to: value, in: modelContext)`.
+    - Timer → `CompletionLogger(calendar: calendar).logTimerSession(for: habit, seconds: value, on: date, in: modelContext)`.
+    - Clear → `setCounter(... to: 0, ...)` or `logTimerSession(... seconds: 0, ...)`.
+  - After every mutation: `try? modelContext.save()` +
+    `WidgetReloader.reloadAll(using: modelContext)` (existing
+    pattern).
+
+**Tests / verification**:
+- `build_sim` clean.
+- `test_sim` full suite green — existing detail-view tests should
+  still pass.
+- Manual in simulator (iPhone 17 Pro):
+  1. Binary habit: tap past cell, popover opens, mark complete,
+     dismiss, cell is now completed.
+  2. Same cell again: tap, popover shows "Unmark," unmark, cell
+     returns to missed.
+  3. Counter habit: set value to target on a past day, popover
+     stays open, close, cell shows completed.
+  4. Timer habit: log 30 min on a past day; close; score /
+     streak update.
+  5. Negative habit: popover copy uses "Mark missed"/"Unmark."
+  6. Future cell: tap does nothing.
+  7. Archived habit: tap does nothing.
+- Screenshot each state, drop into the compound doc.
+- VoiceOver pass on the grid: hint reads, double-tap opens the
+  popover, labels in the popover are accurate.
+- Dynamic Type XXXL: popover body doesn't clip. If it does, fall
+  back to sheet presentation for accessibility sizes — decision
+  point during this task.
+
+**Commit**: `feat(habit-detail): edit past-day completions via calendar popover`
+
+---
+
+## Risks and mitigation
+
+- **Day-boundary drift** — `MonthlyCalendarView.state(for:)` and the
+  service write path could disagree on "is this day D" if different
+  `Calendar` instances are used. **Mitigation**: both read
+  `@Environment(\.calendar)` in the detail view; pass that same
+  calendar into both the view (implicitly via env) and the service
+  constructors explicitly. Regression tests in task 1 lock this in.
+- **Popover sizing under XXXL Dynamic Type** — controls may clip.
+  **Mitigation**: during task 4 manual audit, measure; if clipped,
+  fall back to a sheet via
+  `.presentationCompactAdaptation(horizontal: .sheet, vertical: .popover)`
+  or just `.sheet` at accessibility sizes. Note the chosen branch
+  in the compound doc.
+- **Tap target < 44 pt** — 32 pt cells are below HIG guidance.
+  **Mitigation**: `.contentShape(Rectangle())` expands the hit
+  region to the full grid cell (including 8 pt spacing). VoiceOver
+  gets the full focusable element. Accept as a known constraint
+  (calendar dates are traditionally compact); flag in the compound
+  doc.
+- **Counter runaway values** — user could spam +. **Mitigation**:
+  cap stepper max (see task 3).
+- **Toggling counter/timer via popover vs inline** — two UI paths
+  for today's value. **Mitigation**: both call the same services;
+  `@Query`-driven `HabitRecord.completions` re-renders both
+  affordances in step. Verify during task 4 manual.
+- **`.popover(item:)` requires `Identifiable`** — `Date` isn't.
+  **Mitigation**: private `EditingDay` wrapper in the detail view.
+
+## Open questions
+
+- [ ] Month navigation is out of scope — if users reach for it once
+      past-day editing exists, prioritize it in a follow-up. No
+      action for this plan.
+
+## Out of scope
+
+- Month navigation (paging back through prior months).
+- Changing `CompleteHabitIntent` (widget / Siri) to accept an
+  arbitrary date — today-only is correct for the widget tap
+  gesture.
+- Bulk past-day editing (Overview-style for a single habit).
+- Surfacing a hint banner / onboarding tooltip for discoverability —
+  revisit if feedback shows confusion.
+- Editing completions before `habit.createdAt` (current grid only
+  shows the current month; not reachable until month navigation
+  lands).

--- a/docs/plans/2026-04/past-completion-editing/research.md
+++ b/docs/plans/2026-04/past-completion-editing/research.md
@@ -1,0 +1,238 @@
+---
+name: Research — Past-completion editing
+description: Allow users to check/uncheck habits on past days by tapping a cell in the habit detail calendar.
+type: project
+---
+
+# Research — Past-completion editing
+
+**Date**: 2026-04-20
+**Status**: ready for plan
+**Related**: `docs/ROADMAP.md` (v0.x polish), `docs/plans/2026-04/detail-quick-log/`, `docs/plans/2026-04/multi-habit-overview/` (popover pattern)
+
+## Problem
+
+Today, users can only log a completion for **the current day**. The
+detail view's monthly calendar is read-only. If a user forgets to log
+a completion — e.g. they read before bed but their phone was already
+off, or they went to the gym and only remembered the next morning —
+the day is permanently marked as missed.
+
+From the user's perspective, "done" looks like: open the habit's
+detail, tap yesterday's cell in the calendar, confirm the completion,
+and see the streak / score update. The same gesture unchecks a day
+that was marked by mistake.
+
+Why it matters: a single missed log shouldn't break a streak or
+degrade the score when the underlying behavior actually happened.
+This is standard in Streaks, Loop, (Not Boring) Habits — its absence
+is a visible gap.
+
+## Current state of the codebase
+
+The good news: **the service layer is already date-parameterized**.
+Only the UI is read-only.
+
+- `Packages/KadoCore/Sources/KadoCore/Services/CompletionToggler.swift`
+  — `toggleToday(for:on:in:)` already accepts an arbitrary `date`
+  (defaulted to `.now`). Inserts a `CompletionRecord` if none exists
+  for the injected calendar's day, otherwise deletes the match. DST-
+  safe; covered by `KadoTests/CompletionTogglerTests.swift`.
+- `Kado/Services/CompletionLogger.swift` — `incrementCounter(on:)`,
+  `decrementCounter(on:)`, `setCounter(on:to:)`,
+  `logTimerSession(seconds:on:)`. All already take a `date:` and
+  keep the one-record-per-day invariant.
+- `CompletionRecord` (`Packages/KadoCore/Sources/KadoCore/Models/Persistence/CompletionRecord.swift`)
+  — no `@Attribute(.unique)`; uniqueness is application-enforced via
+  calendar-aware lookup.
+- `Kado/UIComponents/MonthlyCalendarView.swift` — renders the grid.
+  Each day is a `ZStack` inside a `LazyVGrid` (32 pt cells). Has an
+  accessibility label per cell. **No tap handler today.** Computes
+  `CellState` of `.future | .completed | .missed | .nonDue` locally.
+- `Kado/Views/HabitDetail/HabitDetailView.swift` — owns the grid,
+  the quick-log affordance (counter/timer), and the
+  `CompletionHistoryList`. `@Bindable var habit: HabitRecord` with
+  `@Environment(\.modelContext)`.
+- `Kado/Views/Overview/CellPopoverContent.swift` — **the UX
+  precedent.** The multi-habit overview already attaches a
+  read-only `.popover` per (habit × day) cell. We'll adapt the
+  look-and-feel (habit mark + date + status) and add edit
+  affordances.
+
+Gaps:
+- No tap gesture on calendar cells.
+- No existing editable popover anywhere in the app.
+- `CompleteHabitIntent` (widget / Siri) is today-only. This feature
+  doesn't need to change that — arbitrary-date logging from the
+  widget is a separate design conversation.
+
+## Proposed approach
+
+Attach a tap gesture to past-or-today cells in `MonthlyCalendarView`.
+The tap opens a popover (anchored to the cell) whose body branches
+on `habit.type`:
+
+- **Binary / negative**: single toggle button. Current state rendered
+  as "Completed / Missed" with a primary action labeled *Mark
+  complete* or *Unmark* (inverted copy for negative). Calls
+  `CompletionToggler.toggleToday(for:on:in:)` with the tapped day.
+- **Counter**: stepper + number field bound to the day's value;
+  calls `CompletionLogger.setCounter(for:on:to:)`. "Clear" sets 0
+  which deletes the record.
+- **Timer**: duration picker (minutes) bound to the day's logged
+  seconds; calls `CompletionLogger.logTimerSession(for:seconds:on:)`.
+  "Clear" logs 0 to delete.
+
+Discoverability is the biggest UX question (cells are small; tap
+affordance isn't obvious). Two mitigations:
+- Add `accessibilityHint("Double-tap to edit this day")`.
+- Add a subtle haptic on tap-down (`.sensoryFeedback(.impact, ...)`)
+  so the cell feels "pressable."
+- Consider a first-launch tooltip (deferred — not in MVP).
+
+Interactions to preserve:
+- **Future days**: remain non-interactive. No popover.
+- **Archived habits**: cells are non-interactive. No popover at all,
+  matching the read-only spirit of the rest of `HabitDetailView` on
+  archived habits.
+- **Today's cell**: also opens the popover. That's a behavior
+  change for counter/timer (today's counter +/- is currently in
+  the inline quick-log above the grid). The popover becomes a
+  second path to log today — cheap, non-conflicting, doesn't
+  remove existing affordances.
+- **Discoverability**: ship silent — no helper text. Rely on the
+  accessibility hint and the familiar popover pattern. Revisit if
+  user feedback shows confusion.
+
+### Key components
+
+- `MonthlyCalendarView` — extend cell closure with a `onTap: (Date) -> Void`
+  callback, gate to `!isFuture`. The view stays presentation-only.
+- `HabitDetailView` — new `@State private var editingDay: Date?` +
+  a single `.popover(item:)` projection. Owns the mutation calls.
+- New `Kado/Views/HabitDetail/DayEditPopover.swift` — small view that
+  switches on `habit.type` and renders the right control. Mirrors
+  `CellPopoverContent` visual style; reuses `CounterQuickLogView` for
+  counter, the timer duration control from `TimerLogSheet` for timer.
+- Localization: new catalog entries for popover copy (EN + FR).
+- `WidgetReloader.reloadAll(using:)` after every mutation (existing
+  pattern; no new work).
+
+### Data model changes
+
+**None.** The existing `CompletionRecord` shape is sufficient. The
+calendar-aware one-per-day invariant already holds at the service
+layer. No schema bump, no migration.
+
+### UI changes
+
+- Cells become tappable for past + today (not future).
+- New popover: binary toggle / counter stepper / timer duration
+  picker depending on type.
+- Minor: add accessibility hint, haptic feedback on cell tap.
+
+### Tests to write
+
+Services are already covered for arbitrary dates; the value-add is
+guarding the new UI path and the day-identity edge cases.
+
+- `@Test("Toggling a past day inserts a record on that day, not today")`
+  — exercise `CompletionToggler.toggleToday(on:)` with `now` fixed to
+  mid-April and `date` = 3 days earlier. Assert the stored
+  `CompletionRecord.date` matches the target day, not `.now`.
+- `@Test("Toggling a past day twice is idempotent (delete)")` —
+  covered conceptually, add a targeted regression if absent.
+- `@Test("Setting counter on a past day preserves other days'
+  values")` — ensure `setCounter(on:to:)` only mutates the matching
+  day.
+- `@Test("DayEditPopover binary flow")` — a light view-model-style
+  test that ensures the right service method is called with the
+  right date. (Or skip if popover is a pure passthrough.)
+- Manual: VoiceOver walk of the grid (focus + hint + action),
+  Dynamic Type XXXL doesn't crop the popover, dark mode contrast on
+  the popover surface.
+
+## Alternatives considered
+
+### Alternative A: long-press instead of tap
+
+- Idea: long-press a cell to enter edit mode; tap preserved for a
+  potential future behavior (e.g. zoom to day detail).
+- Why not: tap is the expected iOS gesture for "interact with this
+  thing," and long-press is less discoverable. We have no other tap
+  semantics competing for the gesture. Keep tap for MVP; revisit if
+  we ever need a secondary action.
+
+### Alternative B: full-screen "edit day" sheet
+
+- Idea: tap opens a sheet listing all habits for that day (Overview-
+  style), allowing bulk edits.
+- Why not: mixes concerns. The user's flow is "I want to log this
+  one habit for yesterday," not "let me revisit all habits for a
+  day." That's a separate feature and arguably belongs in the
+  Overview surface rather than the detail view. Defer.
+
+### Alternative C: inline row below the grid
+
+- Idea: tapping selects a day; a row appears below with the same
+  controls as the today quick-log.
+- Why not: extra vertical push, less spatial continuity. Popover
+  anchored to the cell is the well-established iOS pattern we
+  already use in Overview.
+
+### Alternative D: Swipe on `CompletionHistoryList`
+
+- Idea: use the existing `CompletionHistoryList` to edit past days.
+- Why not: history only shows *existing* completions — it can't
+  insert a missing day. We'd have to add a "pick a date" flow,
+  which is strictly worse UX than tapping the calendar.
+
+## Risks and unknowns
+
+- **Day-boundary bugs.** The calendar is injected via
+  `@Environment(\.calendar)`, but the service layer also takes a
+  `Calendar`. Make sure both paths use the same instance — regress
+  if mismatched around DST.
+- **Popover sizing under Dynamic Type XXXL.** Counter / timer
+  controls can push the popover past comfortable widths. May need
+  `.presentationCompactAdaptation(.popover)` + max-width clamps, or
+  switch to a sheet in compact accessibility sizes.
+- **Tap target.** 32 pt cells are below Apple's 44 pt guideline.
+  VoiceOver users get the full-width focusable element; mouse/tap
+  users have a smaller target. Acceptable (calendar dates are
+  traditionally smaller) but flag as a known constraint.
+- **Counter > target.** The popover stepper should allow values
+  above the target (same as today's quick-log) — just capped at a
+  reasonable max to prevent runaway.
+- **Logging a day before `habit.createdAt`.** Technically possible;
+  the `missed`/`nonDue` classification still works. We should
+  allow it — users sometimes want to record pre-existing behavior
+  — but the calendar currently shows cells only for the current
+  month. Not a blocker; revisit if month navigation ever lands.
+
+## Resolved decisions
+
+- **Habit-type scope**: all four types (binary / negative / counter
+  / timer) in MVP.
+- **Tap-on-today**: opens the popover, same as past days. Inline
+  quick-log remains as a second path for today.
+- **Discoverability**: ship silent. Rely on accessibility hint.
+- **Archived habits**: no popover at all. Cells stay non-interactive.
+
+## Open questions
+
+- [ ] **Month navigation** is out of scope for this feature — the
+      grid still shows only the current month. Past-day editing is
+      limited to that window until someone adds paging. Flag if
+      users reach beyond the current month, otherwise defer.
+
+## References
+
+- Apple HIG — Popovers:
+  https://developer.apple.com/design/human-interface-guidelines/popovers
+- Existing popover precedent: `Kado/Views/Overview/CellPopoverContent.swift`
+- Service entry points:
+  `Packages/KadoCore/Sources/KadoCore/Services/CompletionToggler.swift`,
+  `Kado/Services/CompletionLogger.swift`
+- Test patterns (calendar injection + DST):
+  `KadoTests/CompletionTogglerTests.swift`, `KadoTests/Helpers/TestCalendar.swift`


### PR DESCRIPTION
## Why?

- The habit detail's monthly calendar was read-only. A single forgotten log would break a streak or hurt the score even when the behavior actually happened.
- Standard in Streaks, Loop, (Not Boring) Habits — a visible gap.

## What?

- Tap a past or today cell in the detail calendar to open a popover **anchored to the tapped cell**.
- Popover branches on `habit.type`: single toggle for binary / negative, counter stepper, minute stepper for timer.
- Every stepper tick writes through immediately — no `Done` button. Binary/negative toggles and `Clear` auto-dismiss; otherwise the user taps outside.
- `Clear` appears only when the **live** stepper value is > 0.
- Counter/timer default to `0` when the day has no record (not to the habit's target).
- Future cells and archived-habit cells stay non-interactive.
- EN + FR localization shipped (`Clear` / `Effacer`, `Mark as slipped` / `Marquer comme raté`, etc.).

## How?

- UI-only. `CompletionToggler.toggleToday(on:)` and `CompletionLogger.setCounter(on:)` / `.logTimerSession(on:)` already accept an arbitrary `date`; no schema or service API change.
- `MonthlyCalendarView` is now generic on `PopoverContent: View`, takes `@Binding var selectedDay: Date?` + a `@ViewBuilder popoverContent: (Date) -> PopoverContent`, and attaches `.popover(isPresented:)` **per cell** (mirrors the Overview pattern). A convenience init `where PopoverContent == EmptyView` keeps every existing read-only caller working.
- New `DayEditPopover` view branches on `habit.type` and seeds its local stepper state from the day's saved value.
- `HabitDetailView` owns the mutation helpers; every write is followed by `WidgetReloader.reloadAll(using:)`.
- `logTimerSession(seconds: 0)` doesn't delete — view-side routes to `logger.delete(existing)` via `clear(on:)`. Flagged for a follow-up to normalize the service API.
- 5 regression tests added locking in past-day service invariants. 248/248 tests pass, `build_sim` clean.

## Artifacts

- [Research](docs/plans/2026-04/past-completion-editing/research.md)
- [Plan](docs/plans/2026-04/past-completion-editing/plan.md)
- [Compound retrospective](docs/plans/2026-04/past-completion-editing/compound.md)

## Follow-ups (out of this PR)

- Normalize `CompletionLogger.logTimerSession(seconds: 0)` to delete, matching `setCounter(to: 0)`.
- Month navigation in the detail calendar (past-day editing is limited to the current month until paging lands).
- Optional: `isInteractive: Bool` flag on `MonthlyCalendarView` so archived habits don't attach gestures at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)