### PR TITLE
docs(readme): use <picture> for theme-aware App Store badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </p>
 
   <p>
-    <a href="https://apps.apple.com/app/id6762570244"><img src="https://getkado.app/assets/branding/app-store-en-black.svg#gh-light-mode-only" alt="Download on the App Store" height="48" /><img src="https://getkado.app/assets/branding/app-store-en-white.svg#gh-dark-mode-only" alt="Download on the App Store" height="48" /></a>
+    <a href="https://apps.apple.com/app/id6762570244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://getkado.app/assets/branding/app-store-en-white.svg" /><img src="https://getkado.app/assets/branding/app-store-en-black.svg" alt="Download on the App Store" height="48" /></picture></a>
   </p>
   <p>
     <a href="https://getkado.app/">getkado.app</a>


### PR DESCRIPTION
## Why?
- Previous commit swapped the badge to `https://getkado.app/...` URLs but kept the `#gh-light-mode-only` / `#gh-dark-mode-only` fragment trick — which only works for images hosted on GitHub. For external URLs, GitHub's camo image proxy drops the fragment and both variants render side by side (see screenshot in thread).

## What?
- Replaces the two-`<img>` fragment approach with a single `<picture>` element that switches variants via `prefers-color-scheme: dark`. Works from any host.

## How?
- README-only change.
- Black variant is the `<img>` fallback; white variant is the dark-mode `<source>`.

## Next steps
- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)