### PR TITLE
docs(readme): serve App Store badge from getkado.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </p>
 
   <p>
-    <a href="https://apps.apple.com/app/id6762570244"><img src="site/assets/branding/app-store-en-black.svg#gh-light-mode-only" alt="Download on the App Store" height="48" /><img src="site/assets/branding/app-store-en-white.svg#gh-dark-mode-only" alt="Download on the App Store" height="48" /></a>
+    <a href="https://apps.apple.com/app/id6762570244"><img src="https://getkado.app/assets/branding/app-store-en-black.svg#gh-light-mode-only" alt="Download on the App Store" height="48" /><img src="https://getkado.app/assets/branding/app-store-en-white.svg#gh-dark-mode-only" alt="Download on the App Store" height="48" /></a>
   </p>
   <p>
     <a href="https://getkado.app/">getkado.app</a>


### PR DESCRIPTION
## Why?
- The App Store badge currently renders via a repo-relative path (`site/assets/branding/...`), which doesn't resolve in all README contexts (package registries, mirrors, some proxies).
- Serving from the deployed site also means the badge picks up any future branding refresh without a README edit.

## What?
- Swaps both `src` URLs (light + dark variants) from the `site/assets/branding/...` relative path to `https://getkado.app/assets/branding/app-store-en-{black,white}.svg`.

## How?
- README-only change. `#gh-light-mode-only` / `#gh-dark-mode-only` fragments preserved so GitHub still swaps black/white by theme.

## Next steps
- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)