### PR TITLE
feat(detail): month navigator for habit calendar (issue #45)

### DIFF
--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -3405,6 +3405,40 @@
           }
         }
       }
+    },
+    "Next month": {
+      "comment": "Accessibility label for the forward chevron in the month navigator.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next month"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mois suivant"
+          }
+        }
+      }
+    },
+    "Previous month": {
+      "comment": "Accessibility label for the backward chevron in the month navigator.",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Previous month"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mois précédent"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -8,10 +8,17 @@ import KadoCore
 struct MonthlyCalendarView<PopoverContent: View>: View {
     let habit: Habit
     let completions: [Completion]
-    var month: Date = .now
+    @Binding var month: Date
     @Binding var selectedDay: Date?
+    var lowerBound: Date? = nil
     @ViewBuilder var popoverContent: (Date) -> PopoverContent
     @Environment(\.calendar) private var calendar
+
+    @State private var slideDirection: SlideDirection = .forward
+
+    private enum SlideDirection {
+        case forward, backward
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -26,6 +33,11 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
                         .frame(height: 32)
                 }
             }
+            .id(monthStart)
+            .transition(.asymmetric(
+                insertion: .move(edge: slideDirection == .forward ? .trailing : .leading),
+                removal: .move(edge: slideDirection == .forward ? .leading : .trailing)
+            ))
         }
     }
 
@@ -33,10 +45,82 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
         Array(repeating: GridItem(.flexible(), spacing: 8), count: 7)
     }
 
+    @ViewBuilder
     private var monthHeader: some View {
-        Text(monthTitle)
-            .font(.headline)
+        if lowerBound != nil {
+            navigableMonthHeader
+        } else {
+            Text(monthTitle)
+                .font(.headline)
+                .accessibilityAddTraits(.isHeader)
+        }
+    }
+
+    private var navigableMonthHeader: some View {
+        HStack {
+            Button {
+                navigateMonth(by: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.body.weight(.semibold))
+                    .contentShape(Rectangle())
+            }
+            .disabled(!canGoBackward)
+            .accessibilityLabel(Text(String(localized: "Previous month")))
+
+            Spacer()
+
+            Button {
+                selectedDay = nil
+                slideDirection = .forward
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    month = .now
+                }
+            } label: {
+                Text(monthTitle)
+                    .font(.headline)
+            }
+            .disabled(isShowingCurrentMonth)
             .accessibilityAddTraits(.isHeader)
+
+            Spacer()
+
+            Button {
+                navigateMonth(by: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.body.weight(.semibold))
+                    .contentShape(Rectangle())
+            }
+            .disabled(!canGoForward)
+            .accessibilityLabel(Text(String(localized: "Next month")))
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.primary)
+    }
+
+    private func navigateMonth(by value: Int) {
+        guard let newMonth = calendar.date(byAdding: .month, value: value, to: month) else { return }
+        selectedDay = nil
+        slideDirection = value > 0 ? .forward : .backward
+        withAnimation(.easeInOut(duration: 0.25)) {
+            month = newMonth
+        }
+    }
+
+    private var canGoBackward: Bool {
+        guard let lowerBound else { return false }
+        let lowerMonth = calendar.dateInterval(of: .month, for: lowerBound)?.start
+        return monthStart != lowerMonth
+    }
+
+    private var canGoForward: Bool {
+        !isShowingCurrentMonth
+    }
+
+    private var isShowingCurrentMonth: Bool {
+        let currentMonth = calendar.dateInterval(of: .month, for: .now)?.start
+        return monthStart == currentMonth
     }
 
     private var weekdayHeader: some View {
@@ -238,7 +322,7 @@ extension MonthlyCalendarView where PopoverContent == EmptyView {
     /// Convenience init for read-only callers (previews, any future
     /// surface that shows the grid without edit affordances). Cells
     /// remain tappable but selection goes to a discarded binding, so
-    /// no popover is attached.
+    /// no popover is attached. No month navigation is shown.
     init(
         habit: Habit,
         completions: [Completion],
@@ -247,7 +331,7 @@ extension MonthlyCalendarView where PopoverContent == EmptyView {
         self.init(
             habit: habit,
             completions: completions,
-            month: month,
+            month: .constant(month),
             selectedDay: .constant(nil),
             popoverContent: { _ in EmptyView() }
         )

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -65,7 +65,7 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
                     .font(.body.weight(.semibold))
                     .contentShape(Rectangle())
             }
-            .accessibilityLabel(Text(String(localized: "Previous month")))
+            .accessibilityLabel(Text("Previous month"))
 
             Spacer()
 
@@ -92,7 +92,7 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
                     .contentShape(Rectangle())
             }
             .disabled(!canGoForward)
-            .accessibilityLabel(Text(String(localized: "Next month")))
+            .accessibilityLabel(Text("Next month"))
         }
         .buttonStyle(.plain)
         .foregroundStyle(.primary)

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -10,7 +10,7 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
     let completions: [Completion]
     @Binding var month: Date
     @Binding var selectedDay: Date?
-    var lowerBound: Date? = nil
+    var navigable: Bool = false
     @ViewBuilder var popoverContent: (Date) -> PopoverContent
     @Environment(\.calendar) private var calendar
 
@@ -47,7 +47,7 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
 
     @ViewBuilder
     private var monthHeader: some View {
-        if lowerBound != nil {
+        if navigable {
             navigableMonthHeader
         } else {
             Text(monthTitle)
@@ -65,7 +65,6 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
                     .font(.body.weight(.semibold))
                     .contentShape(Rectangle())
             }
-            .disabled(!canGoBackward)
             .accessibilityLabel(Text(String(localized: "Previous month")))
 
             Spacer()
@@ -80,7 +79,7 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
                 Text(monthTitle)
                     .font(.headline)
             }
-            .disabled(isShowingCurrentMonth)
+            .disabled(!canGoForward)
             .accessibilityAddTraits(.isHeader)
 
             Spacer()
@@ -108,19 +107,9 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
         }
     }
 
-    private var canGoBackward: Bool {
-        guard let lowerBound else { return false }
-        let lowerMonth = calendar.dateInterval(of: .month, for: lowerBound)?.start
-        return monthStart != lowerMonth
-    }
-
     private var canGoForward: Bool {
-        !isShowingCurrentMonth
-    }
-
-    private var isShowingCurrentMonth: Bool {
         let currentMonth = calendar.dateInterval(of: .month, for: .now)?.start
-        return monthStart == currentMonth
+        return monthStart != currentMonth
     }
 
     private var weekdayHeader: some View {

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -20,6 +20,7 @@ struct HabitDetailView: View {
     @State private var showingTimerSheet = false
     @State private var showingScoreInfo = false
     @State private var editingDay: Date? = nil
+    @State private var displayedMonth: Date = .now
 
     private var isArchived: Bool { habit.archivedAt != nil }
 
@@ -45,7 +46,12 @@ struct HabitDetailView: View {
                 MonthlyCalendarView(
                     habit: habit.snapshot,
                     completions: (habit.completions ?? []).map(\.snapshot),
+                    month: $displayedMonth,
                     selectedDay: isArchived ? .constant(nil) : $editingDay,
+                    lowerBound: habit.snapshot.effectiveStart(
+                        completions: (habit.completions ?? []).map(\.snapshot),
+                        calendar: calendar
+                    ),
                     popoverContent: { day in
                         DayEditPopover(
                             habit: habit.snapshot,

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -48,10 +48,7 @@ struct HabitDetailView: View {
                     completions: (habit.completions ?? []).map(\.snapshot),
                     month: $displayedMonth,
                     selectedDay: isArchived ? .constant(nil) : $editingDay,
-                    lowerBound: habit.snapshot.effectiveStart(
-                        completions: (habit.completions ?? []).map(\.snapshot),
-                        calendar: calendar
-                    ),
+                    navigable: true,
                     popoverContent: { day in
                         DayEditPopover(
                             habit: habit.snapshot,

--- a/docs/plans/2026-04/month-navigator/compound.md
+++ b/docs/plans/2026-04/month-navigator/compound.md
@@ -1,0 +1,62 @@
+# Compound — Month navigator
+
+**Date**: 2026-04-29
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [#46](https://github.com/scastiel/kado/pull/46)
+
+## Summary
+
+Added month navigation to `MonthlyCalendarView` — chevron buttons
+flank the month title, tapping the title resets to the current month,
+and transitions animate directionally. The initial plan included a
+backward lower bound (`lowerBound: Date?` tied to `effectiveStart`),
+which was removed mid-build at the user's request. The final API is
+simpler: a `navigable: Bool` flag.
+
+## Decisions made
+
+- **Navigation lives inside `MonthlyCalendarView`, not `HabitDetailView`**: the header and chevrons are semantically coupled; any future consumer gets navigation for free by setting `navigable: true`.
+- **`navigable: Bool` over `lowerBound: Date?`**: originally the presence of a lower bound toggled navigation and constrained backward movement. User feedback simplified this to a plain boolean with unlimited backward navigation.
+- **`@Binding var month` over callbacks**: the parent owns the state, the component mutates via binding. Cleaner than `onMonthChange` closures and consistent with how `selectedDay` already works.
+- **`.id(monthStart)` for animation**: swapping the grid's identity on month change triggers SwiftUI's insert/remove transition. Simple, no `TabView` or manual offset math needed.
+- **Tap title to reset**: low-effort affordance to return to the current month. Disabled when already viewing the current month.
+
+## Surprises and how we handled them
+
+### Lower bound removal mid-build
+
+- **What happened**: the plan called for disabling backward navigation past `effectiveStart`. User said there should be no constraint to go in the past.
+- **What we did**: replaced `lowerBound: Date?` with `navigable: Bool`, removed `canGoBackward` and `isShowingCurrentMonth`, simplified to a single `canGoForward` check.
+- **Lesson**: when designing navigation bounds, default to no constraint unless the user explicitly asks for one.
+
+### Accessibility label wrapping
+
+- **What happened**: initial code used `Text(String(localized: "Previous month"))` — double-wrapping since `Text("...")` already goes through `LocalizedStringKey`.
+- **What we did**: simplified to `Text("Previous month")` during review.
+- **Lesson**: when the API accepts `Text`, rely on `LocalizedStringKey` implicit conversion. Reserve `String(localized:)` for `String`-typed APIs.
+
+## What worked well
+
+- **Existing `month: Date` parameter**: `MonthlyCalendarView` already accepted a month parameter that was always `.now`. Changing it to a `@Binding` was the minimal delta to unlock full navigation.
+- **Convenience init backward compat**: wrapping the plain `Date` in `.constant()` in the `EmptyView` convenience init meant zero changes to preview call sites.
+- **Single commit for tightly coupled changes**: calendar view + detail view + localization shipped together since they're inseparable.
+
+## For the next person
+
+- `MonthlyCalendarView` has two modes: static (default, `navigable: false`) and navigable. The convenience init forces static mode — no way to accidentally get navigation without a real `@Binding`.
+- The slide animation relies on `.id(monthStart)` destroying and recreating the grid. This is fine for ~30 cells but would need rethinking if the grid ever becomes heavy (e.g., multi-month view).
+- `canGoForward` compares `monthStart` against `Calendar.dateInterval(of: .month, for: .now)?.start`. This uses `.now` at evaluation time, which is correct for SwiftUI's re-render model.
+
+## Generalizable lessons
+
+- **[local]** `navigable: Bool` is simpler than `lowerBound: Date?` when the only question is "show navigation or not."
+- **[local]** `.accessibilityLabel(Text("..."))` uses `LocalizedStringKey` — no need for `String(localized:)` wrapping.
+
+## Metrics
+
+- Tasks completed: 4 of 4 (including visual verification by user)
+- Tests added: 0 (pure UI, no extractable business logic)
+- Commits: 6
+- Files touched: 3 production + 2 docs

--- a/docs/plans/2026-04/month-navigator/plan.md
+++ b/docs/plans/2026-04/month-navigator/plan.md
@@ -1,7 +1,7 @@
 # Plan — Month navigator
 
 **Date**: 2026-04-29
-**Status**: in progress
+**Status**: done
 **Research**: [research.md](./research.md)
 
 ## Summary

--- a/docs/plans/2026-04/month-navigator/plan.md
+++ b/docs/plans/2026-04/month-navigator/plan.md
@@ -1,7 +1,7 @@
 # Plan — Month navigator
 
 **Date**: 2026-04-29
-**Status**: ready to build
+**Status**: in progress
 **Research**: [research.md](./research.md)
 
 ## Summary
@@ -23,7 +23,7 @@ go past the current month.
 
 ## Task list
 
-### Task 1: Add month navigation to MonthlyCalendarView
+### ~~Task 1: Add month navigation to MonthlyCalendarView~~ ✅
 
 **Goal**: Turn the static month header into a navigable one with
 chevron buttons, bounds, animation, and tap-to-reset.
@@ -56,7 +56,7 @@ chevron buttons, bounds, animation, and tap-to-reset.
 
 ---
 
-### Task 2: Wire month navigation in HabitDetailView
+### ~~Task 2: Wire month navigation in HabitDetailView~~ ✅
 
 **Goal**: Connect the new navigation to the habit detail screen.
 
@@ -80,7 +80,7 @@ chevron buttons, bounds, animation, and tap-to-reset.
 
 ---
 
-### Task 3: Localization (EN + FR)
+### ~~Task 3: Localization (EN + FR)~~ ✅
 
 **Goal**: Add catalog entries for the new accessibility labels and any
 visible strings.
@@ -129,6 +129,19 @@ visible strings.
 ## Open questions
 
 None — all resolved during research.
+
+## Notes during build
+
+- **Tasks 1–3** shipped in a single commit — the feature is small
+  enough that splitting would have been artificial. All three files
+  (`MonthlyCalendarView`, `HabitDetailView`, `Localizable.xcstrings`)
+  are tightly coupled.
+- No surprises; the `@Binding` change was clean and the convenience
+  init wrapped in `.constant()` with no call-site breakage.
+- Visual verification limited: XcodeBuildMCP tap primitives are not
+  enabled, so the habit detail screen could not be reached in the
+  simulator. Build + 318 tests pass. Manual verification by the user
+  is needed.
 
 ## Out of scope
 

--- a/docs/plans/2026-04/month-navigator/plan.md
+++ b/docs/plans/2026-04/month-navigator/plan.md
@@ -1,0 +1,137 @@
+# Plan — Month navigator
+
+**Date**: 2026-04-29
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Add month navigation to the habit detail calendar so users can browse
+past months. Chevron buttons flank the month title; tapping the title
+resets to the current month. Month changes animate with a directional
+slide. Navigation is bounded: can't go before `effectiveStart`, can't
+go past the current month.
+
+## Decisions locked in
+
+- Navigation lives inside `MonthlyCalendarView` — any consumer that passes `lowerBound` gets it for free.
+- `month` becomes `@Binding var month: Date`; presence of `lowerBound: Date?` toggles navigation visibility.
+- Tap month title → reset to current month.
+- Slide animation matching chevron direction on month change.
+- Dismiss any open day-edit popover on month change.
+- Convenience init (read-only callers) keeps `month: Date` signature via `.constant()` wrapper, no navigation shown.
+
+## Task list
+
+### Task 1: Add month navigation to MonthlyCalendarView
+
+**Goal**: Turn the static month header into a navigable one with
+chevron buttons, bounds, animation, and tap-to-reset.
+
+**Changes**:
+- `Kado/UIComponents/MonthlyCalendarView.swift`:
+  - Change `var month: Date = .now` → `@Binding var month: Date`
+  - Add `var lowerBound: Date? = nil`
+  - Replace `monthHeader` with a conditional layout:
+    - When `lowerBound` is nil: current plain `Text` (backward compat)
+    - When `lowerBound` is set: `HStack` with `chevron.left` button,
+      tappable month title, `chevron.right` button
+  - Previous button: `calendar.date(byAdding: .month, value: -1, to: month)`;
+    disabled when displayed month contains `lowerBound`
+  - Next button: `calendar.date(byAdding: .month, value: 1, to: month)`;
+    disabled when displayed month is current month
+  - Tap title: set `month = .now`
+  - On any navigation: set `selectedDay = nil` to dismiss popovers
+  - Add `.transition(.asymmetric(...))` or `.animation` keyed on month
+    for directional slide
+  - Update the `EmptyView` convenience init: accept `month: Date = .now`,
+    pass `.constant(month)` to the binding, leave `lowerBound` nil
+  - Update all previews for the new init signature
+
+**Tests / verification**:
+- Previews compile and render correctly
+- `build_sim` passes
+
+**Commit message (suggested)**: `feat(calendar): add month navigation to MonthlyCalendarView`
+
+---
+
+### Task 2: Wire month navigation in HabitDetailView
+
+**Goal**: Connect the new navigation to the habit detail screen.
+
+**Changes**:
+- `Kado/Views/HabitDetail/HabitDetailView.swift`:
+  - Add `@State private var displayedMonth: Date = .now`
+  - Pass `month: $displayedMonth` to `MonthlyCalendarView`
+  - Compute `lowerBound` from
+    `habit.snapshot.effectiveStart(completions:calendar:)`
+    and pass it
+
+**Tests / verification**:
+- `build_sim` passes
+- Navigate to a habit detail → chevrons appear
+- Navigate backward → see previous month
+- Navigate past `effectiveStart` → left chevron disabled
+- Current month → right chevron disabled
+- Tap month title → returns to current month
+
+**Commit message (suggested)**: `feat(detail): wire month navigation in HabitDetailView`
+
+---
+
+### Task 3: Localization (EN + FR)
+
+**Goal**: Add catalog entries for the new accessibility labels and any
+visible strings.
+
+**Changes**:
+- `Kado/Resources/Localizable.xcstrings`:
+  - `"Previous month"` — accessibility label for left chevron
+    (FR: `"Mois précédent"`)
+  - `"Next month"` — accessibility label for right chevron
+    (FR: `"Mois suivant"`)
+
+**Tests / verification**:
+- `LocalizationCoverageTests` passes
+- `build_sim` passes
+
+**Commit message (suggested)**: `feat(l10n): add month navigator translations (EN + FR)`
+
+---
+
+### Task 4: Visual verification
+
+**Goal**: Confirm the feature looks correct on light/dark, iPhone/iPad.
+
+**Changes**: none (verification only)
+
+**Verification**:
+- `screenshot` on iPhone sim — light mode, current month
+- `screenshot` on iPhone sim — dark mode, navigated to past month
+- Verify disabled chevron state visually
+- Check Dynamic Type XXXL doesn't clip the header
+
+**Commit message (suggested)**: n/a (no code changes)
+
+## Risks and mitigation
+
+- **Animation jank with popover dismissal**: dismissing the popover
+  and animating the month transition simultaneously might look odd.
+  Mitigation: set `selectedDay = nil` *before* updating `month`, or
+  use `withAnimation` only on the month change so the popover
+  dismisses instantly.
+- **Convenience init breakage**: changing `month` to `@Binding`
+  affects the memberwise init. Mitigation: the `EmptyView`
+  convenience init wraps the plain `Date` in `.constant()`, so
+  existing read-only callers are unaffected.
+
+## Open questions
+
+None — all resolved during research.
+
+## Out of scope
+
+- Swipe gesture for month navigation (future polish)
+- `TabView(.page)` infinite-scroll approach (over-engineered for now)
+- Month navigation on the Overview matrix (separate feature)

--- a/docs/plans/2026-04/month-navigator/plan.md
+++ b/docs/plans/2026-04/month-navigator/plan.md
@@ -9,13 +9,13 @@
 Add month navigation to the habit detail calendar so users can browse
 past months. Chevron buttons flank the month title; tapping the title
 resets to the current month. Month changes animate with a directional
-slide. Navigation is bounded: can't go before `effectiveStart`, can't
-go past the current month.
+slide. Backward navigation is unlimited; forward navigation stops at
+the current month.
 
 ## Decisions locked in
 
-- Navigation lives inside `MonthlyCalendarView` — any consumer that passes `lowerBound` gets it for free.
-- `month` becomes `@Binding var month: Date`; presence of `lowerBound: Date?` toggles navigation visibility.
+- Navigation lives inside `MonthlyCalendarView` — any consumer that sets `navigable: true` gets it for free.
+- `month` becomes `@Binding var month: Date`; `navigable: Bool` toggles navigation visibility.
 - Tap month title → reset to current month.
 - Slide animation matching chevron direction on month change.
 - Dismiss any open day-edit popover on month change.

--- a/docs/plans/2026-04/month-navigator/research.md
+++ b/docs/plans/2026-04/month-navigator/research.md
@@ -1,0 +1,96 @@
+# Research — Month navigator
+
+**Date**: 2026-04-29
+**Status**: ready for plan
+**Related**: [GitHub issue #45](https://github.com/scastiel/kado/issues/45), `Kado/UIComponents/MonthlyCalendarView.swift`, `Kado/Views/HabitDetail/HabitDetailView.swift`
+
+## Problem
+
+The habit detail screen shows a calendar grid for the **current month only**. Users with history spanning multiple months have no way to browse past completions on the calendar — they can only see the flat `CompletionHistoryList` below. Navigating months is essential for reviewing patterns, editing past days, and understanding long-term trends.
+
+## Current state of the codebase
+
+`MonthlyCalendarView` already accepts a `month: Date` parameter (defaults to `.now`) and renders whichever month that date falls in. All the month-start, day-range, and leading-blank computation is self-contained. The component just never gets a different month because `HabitDetailView` uses the default.
+
+The month header (`monthHeader`) is a plain `Text(monthTitle)` with no navigation controls.
+
+`HabitDetailView` has no `@State` for which month is displayed. The `editingDay` binding already flows into `MonthlyCalendarView` for the day-edit popover, so the interaction pattern is established.
+
+`Habit.effectiveStart(completions:calendar:)` returns the earliest meaningful date (earliest completion or `createdAt`), which is a natural lower bound for backward navigation.
+
+No existing chevron-navigation pattern exists in the app — this will be the first.
+
+## Proposed approach
+
+Add month navigation **inside `MonthlyCalendarView`** so any consumer gets it for free. The component already owns the month header — flanking it with chevron buttons is a natural extension.
+
+### Design
+
+The month header row becomes:
+
+```
+  ‹   April 2026   ›
+```
+
+- Left chevron: go to previous month. Disabled when the displayed month contains `effectiveStart`.
+- Right chevron: go to next month. Disabled (or hidden) when the displayed month is the current month.
+- Tapping the month title could reset to current month (nice touch, not required for MVP).
+
+### Key changes
+
+1. **`MonthlyCalendarView`**: change `month` from a plain `Date` property to a `@Binding var month: Date` so the parent can track which month is displayed and the component can mutate it. Add chevron buttons to `monthHeader`. Add lower/upper bound logic.
+
+2. **`HabitDetailView`**: add `@State private var displayedMonth: Date = .now` and pass it as the binding. Pass `habit.snapshot.effectiveStart(...)` as the lower bound.
+
+3. **Localization**: the chevron buttons use SF Symbols (`chevron.left` / `chevron.right`) and accessibility labels ("Previous month" / "Next month") — two new catalog entries with FR translations.
+
+### Data model changes
+
+None.
+
+### UI changes
+
+- `MonthlyCalendarView.monthHeader` gains two `Button`s flanking the title.
+- The month title becomes tappable to reset to current month (optional, low effort).
+
+### Tests to write
+
+- `@Test("Previous month button navigates backward")` — verify `month` binding updates to the prior month's first day.
+- `@Test("Next month button is disabled on current month")` — verify the upper bound.
+- `@Test("Previous month button is disabled on effectiveStart month")` — verify the lower bound.
+
+These are UI-behavior tests and can be light — the core date math uses `calendar.date(byAdding:)` which is already well-tested by the system. If we prefer pure-unit coverage, we can extract the bound-checking logic into a small helper.
+
+## Alternatives considered
+
+### Alternative A: Navigation owned by HabitDetailView
+
+- Idea: put the chevron buttons outside `MonthlyCalendarView`, in `HabitDetailView`'s VStack.
+- Why not: the month header and navigation are visually and semantically coupled. Splitting them forces layout coordination and makes `MonthlyCalendarView` less reusable. Any future consumer (e.g., overview, widget preview) would need to re-implement navigation.
+
+### Alternative B: Swipe gesture instead of buttons
+
+- Idea: horizontal swipe on the calendar to change months.
+- Why not as primary: conflicts with the scroll view's gesture and the popover tap targets. Could be a future enhancement layered on top of buttons.
+
+### Alternative C: `TabView` with page-style swiping
+
+- Idea: embed months in a `TabView(.page)` for swipe navigation.
+- Why not: adds complexity (lazy loading of off-screen months, gesture conflicts with day taps and popovers). Buttons are simpler and more accessible. Could revisit for a polish pass.
+
+## Risks and unknowns
+
+- **Popover + month change interaction**: if a day-edit popover is open and the user navigates away, the popover should dismiss. Setting `selectedDay = nil` on month change handles this naturally.
+- **Performance**: rendering a month grid is fast (~30 cells). No concern even with rapid navigation.
+
+## Open questions
+
+- [x] Should tapping the month title reset to the current month? **Yes.**
+- [x] Should the calendar animate the month transition (e.g., slide left/right)? **Yes** — slide transition matching chevron direction.
+
+## References
+
+- [GitHub issue #45](https://github.com/scastiel/kado/issues/45)
+- `MonthlyCalendarView.swift` — existing calendar grid component
+- `HabitDetailView.swift` — detail screen that hosts the calendar
+- `Habit.effectiveStart(completions:calendar:)` — lower bound for navigation


### PR DESCRIPTION
## Why?

- Habit detail shows only the current month's calendar — users can't browse past completions visually ([#45](https://github.com/scastiel/kado/issues/45))

## What?

- Add chevron navigation (previous/next month) to the calendar grid header
- Tap month title to jump back to current month
- Animated slide transition matching navigation direction
- Unlimited backward navigation; forward capped at current month

## How?

- `MonthlyCalendarView.month` becomes a `@Binding`; `navigable: Bool` toggles the chevron header
- `HabitDetailView` holds the `@State` for displayed month
- Two new localization keys for accessibility labels (EN + FR)
- Docs: [research](docs/plans/2026-04/month-navigator/research.md) · [plan](docs/plans/2026-04/month-navigator/plan.md) · [compound](docs/plans/2026-04/month-navigator/compound.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)