### PR TITLE
fix(today): refresh current day on foreground return

### DIFF
--- a/Kado/App/EnvironmentValues+Services.swift
+++ b/Kado/App/EnvironmentValues+Services.swift
@@ -64,4 +64,12 @@ extension EnvironmentValues {
     /// Parses a `BackupDocument` and merges it into the live store for
     /// the Settings → Import flow.
     @Entry var backupImporter: any BackupImporting = DefaultBackupImporter()
+
+    /// Day-granular "now" driven by the scene lifecycle. `KadoApp` bumps
+    /// this on every `scenePhase → .active` transition where the calendar
+    /// day has changed, so views that read it re-evaluate their body on
+    /// the new day without needing a relaunch. Views should read this
+    /// instead of `.now` for any day-boundary decision (what's due today,
+    /// where the overview's trailing edge lands).
+    @Entry var today: Date = .now
 }

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -11,6 +11,7 @@ struct KadoApp: App {
     @State private var cloudAccountStatus = DefaultCloudAccountStatusObserver()
     @State private var notificationScheduler: any NotificationScheduling
     @State private var notificationManager: NotificationManager
+    @State private var today: Date = .now
 
     init() {
         DevModeDefaults.migrateFromStandardIfNeeded()
@@ -49,6 +50,7 @@ struct KadoApp: App {
         .modelContainer(container)
         .environment(\.cloudAccountStatus, cloudAccountStatus)
         .environment(\.notificationScheduler, notificationScheduler)
+        .environment(\.today, today)
         .onChange(of: scenePhase) { _, newPhase in
             // Reconciles the pending set every time the app comes
             // to the foreground — handles clock-drift, day-rollover,
@@ -56,6 +58,10 @@ struct KadoApp: App {
             // the app was suspended.
             if newPhase == .active {
                 RemindersSync.rescheduleAll(using: container.mainContext)
+                let calendar = Calendar.current
+                if !calendar.isDate(today, inSameDayAs: .now) {
+                    today = .now
+                }
             }
         }
         .onChange(of: isDevMode) { oldValue, newValue in

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -23,6 +23,7 @@ struct OverviewView: View {
     private var records: [HabitRecord]
 
     @Environment(\.calendar) private var calendar
+    @Environment(\.today) private var now
     @Environment(\.frequencyEvaluator) private var frequencyEvaluator
     @Environment(\.streakCalculator) private var streakCalculator
     @Environment(\.habitScoreCalculator) private var scoreCalculator
@@ -83,7 +84,7 @@ struct OverviewView: View {
     }
 
     private var matrix: some View {
-        let today = calendar.startOfDay(for: .now)
+        let today = calendar.startOfDay(for: now)
         let days = dayRange(endingAt: today)
         let snapshots = records.map { record -> (Habit, [Completion]) in
             (record.snapshot, (record.completions ?? []).map(\.snapshot))

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -12,6 +12,7 @@ struct TodayView: View {
     @Environment(\.streakCalculator) private var streakCalculator
     @Environment(\.habitScoreCalculator) private var scoreCalculator
     @Environment(\.calendar) private var calendar
+    @Environment(\.today) private var today
 
     @Query(
         filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
@@ -191,16 +192,14 @@ struct TodayView: View {
     }
 
     private var habitsDueToday: [HabitRecord] {
-        let now = Date.now
-        return activeHabits.filter { record in
-            isDueTodayOrCompletedToday(record, on: now)
+        activeHabits.filter { record in
+            isDueTodayOrCompletedToday(record, on: today)
         }
     }
 
     private var habitsNotDueToday: [HabitRecord] {
-        let now = Date.now
-        return activeHabits.filter { record in
-            !isDueTodayOrCompletedToday(record, on: now)
+        activeHabits.filter { record in
+            !isDueTodayOrCompletedToday(record, on: today)
         }
     }
 


### PR DESCRIPTION
Closes #33.

## Why?
- Opening the app on a new calendar day (after it had been backgrounded overnight) still rendered "yesterday" on both **Today** and **Overview**. Only a kill-and-relaunch fixed it.
- Root cause: both views derive the current day from inline `.now` reads inside computed properties. Nothing in their `@State`, `@Query`, or `@Environment` changed on foreground return, so SwiftUI never re-evaluated `body` — the stale day-filter from the prior session persisted.

## What?
- Today and Overview now roll over automatically the moment the app returns to the foreground on a new day. No user action, no relaunch.

## How?
- New `Environment.today: Date` entry in the service registry.
- `KadoApp` owns a `@State private var today` and injects it at the scene root. The existing `scenePhase → .active` handler (which already reschedules reminders) now also bumps `today` when `calendar.isDate(today, inSameDayAs: .now)` is false.
- `TodayView` reads `@Environment(\.today)` and uses it in `habitsDueToday` / `habitsNotDueToday`.
- `OverviewView` reads it and uses it as the anchor for `calendar.startOfDay(for:)` in `matrix`.
- The env read at body-level is what creates the dependency forcing re-eval — no view remount, no `@Query` invalidation, no loss of nav / tab / scroll state.
- Non-day-boundary `.now` reads (streak / score `asOf:`) are left alone; they resolve inside body at render time, which the `today` dependency already re-triggers.

## Next steps
- None required. Watch for reports around DST transitions, but the use of `calendar.isDate(_:inSameDayAs:)` should handle those correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)