### PR TITLE
feat(app): display home-screen name as "Kadō"

### DIFF
--- a/Kado.xcodeproj/project.pbxproj
+++ b/Kado.xcodeproj/project.pbxproj
@@ -467,6 +467,7 @@
 				DEVELOPMENT_TEAM = VKY5EKKU47;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Kadō";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -502,6 +503,7 @@
 				DEVELOPMENT_TEAM = VKY5EKKU47;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Kadō";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;


### PR DESCRIPTION
## Why?
- The brand is spelled **Kadō** (with the macron) everywhere in the product and docs, but the iOS home-screen label currently reads **Kado**.

## What?
- The app icon label on iOS (home screen, App Library, Spotlight, Settings) now renders as **Kadō**.

## How?
- Set `INFOPLIST_KEY_CFBundleDisplayName = "Kadō"` on the main app target for both Debug and Release. No bundle-identifier, scheme, or widget-extension change.
- `GENERATE_INFOPLIST_FILE` is already on, so no standalone `Info.plist` is needed.

## Next steps
- If we later ship an `InfoPlist.xcstrings` for localized metadata, add `CFBundleDisplayName` there (same value for EN and FR — brand).