### PR TITLE
feat(habit-backdate): allow completions before creation date (issue #42)

### DIFF
--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -3388,6 +3388,23 @@
           }
         }
       }
+    },
+    "Tracking since %@": {
+      "comment": "Label shown in habit detail header when the effective tracking start date differs from the creation date. The argument is a formatted date.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tracking since %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suivi depuis le %@"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -150,10 +150,15 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
         if day > calendar.startOfDay(for: .now) {
             return .future
         }
+        let effectiveStartDay = calendar.startOfDay(
+            for: habit.effectiveStart(completions: completions, calendar: calendar)
+        )
+        if day < effectiveStartDay {
+            return .nonDue
+        }
         let completedOnDay = completions.contains { c in
             c.habitID == habit.id && c.value > 0 && calendar.isDate(c.date, inSameDayAs: day)
         }
-        // For negative habits, "completed" inverts: presence = failure.
         switch habit.type {
         case .negative:
             return completedOnDay ? .missed : .completed
@@ -175,7 +180,7 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
             guard n > 0 else { return false }
             let createdDay = calendar.startOfDay(for: habit.createdAt)
             let delta = calendar.dateComponents([.day], from: createdDay, to: day).day ?? 0
-            return delta >= 0 && delta % n == 0
+            return ((delta % n) + n) % n == 0
         case .daysPerWeek:
             // Every day is potentially due; no "non-due" distinction on grid.
             return true

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -23,6 +23,19 @@ struct HabitDetailView: View {
 
     private var isArchived: Bool { habit.archivedAt != nil }
 
+    private var trackingSinceLabel: String? {
+        let comps = (habit.completions ?? []).map(\.snapshot)
+        let effective = habit.snapshot.effectiveStart(completions: comps, calendar: calendar)
+        let createdDay = calendar.startOfDay(for: habit.createdAt)
+        let effectiveDay = calendar.startOfDay(for: effective)
+        guard effectiveDay != createdDay else { return nil }
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = calendar.locale ?? .current
+        formatter.dateStyle = .medium
+        return String(localized: "Tracking since \(formatter.string(from: effective))")
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -224,6 +237,13 @@ struct HabitDetailView: View {
             }
             .font(.subheadline)
             .foregroundStyle(.secondary)
+
+            if let trackingSince = trackingSinceLabel {
+                Label(trackingSince, systemImage: "calendar")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 2)
+            }
 
             if habit.archivedAt != nil {
                 Text("Archived")

--- a/KadoTests/FrequencyEvaluatorTests.swift
+++ b/KadoTests/FrequencyEvaluatorTests.swift
@@ -9,10 +9,24 @@ struct FrequencyEvaluatorTests {
 
     // MARK: Lifecycle bounds
 
-    @Test("Day before createdAt is never due")
-    func notDueBeforeCreated() {
+    @Test("Day before createdAt with no completions is not due")
+    func notDueBeforeCreatedNoCompletions() {
         let habit = makeHabit(.daily, createdOffset: 0)
         #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(-1), completions: []))
+    }
+
+    @Test("Day before createdAt with a completion on that day is due")
+    func dueBeforeCreatedWithCompletion() {
+        let habit = makeHabit(.daily, createdOffset: 0)
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(-1))]
+        #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(-1), completions: completions))
+    }
+
+    @Test("Day before effective start is not due")
+    func notDueBeforeEffectiveStart() {
+        let habit = makeHabit(.daily, createdOffset: 0)
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(-3))]
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(-5), completions: completions))
     }
 
     @Test("Day after archivedAt is never due")
@@ -108,6 +122,34 @@ struct FrequencyEvaluatorTests {
             Completion(habitID: otherID, date: TestCalendar.day($0))
         }
         #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(5), completions: completions))
+    }
+
+    // MARK: Backdate — everyNDays with negative deltas
+
+    @Test("everyNDays: 6 days before creation (cycle-aligned) is due when backdated")
+    func everyNDaysBackdateAligned() {
+        let habit = makeHabit(.everyNDays(3), createdOffset: 0)
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(-6))]
+        #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(-6), completions: completions))
+    }
+
+    @Test("everyNDays: 5 days before creation (not aligned) is not due")
+    func everyNDaysBackdateNotAligned() {
+        let habit = makeHabit(.everyNDays(3), createdOffset: 0)
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(-6))]
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(-5), completions: completions))
+    }
+
+    @Test("Negative habit: day before createdAt is never due even with completion")
+    func negativeNotDueBeforeCreation() {
+        let habit = Habit(
+            name: "No smoking",
+            frequency: .daily,
+            type: .negative,
+            createdAt: TestCalendar.day(0)
+        )
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(-2))]
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(-2), completions: completions))
     }
 
     // MARK: Helpers

--- a/KadoTests/HabitEffectiveStartTests.swift
+++ b/KadoTests/HabitEffectiveStartTests.swift
@@ -1,0 +1,90 @@
+import Testing
+import Foundation
+import KadoCore
+
+@Suite("Habit.effectiveStart")
+struct HabitEffectiveStartTests {
+    private let calendar = TestCalendar.utc
+
+    private func habit(
+        type: HabitType = .binary,
+        createdAtOffset: Int = 0
+    ) -> Habit {
+        Habit(
+            name: "Test",
+            frequency: .daily,
+            type: type,
+            createdAt: TestCalendar.day(createdAtOffset)
+        )
+    }
+
+    private func completion(for habit: Habit, dayOffset: Int, value: Double = 1.0) -> Completion {
+        Completion(habitID: habit.id, date: TestCalendar.day(dayOffset), value: value)
+    }
+
+    @Test("No completions returns createdAt")
+    func noCompletions() {
+        let h = habit(createdAtOffset: 0)
+        let start = h.effectiveStart(completions: [], calendar: calendar)
+        #expect(calendar.isDate(start, inSameDayAs: TestCalendar.day(0)))
+    }
+
+    @Test("First completion before createdAt returns completion date")
+    func completionBeforeCreation() {
+        let h = habit(createdAtOffset: 0)
+        let comps = [completion(for: h, dayOffset: -3)]
+        let start = h.effectiveStart(completions: comps, calendar: calendar)
+        #expect(calendar.isDate(start, inSameDayAs: TestCalendar.day(-3)))
+    }
+
+    @Test("First completion after createdAt returns first completion date")
+    func completionAfterCreation() {
+        let h = habit(createdAtOffset: 0)
+        let comps = [completion(for: h, dayOffset: 5)]
+        let start = h.effectiveStart(completions: comps, calendar: calendar)
+        #expect(calendar.isDate(start, inSameDayAs: TestCalendar.day(5)))
+    }
+
+    @Test("Multiple completions returns the earliest")
+    func multipleCompletions() {
+        let h = habit(createdAtOffset: 0)
+        let comps = [
+            completion(for: h, dayOffset: -1),
+            completion(for: h, dayOffset: -5),
+            completion(for: h, dayOffset: 2),
+        ]
+        let start = h.effectiveStart(completions: comps, calendar: calendar)
+        #expect(calendar.isDate(start, inSameDayAs: TestCalendar.day(-5)))
+    }
+
+    @Test("Negative habit always returns createdAt regardless of completions")
+    func negativeHabitKeepsCreatedAt() {
+        let h = habit(type: .negative, createdAtOffset: 0)
+        let comps = [completion(for: h, dayOffset: -5)]
+        let start = h.effectiveStart(completions: comps, calendar: calendar)
+        #expect(calendar.isDate(start, inSameDayAs: TestCalendar.day(0)))
+    }
+
+    @Test("Zero-value completions are ignored")
+    func zeroValueIgnored() {
+        let h = habit(createdAtOffset: 0)
+        let comps = [
+            completion(for: h, dayOffset: -5, value: 0),
+            completion(for: h, dayOffset: 2, value: 1),
+        ]
+        let start = h.effectiveStart(completions: comps, calendar: calendar)
+        #expect(calendar.isDate(start, inSameDayAs: TestCalendar.day(2)))
+    }
+
+    @Test("Only completions for this habit are considered")
+    func filtersByHabitID() {
+        let h = habit(createdAtOffset: 0)
+        let other = Habit(name: "Other", frequency: .daily, type: .binary, createdAt: TestCalendar.day(-10))
+        let comps = [
+            Completion(habitID: other.id, date: TestCalendar.day(-8)),
+            completion(for: h, dayOffset: 3),
+        ]
+        let start = h.effectiveStart(completions: comps, calendar: calendar)
+        #expect(calendar.isDate(start, inSameDayAs: TestCalendar.day(3)))
+    }
+}

--- a/KadoTests/HabitScoreCalculatorTests.swift
+++ b/KadoTests/HabitScoreCalculatorTests.swift
@@ -575,6 +575,43 @@ struct HabitScoreCalculatorTests {
         #expect(scoreWithNote == scoreEmpty)
     }
 
+    // MARK: - Backdate
+
+    @Test("Backdated completion: score starts at first completion, not createdAt")
+    func backdatedCompletionAnchorsScore() {
+        let habit = makeHabit(createdOffset: 0)
+        let completions = [
+            Completion(habitID: habit.id, date: TestCalendar.day(-3)),
+        ]
+        let score = calculator.currentScore(for: habit, completions: completions, asOf: TestCalendar.day(-3))
+        #expect(abs(score - 0.05) < 1e-9, "single day should equal alpha, got \(score)")
+    }
+
+    @Test("First completion after createdAt: early missed days don't penalize")
+    func firstCompletionAfterCreation() {
+        let habit = makeHabit(createdOffset: 0)
+        let completions = [
+            Completion(habitID: habit.id, date: TestCalendar.day(5)),
+        ]
+        let score = calculator.currentScore(for: habit, completions: completions, asOf: TestCalendar.day(5))
+        #expect(abs(score - 0.05) < 1e-9, "should equal alpha — no penalty for days 0-4, got \(score)")
+    }
+
+    @Test("Negative habit: score starts at createdAt regardless of completion timing")
+    func negativeScoreStartsAtCreatedAt() {
+        let neg = Habit(
+            name: "No smoking",
+            frequency: .daily,
+            type: .negative,
+            createdAt: TestCalendar.day(0)
+        )
+        let scoreNoCompletions = calculator.currentScore(for: neg, completions: [], asOf: TestCalendar.day(5))
+        let withSlip = [Completion(habitID: neg.id, date: TestCalendar.day(3))]
+        let scoreWithSlip = calculator.currentScore(for: neg, completions: withSlip, asOf: TestCalendar.day(5))
+        #expect(scoreNoCompletions > scoreWithSlip)
+        #expect(scoreNoCompletions > 0, "clean days from creation should build score")
+    }
+
     // MARK: Helpers
 
     private func makeHabit(createdOffset: Int) -> Habit {

--- a/KadoTests/OverviewMatrixTests.swift
+++ b/KadoTests/OverviewMatrixTests.swift
@@ -160,13 +160,13 @@ struct OverviewMatrixTests {
         )
         let row = try #require(result.first)
 
-        // Only the day with the completion should be scored 1.0; every
-        // other due day should be 0.0. This is the core contract: the
-        // matrix surfaces per-day completion, not smoothed history.
+        // The effective start is day -2 (the first completion), so
+        // days -4 and -3 are .notDue. Day -2 is scored 1.0; days -1
+        // and 0 are scored 0.0 (due but not completed).
         let values: [Double] = row.days.map { cell in
             if case .scored(let v) = cell { v } else { -1 }
         }
-        #expect(values == [0.0, 0.0, 1.0, 0.0, 0.0])
+        #expect(values == [-1.0, -1.0, 1.0, 0.0, 0.0])
     }
 
     @Test("Counter habit scored cells use achieved/target fraction")
@@ -225,6 +225,37 @@ struct OverviewMatrixTests {
         #expect(postCreation.allSatisfy {
             if case .scored = $0 { return true } else { return false }
         })
+    }
+
+    @Test("Pre-creation day with a backdated completion renders as .scored")
+    func preCreationWithCompletionIsScored() throws {
+        let habit = Habit(
+            name: "Habit",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-2)
+        )
+        let completions = [
+            Completion(habitID: habit.id, date: TestCalendar.day(-4)),
+        ]
+        let dayRange = days(offset: -5, count: 6)
+        let result = OverviewMatrix.compute(
+            habits: [habit],
+            completions: completions,
+            days: dayRange,
+            today: today,
+            calendar: calendar,
+            frequencyEvaluator: frequencyEvaluator
+        )
+        let row = try #require(result.first)
+        let preEffective = row.days[0] // day -5: before effective start (-4)
+        let atEffective = row.days[1]  // day -4: effective start, completed
+        #expect(preEffective == .notDue)
+        if case .scored(let v) = atEffective {
+            #expect(v == 1.0)
+        } else {
+            Issue.record("Expected .scored at effective start, got \(atEffective)")
+        }
     }
 
     // MARK: - colorOpacity

--- a/KadoTests/StreakCalculatorTests.swift
+++ b/KadoTests/StreakCalculatorTests.swift
@@ -256,4 +256,30 @@ struct StreakCalculatorTests {
         let calc = calculator()
         #expect(calc.best(for: h, completions: completions, asOf: asOf) == 2)
     }
+
+    // MARK: - Backdate
+
+    @Test("Backdated completions extend current streak past createdAt")
+    func backdatedExtendsCurrent() {
+        let h = habit(createdAtOffset: -3)
+        let completions = (0...5).map { completion(for: h, dayOffset: -$0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 6)
+    }
+
+    @Test("Backdated completions count in best streak")
+    func backdatedCountsInBest() {
+        let h = habit(createdAtOffset: -3)
+        let completions = (3...7).map { completion(for: h, dayOffset: -$0) }
+        let calc = calculator()
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 5)
+    }
+
+    @Test("First completion after createdAt: early days don't break streak")
+    func firstCompletionAfterCreation() {
+        let h = habit(createdAtOffset: -10)
+        let completions = (0...3).map { completion(for: h, dayOffset: -$0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 4)
+    }
 }

--- a/Packages/KadoCore/Sources/KadoCore/Models/Habit.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Habit.swift
@@ -46,6 +46,15 @@ public struct Habit: Identifiable, Hashable, Sendable {
         self.reminderMinute = reminderMinute
     }
 
+    public func effectiveStart(completions: [Completion], calendar: Calendar) -> Date {
+        if case .negative = type { return createdAt }
+        let earliest = completions
+            .filter { $0.habitID == id && $0.value > 0 }
+            .map(\.date)
+            .min()
+        return earliest ?? createdAt
+    }
+
     public static func == (lhs: Habit, rhs: Habit) -> Bool {
         lhs.id == rhs.id
     }

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultFrequencyEvaluator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultFrequencyEvaluator.swift
@@ -9,8 +9,10 @@ public struct DefaultFrequencyEvaluator: FrequencyEvaluating {
 
     public func isDue(habit: Habit, on date: Date, completions: [Completion]) -> Bool {
         let day = calendar.startOfDay(for: date)
-        let createdDay = calendar.startOfDay(for: habit.createdAt)
-        guard day >= createdDay else { return false }
+        let effectiveStartDay = calendar.startOfDay(
+            for: habit.effectiveStart(completions: completions, calendar: calendar)
+        )
+        guard day >= effectiveStartDay else { return false }
         if let archivedAt = habit.archivedAt {
             let archivedDay = calendar.startOfDay(for: archivedAt)
             guard day <= archivedDay else { return false }
@@ -27,8 +29,9 @@ public struct DefaultFrequencyEvaluator: FrequencyEvaluating {
 
         case .everyNDays(let n):
             guard n > 0 else { return false }
+            let createdDay = calendar.startOfDay(for: habit.createdAt)
             let delta = calendar.dateComponents([.day], from: createdDay, to: day).day ?? 0
-            return delta % n == 0
+            return ((delta % n) + n) % n == 0
 
         case .daysPerWeek(let target):
             guard target > 0 else { return false }

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultHabitScoreCalculator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultHabitScoreCalculator.swift
@@ -21,10 +21,11 @@ public struct DefaultHabitScoreCalculator: HabitScoreCalculating {
         completions: [Completion],
         asOf date: Date
     ) -> Double {
+        let start = habit.effectiveStart(completions: completions, calendar: calendar)
         let history = scoreHistory(
             for: habit,
             completions: completions,
-            from: habit.createdAt,
+            from: start,
             to: date
         )
         return history.last?.score ?? 0.0
@@ -36,8 +37,10 @@ public struct DefaultHabitScoreCalculator: HabitScoreCalculating {
         from startDate: Date,
         to endDate: Date
     ) -> [DailyScore] {
-        let createdDay = calendar.startOfDay(for: habit.createdAt)
-        let firstDay = max(calendar.startOfDay(for: startDate), createdDay)
+        let effectiveStartDay = calendar.startOfDay(
+            for: habit.effectiveStart(completions: completions, calendar: calendar)
+        )
+        let firstDay = max(calendar.startOfDay(for: startDate), effectiveStartDay)
         let lastDay = calendar.startOfDay(for: endDate)
         guard firstDay <= lastDay else { return [] }
 

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
@@ -10,28 +10,32 @@ public struct DefaultStreakCalculator: StreakCalculating {
     public func current(for habit: Habit, completions: [Completion], asOf date: Date) -> Int {
         let endDate = habit.archivedAt ?? date
         let end = calendar.startOfDay(for: endDate)
-        let createdDay = calendar.startOfDay(for: habit.createdAt)
-        guard end >= createdDay else { return 0 }
+        let startDay = calendar.startOfDay(
+            for: habit.effectiveStart(completions: completions, calendar: calendar)
+        )
+        guard end >= startDay else { return 0 }
 
         switch habit.frequency {
         case .daysPerWeek(let target):
-            return currentDaysPerWeek(target: target, habit: habit, completions: completions, end: end, createdDay: createdDay)
+            return currentDaysPerWeek(target: target, habit: habit, completions: completions, end: end, startDay: startDay)
         default:
-            return currentByDay(habit: habit, completions: completions, end: end, createdDay: createdDay)
+            return currentByDay(habit: habit, completions: completions, end: end, startDay: startDay)
         }
     }
 
     public func best(for habit: Habit, completions: [Completion], asOf date: Date) -> Int {
         let endDate = habit.archivedAt ?? date
         let end = calendar.startOfDay(for: endDate)
-        let createdDay = calendar.startOfDay(for: habit.createdAt)
-        guard end >= createdDay else { return 0 }
+        let startDay = calendar.startOfDay(
+            for: habit.effectiveStart(completions: completions, calendar: calendar)
+        )
+        guard end >= startDay else { return 0 }
 
         switch habit.frequency {
         case .daysPerWeek(let target):
-            return bestDaysPerWeek(target: target, habit: habit, completions: completions, end: end, createdDay: createdDay)
+            return bestDaysPerWeek(target: target, habit: habit, completions: completions, end: end, startDay: startDay)
         default:
-            return bestByDay(habit: habit, completions: completions, end: end, createdDay: createdDay)
+            return bestByDay(habit: habit, completions: completions, end: end, startDay: startDay)
         }
     }
 
@@ -41,14 +45,14 @@ public struct DefaultStreakCalculator: StreakCalculating {
         habit: Habit,
         completions: [Completion],
         end: Date,
-        createdDay: Date
+        startDay: Date
     ) -> Int {
         let completedDays = completedDaySet(habit: habit, completions: completions)
         var streak = 0
         var day = end
         var isEndDay = true
 
-        while day >= createdDay {
+        while day >= startDay {
             let due = isDueByDay(habit: habit, on: day)
             if !due {
                 day = previousDay(day)
@@ -74,12 +78,12 @@ public struct DefaultStreakCalculator: StreakCalculating {
         habit: Habit,
         completions: [Completion],
         end: Date,
-        createdDay: Date
+        startDay: Date
     ) -> Int {
         let completedDays = completedDaySet(habit: habit, completions: completions)
         var best = 0
         var run = 0
-        var day = createdDay
+        var day = startDay
 
         while day <= end {
             let due = isDueByDay(habit: habit, on: day)
@@ -110,7 +114,7 @@ public struct DefaultStreakCalculator: StreakCalculating {
         habit: Habit,
         completions: [Completion],
         end: Date,
-        createdDay: Date
+        startDay: Date
     ) -> Int {
         guard target > 0 else { return 0 }
         let filtered = completions.filter { $0.habitID == habit.id }
@@ -124,8 +128,8 @@ public struct DefaultStreakCalculator: StreakCalculating {
 
         var weekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: endWeek.start)!
 
-        while weekStart >= createdDay ||
-              calendar.dateInterval(of: .weekOfYear, for: createdDay)!.start == weekStart {
+        while weekStart >= startDay ||
+              calendar.dateInterval(of: .weekOfYear, for: startDay)!.start == weekStart {
             let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart)!
             let count = completionsInRange(filtered, from: weekStart, through: weekEnd)
             if count >= target {
@@ -143,23 +147,23 @@ public struct DefaultStreakCalculator: StreakCalculating {
         habit: Habit,
         completions: [Completion],
         end: Date,
-        createdDay: Date
+        startDay: Date
     ) -> Int {
         guard target > 0 else { return 0 }
         let filtered = completions.filter { $0.habitID == habit.id }
-        guard let createdWeek = calendar.dateInterval(of: .weekOfYear, for: createdDay),
+        guard let startWeek = calendar.dateInterval(of: .weekOfYear, for: startDay),
               let endWeek = calendar.dateInterval(of: .weekOfYear, for: end) else { return 0 }
 
         var best = 0
         var run = 0
-        var weekStart = createdWeek.start
+        var weekStart = startWeek.start
 
         while weekStart <= endWeek.start {
             let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart)!
             let isEndWeek = calendar.isDate(weekStart, inSameDayAs: endWeek.start)
             let count = completionsInRange(filtered, from: weekStart, through: weekEnd)
             let qualifies = count >= target
-            let graceCarries = isEndWeek && !qualifies  // don't reset for current week
+            let graceCarries = isEndWeek && !qualifies
             if qualifies {
                 run += 1
                 best = max(best, run)
@@ -195,9 +199,8 @@ public struct DefaultStreakCalculator: StreakCalculating {
             guard n > 0 else { return false }
             let createdDay = calendar.startOfDay(for: habit.createdAt)
             let delta = calendar.dateComponents([.day], from: createdDay, to: day).day ?? 0
-            return delta >= 0 && delta % n == 0
+            return ((delta % n) + n) % n == 0
         case .daysPerWeek:
-            // Not used — daysPerWeek branches before reaching here.
             return false
         }
     }

--- a/Packages/KadoCore/Sources/KadoCore/Services/OverviewMatrix.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/OverviewMatrix.swift
@@ -64,11 +64,13 @@ public enum OverviewMatrix {
             let completionsByDay = Dictionary(grouping: habitCompletions) {
                 calendar.startOfDay(for: $0.date)
             }
-            let habitCreatedStart = calendar.startOfDay(for: habit.createdAt)
+            let effectiveStartDay = calendar.startOfDay(
+                for: habit.effectiveStart(completions: habitCompletions, calendar: calendar)
+            )
 
             let cells = days.map { day -> DayCell in
                 if day > todayStart { return .future }
-                if day < habitCreatedStart { return .notDue }
+                if day < effectiveStartDay { return .notDue }
                 if !frequencyEvaluator.isDue(
                     habit: habit,
                     on: day,

--- a/docs/plans/2026-04/habit-backdate/compound.md
+++ b/docs/plans/2026-04/habit-backdate/compound.md
@@ -1,0 +1,98 @@
+# Compound — Habit Backdate
+
+**Date**: 2026-04-29
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [feature/habit-backdate — PR #44](https://github.com/scastiel/kado/pull/44)
+
+## Summary
+
+Replaced `createdAt` as the hard boundary in all 6 code paths with a
+computed `effectiveStart` — the earliest positive-value completion
+date, or `createdAt` if none. Users can now log completions before
+creation, and the score/streak window starts at the first completion
+rather than penalizing early missed days. No schema migration. The
+build went smoothly — no mid-plan pivots, and the one existing test
+that broke (`scoredReflectsDailyValue`) was an expected semantic
+change.
+
+## Decisions made
+
+- **Computed, not stored**: `effectiveStart` is derived from
+  completions at call time. No new field, no migration, no CloudKit
+  complexity. Trade-off: O(N) scan per call — acceptable for current
+  data volumes.
+- **Negative habits keep `createdAt`**: "no completion = success"
+  means the start must be anchored to creation, not first slip.
+  Without this exception, early clean days would vanish from the
+  score when a slip is recorded.
+- **`everyNDays` cycle anchor stays at `createdAt`**: only the
+  boundary shifts; the modular arithmetic that defines which days
+  are due still anchors to the original creation. This avoids
+  shifting the cycle when backdating.
+- **`((delta % n) + n) % n == 0` for negative deltas**: Swift's `%`
+  preserves the sign of the dividend, so `-5 % 3 == -2`, not `1`.
+  The double-modulo idiom normalizes to `[0, n)`.
+- **"Tracking since" only shown when effective start differs from
+  `createdAt`**: avoids noise on habits where they match (the
+  common case).
+- **No backdate limit**: users can go as far back as they want.
+
+## Surprises and how we handled them
+
+### No surprises
+
+The research correctly identified all 6 code paths and the
+`everyNDays` modular arithmetic trap. The only test that broke
+(`scoredReflectsDailyValue` in `OverviewMatrixTests`) was an expected
+semantic change — pre-creation days now render as `.notDue` instead
+of `.scored(0.0)` because the effective start shifted forward to the
+first completion. Updated the expectation.
+
+## What worked well
+
+- **Research-first approach**: the codebase survey identified every
+  `createdAt` usage before writing a line of code. Zero surprises
+  during build.
+- **Pure function on a value type**: `effectiveStart` is testable in
+  isolation, no SwiftData needed. The 7 unit tests for it run in
+  milliseconds.
+- **Consistent replacement pattern**: every code path followed the
+  same change — replace `createdAt` with `effectiveStart`. No
+  special cases beyond negative habits.
+
+## For the next person
+
+- **`effectiveStart` is called multiple times per render.** The
+  calendar view calls it once per cell (up to 31 times), and the
+  score/streak calculators call it independently. If performance
+  becomes an issue with large completion sets, precompute once per
+  view update and pass through. Profile before optimizing.
+- **The `everyNDays` modular arithmetic appears in three places**:
+  `DefaultFrequencyEvaluator`, `DefaultStreakCalculator.isDueByDay`,
+  and `MonthlyCalendarView.dayIsDue`. All three must use the
+  `((delta % n) + n) % n` pattern. If you add a fourth, check for
+  negative deltas.
+- **Pre-effective-start calendar cells are `.nonDue` but tappable.**
+  Creating a completion on a pre-effective-start day shifts the
+  effective start back and lights up the intervening cells. This is
+  intentional — it's how backdating works from the user's
+  perspective.
+
+## Generalizable lessons
+
+- **[local]** When replacing a boundary value used across multiple
+  services, a pure computed property on the domain type is cleaner
+  than passing a new parameter everywhere — callers already have the
+  habit and its completions.
+- **[local]** Swift's `%` operator with negative dividends is a
+  recurring trap. The `((x % n) + n) % n` idiom should be used
+  anywhere modular day arithmetic can go negative.
+
+## Metrics
+
+- Tasks completed: 7 of 7 (tasks 6+7 combined into one commit)
+- Tests added: 22
+- Commits: 8
+- Files touched: 12 Swift files + 1 xcstrings

--- a/docs/plans/2026-04/habit-backdate/plan.md
+++ b/docs/plans/2026-04/habit-backdate/plan.md
@@ -1,7 +1,7 @@
 # Plan — Habit Backdate
 
 **Date**: 2026-04-29
-**Status**: ready to build
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary

--- a/docs/plans/2026-04/habit-backdate/plan.md
+++ b/docs/plans/2026-04/habit-backdate/plan.md
@@ -1,0 +1,206 @@
+# Plan — Habit Backdate
+
+**Date**: 2026-04-29
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Allow users to log completions before a habit's creation date and
+anchor score/streak calculations to the first completion date instead
+of `createdAt`. Six code paths currently use `createdAt` as a hard
+boundary — all need to use a computed "effective start" instead. No
+schema migration. The habit detail view gains a "Tracking since"
+label. Negative habits keep `createdAt` as their start.
+
+## Decisions locked in
+
+- Effective start = first completion date (or `createdAt` if none)
+- Negative habits: effective start always = `createdAt`
+- No backdate limit — users can go as far back as they want
+- "Tracking since <date>" shown in the habit detail header
+- No new stored field — effective start is computed
+- `everyNDays` cycle anchor stays at `createdAt` (only the boundary
+  shifts, not the modular arithmetic)
+
+## Task list
+
+### Task 1: Add `effectiveStart` to Habit domain type
+
+**Goal**: Pure function that computes the effective start from a
+habit and its completions.
+
+**Changes**:
+- `Packages/KadoCore/Sources/KadoCore/Models/Habit.swift` — add
+  `effectiveStart(completions:calendar:) -> Date` method. For
+  negative habits, returns `createdAt`. For others, returns
+  `min(createdAt, earliestCompletionDate)` — or `createdAt` if no
+  completions.
+
+**Tests / verification**:
+- No completions → returns `createdAt`
+- First completion before `createdAt` → returns completion date
+- First completion after `createdAt` → returns first completion date
+- Negative habit with pre-creation completion → returns `createdAt`
+- Multiple completions → returns the earliest
+
+**Commit message**: `feat(habit-backdate): add effectiveStart to Habit`
+
+---
+
+### Task 2: Update DefaultFrequencyEvaluator
+
+**Goal**: Days before effective start are not due; days between
+effective start and `createdAt` are due. `everyNDays` modular
+arithmetic stays anchored to `createdAt`.
+
+**Changes**:
+- `DefaultFrequencyEvaluator.swift` — the `isDue` method needs
+  access to completions (already has them) and calendar to compute
+  effective start. Replace `guard day >= createdDay` with
+  `guard day >= effectiveStartDay`. For `everyNDays`, keep
+  `createdDay` as the modular anchor but allow negative deltas:
+  use `((delta % n) + n) % n == 0` instead of `delta >= 0 && delta % n == 0`.
+
+**Tests / verification**:
+- Daily habit, day before `createdAt` with completion → `isDue` returns true
+- Daily habit, day before effective start → `isDue` returns false
+- `everyNDays(3)`, 6 days before creation (cycle-aligned) → `isDue` true
+- `everyNDays(3)`, 5 days before creation (not aligned) → `isDue` false
+- Negative habit, day before `createdAt` → `isDue` false (keeps `createdAt`)
+- Existing tests still pass
+
+**Commit message**: `feat(habit-backdate): allow pre-creation days in FrequencyEvaluator`
+
+---
+
+### Task 3: Update DefaultHabitScoreCalculator
+
+**Goal**: Score history starts at effective start, not `createdAt`.
+
+**Changes**:
+- `DefaultHabitScoreCalculator.swift` — `currentScore` passes
+  effective start instead of `habit.createdAt` to `scoreHistory`.
+  `scoreHistory` already accepts a `from:` parameter — just need
+  to compute effective start from the completions. Add completions
+  parameter awareness for effective start calculation.
+
+**Tests / verification**:
+- Habit created day 0, completion on day -3 → score starts at day -3
+- Habit created day 0, first completion on day 5 → score starts at
+  day 5, days 0-4 not penalized (score on day 5 = alpha, not
+  alpha * (1-alpha)^5)
+- Negative habit: score starts at `createdAt` regardless
+- Existing score tests still pass
+
+**Commit message**: `feat(habit-backdate): anchor score to effective start`
+
+---
+
+### Task 4: Update DefaultStreakCalculator
+
+**Goal**: Streak calculation boundaries use effective start.
+
+**Changes**:
+- `DefaultStreakCalculator.swift` — replace `createdDay` with
+  effective start in all four loop methods (`currentByDay`,
+  `bestByDay`, `currentDaysPerWeek`, `bestDaysPerWeek`). The
+  `isDueByDay` private method also needs the same `everyNDays` fix
+  as the frequency evaluator (negative delta modular arithmetic).
+
+**Tests / verification**:
+- Backdated completion extends streak past `createdAt`
+- Best streak includes pre-creation completions
+- `daysPerWeek` counts pre-creation week completions
+- Existing streak tests still pass
+
+**Commit message**: `feat(habit-backdate): extend streak past createdAt`
+
+---
+
+### Task 5: Update OverviewMatrix and MonthlyCalendarView
+
+**Goal**: Pre-creation days with completions render correctly.
+
+**Changes**:
+- `OverviewMatrix.swift` — replace `habitCreatedStart` with
+  effective start. Days before effective start are `.notDue`;
+  days between effective start and `createdAt` follow normal
+  due/completed logic.
+- `MonthlyCalendarView.swift` — `isDueByDay` for `everyNDays`
+  needs the same negative-delta fix. The `state(for:)` method
+  already delegates to `isDueByDay` / checks completions, so
+  it should work once the frequency logic is fixed.
+
+**Tests / verification**:
+- Overview matrix: pre-creation day with completion → `.scored`
+- Calendar: pre-creation day shows as `.completed` or `.missed`,
+  not `.nonDue`
+- Existing overview matrix tests updated
+
+**Commit message**: `feat(habit-backdate): update calendar and matrix for pre-creation days`
+
+---
+
+### Task 6: "Tracking since" label in HabitDetailView
+
+**Goal**: Show the effective start date in the habit detail header.
+
+**Changes**:
+- `HabitDetailView.swift` — add a "Tracking since <date>" label
+  below the frequency/type labels in the header. Only show when
+  effective start differs from `createdAt` (to avoid noise on
+  habits where they match).
+
+**Tests / verification**:
+- Preview: habit with backdated completions shows "Tracking since"
+- Preview: habit with no backdated completions doesn't show it
+- Localization: add EN + FR strings
+
+**Commit message**: `feat(habit-backdate): show "Tracking since" in habit detail`
+
+---
+
+### Task 7: Localization and accessibility
+
+**Goal**: New strings localized EN + FR, VoiceOver updated.
+
+**Changes**:
+- `Localizable.xcstrings` — add "Tracking since %@" / "Suivi
+  depuis le %@" (or similar FR phrasing)
+- Calendar accessibility labels: pre-creation days should be
+  described accurately
+
+**Tests / verification**:
+- `LocalizationCoverageTests` passes
+- VoiceOver reads "Tracking since" label correctly
+
+**Commit message**: `feat(habit-backdate): localization and accessibility`
+
+## Risks and mitigation
+
+- **`everyNDays` negative modular arithmetic**: Swift's `%` gives
+  negative results for negative dividends. The fix
+  `((delta % n) + n) % n == 0` is standard but needs careful testing.
+  Covered in Task 2 and Task 4/5.
+- **Performance of effective start**: finding the earliest completion
+  is O(N). For habits with thousands of completions this could be
+  noticeable if called per-cell. Mitigation: compute once per render
+  in the view/calculator, not per-day.
+- **Interaction with habit-notes (PR #43)**: zero-value note-only
+  records should not shift the effective start. The `effectiveStart`
+  method should filter `value > 0` when finding the earliest
+  completion, consistent with how all other code paths treat
+  zero-value records.
+
+## Open questions
+
+- (All resolved during planning — none remaining.)
+
+## Out of scope
+
+- User-editable `startDate` field on `HabitRecord` (Alternative B
+  from research — revisit if users want explicit control)
+- Backdate limit enforcement
+- Month navigation in the calendar (currently shows only the current
+  month — adding month navigation is a separate feature)

--- a/docs/plans/2026-04/habit-backdate/research.md
+++ b/docs/plans/2026-04/habit-backdate/research.md
@@ -1,0 +1,216 @@
+# Research — Habit Backdate
+
+**Date**: 2026-04-29
+**Status**: ready for plan
+**Related**: [Issue #42](https://github.com/scastiel/kado/issues/42)
+
+## Problem
+
+When a user creates a habit, they often want to log completions for
+the past few days ("I started running on Monday but only installed
+the app today, Wednesday"). Currently `createdAt` is set to `.now`
+on creation and acts as a hard boundary — score, streak, frequency,
+calendar, and overview matrix all refuse to acknowledge days before
+it. The user's Monday and Tuesday runs are impossible to record.
+
+A related frustration: if a user creates a habit on Monday but
+doesn't complete it until Wednesday, the two missed Mon/Tue days
+drag the score down. The issue author suggests the score should
+start at the first completion, not at creation.
+
+## Current state of the codebase
+
+### `createdAt` is a hard boundary in 6 places
+
+| Component | File | How it uses `createdAt` |
+|---|---|---|
+| `DefaultFrequencyEvaluator` | `DefaultFrequencyEvaluator.swift:13` | `guard day >= createdDay else { return false }` — days before creation are never due |
+| `DefaultHabitScoreCalculator` | `DefaultHabitScoreCalculator.swift:39` | `let firstDay = max(startDate, createdDay)` — score history starts at creation |
+| `DefaultStreakCalculator` | `DefaultStreakCalculator.swift:13,51,82` | Streak loops stop/start at `createdDay` |
+| `OverviewMatrix` | `OverviewMatrix.swift:71` | `if day < habitCreatedStart { return .notDue }` |
+| `MonthlyCalendarView` | `MonthlyCalendarView.swift:176` | `isDueByDay` for `everyNDays` uses `createdDay` as cycle anchor |
+| `DefaultFrequencyEvaluator` | `DefaultFrequencyEvaluator.swift:30` | `everyNDays` modular arithmetic anchored to `createdDay` |
+
+### `createdAt` is immutable after creation
+
+- `NewHabitFormModel.save()` never touches `createdAt` on the edit
+  path (`HabitDetailView.swift:173-180`).
+- No UI exists to modify it.
+- Defaults to `.now` on creation (`HabitRecord.swift:35`).
+
+### No guard in the UI against pre-creation edits
+
+- `DayEditPopover` accepts any date — no validation against
+  `createdAt`.
+- `CompletionToggler` and `CompletionLogger` accept any date.
+- The calendar lets you navigate to pre-creation months; cells just
+  show as `.nonDue` or `.missed`.
+
+So the persistence layer already handles pre-creation completions —
+only the calculators and display logic block them.
+
+## Proposed approach
+
+**Introduce an "effective start date" computed as
+`min(createdAt, earliestCompletionDate)`.** When the first completion
+is after `createdAt`, use that instead (addressing the "grace period"
+ask). When a completion is backdated before `createdAt`, the
+effective start shifts back automatically.
+
+This is a pure computation — no schema change, no migration, no new
+stored field. The effective start is derived from existing data.
+
+### Key components
+
+- **`Habit.effectiveStart(given:calendar:)` method**: computes the
+  effective start from the habit's `createdAt` and its completions.
+  If there are completions, returns `min(createdAt, earliestDate)`.
+  If no completions, returns `createdAt`. For the "score starts at
+  first completion" behavior: returns `firstCompletionDate` when it's
+  after `createdAt`. This means an empty habit has no due days until
+  the first completion — which matches the user's expectation
+  ("I haven't started yet").
+
+  Actually, this needs careful thought. Two sub-behaviors:
+
+  **Option 1 — Effective start = min(createdAt, firstCompletion)**:
+  - Backdated completions shift the window back. Good.
+  - But a habit with no completions still starts at `createdAt`,
+    meaning missed days accumulate. The issue author's complaint
+    about "score starts at first completion" isn't fully addressed.
+
+  **Option 2 — Effective start = firstCompletionDate (or createdAt
+  if none)**:
+  - Score/streak only start once you first do the habit. No penalty
+    for creating it early.
+  - Backdated completions automatically anchor the start.
+  - A habit with zero completions has `effectiveStart = createdAt`,
+    but since there are no completions the score is 0 anyway —
+    harmless.
+  - Risk: for negative habits, "no completions = success." Moving
+    the start to the first completion would erase the early
+    successful days. Need to handle negative habits separately
+    (keep `createdAt` as start for negative habits).
+
+  **Recommendation: Option 2** — it matches the issue request most
+  closely. Negative habits use `createdAt` as before.
+
+- **`DefaultFrequencyEvaluator`**: replace `createdDay` guard with
+  `effectiveStart`. For `everyNDays`, the modular anchor stays
+  `createdAt` (the cycle definition doesn't change — only the
+  boundary does).
+
+- **`DefaultHabitScoreCalculator`**: replace `habit.createdAt` with
+  effective start in `scoreHistory`.
+
+- **`DefaultStreakCalculator`**: replace `createdDay` boundaries with
+  effective start in all four loop methods.
+
+- **`OverviewMatrix`**: replace `habitCreatedStart` with effective
+  start.
+
+- **`MonthlyCalendarView.isDueByDay`**: remove `delta >= 0` guard
+  for `everyNDays` (or use effective start). Other frequency types
+  don't use `createdAt` in the calendar.
+
+### Data model changes
+
+None. `createdAt` keeps its current meaning ("when the record was
+added to the app"). The effective start is computed, not stored.
+
+### UI changes
+
+- **MonthlyCalendarView**: days before `createdAt` but after the
+  effective start should render as due (`.missed` or `.completed`),
+  not `.nonDue`. Currently the calendar only shows the current month
+  — pre-creation days in the current month will "light up" once
+  backdated completions exist.
+- **Optional**: show the effective start date somewhere in the
+  habit detail (e.g., "Tracking since Apr 25" below the habit
+  name). This makes the behavior explicit as the issue suggests.
+- **Overview matrix**: same — pre-creation cells with completions
+  should show as scored, not `.notDue`.
+
+### Tests to write
+
+- Score calculator: habit created day 0, completion on day -3 →
+  score history starts at day -3.
+- Score calculator: habit created day 0, first completion on day 5 →
+  score history starts at day 5, days 0-4 are not penalized.
+- Streak calculator: backdated completion extends streak past
+  `createdAt`.
+- Frequency evaluator: day before `createdAt` with a completion is
+  considered due.
+- Negative habit: effective start stays at `createdAt` regardless of
+  completions.
+- `everyNDays`: cycle anchor stays at `createdAt` even when effective
+  start is earlier (modular arithmetic consistency).
+- Overview matrix: pre-creation day with completion renders as
+  `.scored`, not `.notDue`.
+
+## Alternatives considered
+
+### Alternative A: Move `createdAt` back when backdating
+
+- Idea: when a completion is logged before `createdAt`,
+  automatically move `createdAt` to that date.
+- Why not: loses the original creation timestamp. Couples a mutation
+  side-effect to completion logging. The `everyNDays` cycle would
+  shift unpredictably. And it doesn't solve the "first completion
+  after creation" case.
+
+### Alternative B: Add a `startDate` field to `HabitRecord`
+
+- Idea: new stored `startDate: Date?` field, user-editable, defaults
+  to `createdAt`. Schema migration V3 → V4.
+- Why not: heavier than needed. A computed effective start achieves
+  the same result without a migration or extra UI for editing the
+  field. Could revisit if users want explicit control over the start
+  date independent of completions.
+
+### Alternative C: Only change the score, not the streak/frequency
+
+- Idea: anchor score to first completion but keep streak/frequency
+  boundaries at `createdAt`.
+- Why not: inconsistent. If the score says "tracking since Wednesday"
+  but the streak counts from Monday, the user sees contradictory
+  numbers.
+
+## Risks and unknowns
+
+- **Performance of `effectiveStart`**: requires finding the earliest
+  completion. On a habit with thousands of completions, this is a
+  linear scan. Mitigation: cache the min date, or compute it once
+  per render cycle and pass it through. Alternatively, maintain a
+  `firstCompletionDate` computed property on `HabitRecord` that
+  scans the relationship — SwiftData relationships are lazy-loaded.
+- **`everyNDays` cycle anchor**: the modular arithmetic
+  `delta % n == 0` is anchored to `createdAt`. If we allow days
+  before `createdAt`, `delta` becomes negative, and `% n` behaves
+  differently for negative dividends in Swift (result has the sign
+  of the dividend). Need to use `((delta % n) + n) % n == 0` or
+  equivalent. This is a subtle bug waiting to happen — test it.
+- **Negative habits**: "no completion = success" means the effective
+  start must stay at `createdAt` for negative habits, otherwise
+  backdating a slip would erase prior "successful" days from the
+  score. Need clear documentation of this exception.
+- **CloudKit sync**: two devices could have different completion
+  sets mid-sync, causing the effective start to differ temporarily.
+  This is acceptable — it self-resolves once sync completes.
+
+## Open questions
+
+- [ ] Should the UI show "Tracking since <date>" in the habit detail
+      to make the effective start explicit?
+- [ ] For negative habits, should the effective start still be
+      `createdAt`, or should it be the first completion (slip) date?
+      The research recommends `createdAt` but this is debatable.
+- [ ] Should there be a limit on how far back a user can backdate?
+      (e.g., max 1 year to prevent accidental taps on ancient dates)
+
+## References
+
+- [Issue #42](https://github.com/scastiel/kado/issues/42)
+- `DefaultFrequencyEvaluator.swift` — the `createdDay` guard is the
+  root blocker
+- `docs/habit-score.md` — EMA score algorithm documentation


### PR DESCRIPTION
## Why?

Users who start a habit before installing the app can't log past days — `createdAt` acts as a hard boundary in score, streak, frequency, and display logic ([#42](https://github.com/scastiel/kado/issues/42)). Also, creating a habit on Monday but not completing it until Wednesday penalizes the early missed days.

## What?

- Completions can be logged before a habit's creation date
- Score/streak anchored to the first completion, not `createdAt` — no penalty for early missed days
- "Tracking since <date>" label in habit detail when effective start differs from `createdAt`
- Negative habits keep `createdAt` as their start (no-completion = success)
- `everyNDays` modular arithmetic handles negative deltas correctly
- No schema migration — computed `effectiveStart` derived from existing data

## How?

- `Habit.effectiveStart(completions:calendar:)` — pure function, returns earliest positive-value completion date or `createdAt`
- All 6 boundary code paths updated: `DefaultFrequencyEvaluator`, `DefaultHabitScoreCalculator`, `DefaultStreakCalculator`, `OverviewMatrix`, `MonthlyCalendarView`, `HabitDetailView`
- 22 new tests across 5 files
- Plan artifacts: `docs/plans/2026-04/habit-backdate/`

## Next steps

- Profile `effectiveStart` if completion sets grow large (currently O(N) per call, called per calendar cell)
- Future: user-editable start date field if users want explicit control

🤖 Generated with [Claude Code](https://claude.com/claude-code)