### PR TITLE
docs(readme): link header image to website and add App Store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="branding/kado-wordmark.svg" alt="Kadō" width="320" />
+  <a href="https://getkado.app/"><img src="branding/kado-wordmark.svg" alt="Kadō" width="320" /></a>
 
   <p><strong>A privacy-first habit tracker for iPhone and iPad.</strong></p>
   <p>
@@ -8,10 +8,15 @@
   </p>
 
   <p>
+    <a href="https://apps.apple.com/app/id6762570244">Download on the App Store</a> ·
+    <a href="https://getkado.app/">getkado.app</a>
+  </p>
+
+  <p>
     <a href="https://github.com/scastiel/kado/blob/main/LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-blue.svg" /></a>
     <a href="https://developer.apple.com/swift/"><img alt="Swift 5.10" src="https://img.shields.io/badge/Swift-5.10-orange.svg" /></a>
     <img alt="Platforms" src="https://img.shields.io/badge/platforms-iOS%2018%20%7C%20iPadOS%2018-lightgrey.svg" />
-    <img alt="Status" src="https://img.shields.io/badge/App%20Store-in%20review-yellow.svg" />
+    <a href="https://apps.apple.com/app/id6762570244"><img alt="App Store" src="https://img.shields.io/badge/App%20Store-live-brightgreen.svg" /></a>
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </p>
 
   <p>
-    <a href="https://apps.apple.com/app/id6762570244"><img src="branding/app-store-en-black.svg#gh-light-mode-only" alt="Download on the App Store" height="48" /><img src="branding/app-store-en-white.svg#gh-dark-mode-only" alt="Download on the App Store" height="48" /></a>
+    <a href="https://apps.apple.com/app/id6762570244"><img src="site/assets/branding/app-store-en-black.svg#gh-light-mode-only" alt="Download on the App Store" height="48" /><img src="site/assets/branding/app-store-en-white.svg#gh-dark-mode-only" alt="Download on the App Store" height="48" /></a>
   </p>
   <p>
     <a href="https://getkado.app/">getkado.app</a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
   </p>
 
   <p>
-    <a href="https://apps.apple.com/app/id6762570244">Download on the App Store</a> ·
+    <a href="https://apps.apple.com/app/id6762570244"><img src="branding/app-store-en-black.svg#gh-light-mode-only" alt="Download on the App Store" height="48" /><img src="branding/app-store-en-white.svg#gh-dark-mode-only" alt="Download on the App Store" height="48" /></a>
+  </p>
+  <p>
     <a href="https://getkado.app/">getkado.app</a>
   </p>
 
@@ -16,7 +18,6 @@
     <a href="https://github.com/scastiel/kado/blob/main/LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-blue.svg" /></a>
     <a href="https://developer.apple.com/swift/"><img alt="Swift 5.10" src="https://img.shields.io/badge/Swift-5.10-orange.svg" /></a>
     <img alt="Platforms" src="https://img.shields.io/badge/platforms-iOS%2018%20%7C%20iPadOS%2018-lightgrey.svg" />
-    <a href="https://apps.apple.com/app/id6762570244"><img alt="App Store" src="https://img.shields.io/badge/App%20Store-live-brightgreen.svg" /></a>
   </p>
 </div>
 


### PR DESCRIPTION
## Why?
- Kadō is live on the App Store and `getkado.app` is public — the README should surface both prominently instead of the old "in review" placeholder.

## What?
- Wraps the top wordmark image in a link to `https://getkado.app/`.
- Adds a "Download on the App Store · getkado.app" line under the tagline.
- Replaces the yellow "App Store — in review" badge with a green "App Store — live" badge that links to the listing.

## How?
- README-only change; no code paths touched.

## Next steps
- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)