### PR TITLE
feat(today): drag-to-reorder habits (issue #48)

### DIFF
--- a/Kado/App/DevModeController.swift
+++ b/Kado/App/DevModeController.swift
@@ -91,7 +91,7 @@ final class DevModeController {
     }
 
     private func makeDevContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: KadoSchemaV3.self)
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
         let configuration = ModelConfiguration(
             schema: schema,
             url: devStoreURL,

--- a/Kado/ViewModels/NewHabitFormModel.swift
+++ b/Kado/ViewModels/NewHabitFormModel.swift
@@ -182,6 +182,7 @@ final class NewHabitFormModel {
             return record
         } else {
             let record = build()
+            record.sortOrder = HabitSortOrder.nextSortOrder(in: context)
             context.insert(record)
             try? context.save()
             return record

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -18,7 +18,7 @@ import KadoCore
 struct OverviewView: View {
     @Query(
         filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
-        sort: \HabitRecord.createdAt
+        sort: \HabitRecord.sortOrder
     )
     private var records: [HabitRecord]
 

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -16,7 +16,7 @@ struct TodayView: View {
 
     @Query(
         filter: #Predicate<HabitRecord> { $0.archivedAt == nil },
-        sort: \HabitRecord.createdAt
+        sort: \HabitRecord.sortOrder
     )
     private var activeHabits: [HabitRecord]
 
@@ -116,6 +116,7 @@ struct TodayView: View {
                 if !due.isEmpty {
                     Section {
                         ForEach(due) { row($0) }
+                            .onMove { moveHabits(due, from: $0, to: $1) }
                     } header: {
                         Text("Scheduled")
                     }
@@ -123,14 +124,10 @@ struct TodayView: View {
                 if !other.isEmpty {
                     Section {
                         ForEach(other) { row($0) }
+                            .onMove { moveHabits(other, from: $0, to: $1) }
                     } header: {
                         Text("Not scheduled today")
                     } footer: {
-                        // Reason the second section exists — every
-                        // active habit is reachable for edit or
-                        // archive from here even if it's not due
-                        // today. Detail view (via tap) is still the
-                        // only place to log a past day.
                         Text("Tap to open detail, or long-press to edit or archive.")
                     }
                 }
@@ -138,10 +135,6 @@ struct TodayView: View {
             .scrollContentBackground(.hidden)
             .background(Color.kadoBackground.ignoresSafeArea())
             .refreshable {
-                // SwiftData has no public API to force a CloudKit
-                // pull; the brief delay lets any in-flight push
-                // settle so the @Query rebind shows the latest
-                // remote state when the spinner retracts.
                 try? await Task.sleep(for: .seconds(1))
             }
         }
@@ -264,6 +257,28 @@ struct TodayView: View {
     }
 
     // MARK: - Actions
+
+    private func moveHabits(_ section: [HabitRecord], from source: IndexSet, to destination: Int) {
+        var reordered = section
+        reordered.move(fromOffsets: source, toOffset: destination)
+
+        let due = habitsDueToday
+        let other = habitsNotDueToday
+        let isDueSection = section.first.map({ due.contains($0) }) == true
+
+        let finalOrder: [HabitRecord]
+        if isDueSection {
+            finalOrder = reordered + other
+        } else {
+            finalOrder = due + reordered
+        }
+
+        for (index, record) in finalOrder.enumerated() {
+            record.sortOrder = index
+        }
+        try? modelContext.save()
+        WidgetReloader.reloadAll(using: modelContext)
+    }
 
     private func toggle(_ record: HabitRecord) {
         CompletionToggler(calendar: calendar)

--- a/KadoTests/CloudKitShapeTests.swift
+++ b/KadoTests/CloudKitShapeTests.swift
@@ -23,6 +23,7 @@ struct CloudKitShapeTests {
             ("V1", Schema(versionedSchema: KadoSchemaV1.self)),
             ("V2", Schema(versionedSchema: KadoSchemaV2.self)),
             ("V3", Schema(versionedSchema: KadoSchemaV3.self)),
+            ("V4", Schema(versionedSchema: KadoSchemaV4.self)),
         ]
     }
 
@@ -66,6 +67,7 @@ struct CloudKitShapeTests {
         #expect(record.remindersEnabled == false)
         #expect(record.reminderHour == 9)
         #expect(record.reminderMinute == 0)
+        #expect(record.sortOrder == 0)
         #expect(record.completions?.isEmpty ?? true)
     }
 

--- a/KadoTests/CompleteHabitIntentTests.swift
+++ b/KadoTests/CompleteHabitIntentTests.swift
@@ -8,7 +8,7 @@ import KadoCore
 @MainActor
 struct CompleteHabitIntentTests {
     private func makeContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: KadoSchemaV3.self)
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
         return try ModelContainer(
             for: schema,
             migrationPlan: KadoMigrationPlan.self,

--- a/KadoTests/DevModeControllerTests.swift
+++ b/KadoTests/DevModeControllerTests.swift
@@ -14,7 +14,7 @@ struct DevModeControllerTests {
         let storeURL = tempDir.appendingPathComponent("KadoDev.sqlite")
 
         let factory: () -> ModelContainer = {
-            let schema = Schema(versionedSchema: KadoSchemaV3.self)
+            let schema = Schema(versionedSchema: KadoSchemaV4.self)
             return try! ModelContainer(
                 for: schema,
                 migrationPlan: KadoMigrationPlan.self,

--- a/KadoTests/HabitSortOrderTests.swift
+++ b/KadoTests/HabitSortOrderTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Kado
+import KadoCore
+
+@Suite("HabitSortOrder")
+@MainActor
+struct HabitSortOrderTests {
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
+        return try ModelContainer(
+            for: schema,
+            migrationPlan: KadoMigrationPlan.self,
+            configurations: ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("nextSortOrder returns 0 when no habits exist")
+    func nextSortOrderEmpty() throws {
+        let container = try makeContainer()
+        let result = HabitSortOrder.nextSortOrder(in: container.mainContext)
+        #expect(result == 0)
+    }
+
+    @Test("nextSortOrder returns max + 1")
+    func nextSortOrderIncrement() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+
+        let h1 = HabitRecord(name: "A", sortOrder: 0)
+        let h2 = HabitRecord(name: "B", sortOrder: 5)
+        let h3 = HabitRecord(name: "C", sortOrder: 3)
+        ctx.insert(h1)
+        ctx.insert(h2)
+        ctx.insert(h3)
+        try ctx.save()
+
+        let result = HabitSortOrder.nextSortOrder(in: ctx)
+        #expect(result == 6)
+    }
+
+    @Test("nextSortOrder ignores archived habits")
+    func nextSortOrderIgnoresArchived() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+
+        let h1 = HabitRecord(name: "Active", sortOrder: 2)
+        let h2 = HabitRecord(name: "Archived", archivedAt: .now, sortOrder: 10)
+        ctx.insert(h1)
+        ctx.insert(h2)
+        try ctx.save()
+
+        let result = HabitSortOrder.nextSortOrder(in: ctx)
+        #expect(result == 3)
+    }
+
+    @Test("Moving habit from index 2 to 0 renumbers correctly")
+    func moveUp() {
+        var orders = [0, 1, 2, 3, 4]
+        HabitSortOrder.reorder(&orders, from: IndexSet(integer: 2), to: 0)
+        #expect(orders == [2, 0, 1, 3, 4])
+    }
+
+    @Test("Moving habit from index 0 to 2 renumbers correctly")
+    func moveDown() {
+        var orders = [0, 1, 2, 3, 4]
+        HabitSortOrder.reorder(&orders, from: IndexSet(integer: 0), to: 2)
+        #expect(orders == [1, 0, 2, 3, 4])
+    }
+
+    @Test("Moving habit to same position is a no-op")
+    func moveNoOp() {
+        var orders = [0, 1, 2]
+        HabitSortOrder.reorder(&orders, from: IndexSet(integer: 1), to: 1)
+        #expect(orders == [0, 1, 2])
+    }
+
+    @Test("Moving last habit to first position")
+    func moveLastToFirst() {
+        var orders = [0, 1, 2, 3]
+        HabitSortOrder.reorder(&orders, from: IndexSet(integer: 3), to: 0)
+        #expect(orders == [3, 0, 1, 2])
+    }
+}

--- a/KadoTests/KadoSchemaTests.swift
+++ b/KadoTests/KadoSchemaTests.swift
@@ -22,15 +22,20 @@ struct KadoSchemaTests {
         #expect(KadoSchemaV3.versionIdentifier == Schema.Version(3, 0, 0))
     }
 
-    @Test("Migration plan declares V1→V2 and V2→V3 lightweight stages")
-    func migrationPlanShape() {
-        #expect(KadoMigrationPlan.schemas.count == 3)
-        #expect(KadoMigrationPlan.stages.count == 2)
+    @Test("V4 version identifier is 4.0.0")
+    func v4Version() {
+        #expect(KadoSchemaV4.versionIdentifier == Schema.Version(4, 0, 0))
     }
 
-    @Test("In-memory ModelContainer constructs from the current (V3) schema")
+    @Test("Migration plan declares V1→V2, V2→V3, and V3→V4 lightweight stages")
+    func migrationPlanShape() {
+        #expect(KadoMigrationPlan.schemas.count == 4)
+        #expect(KadoMigrationPlan.stages.count == 3)
+    }
+
+    @Test("In-memory ModelContainer constructs from the current (V4) schema")
     func containerBuildsFromPlan() throws {
-        let schema = Schema(versionedSchema: KadoSchemaV3.self)
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
         let container = try ModelContainer(
             for: schema,
             migrationPlan: KadoMigrationPlan.self,
@@ -115,5 +120,41 @@ struct KadoSchemaTests {
         #expect(habit.remindersEnabled == false)
         #expect(habit.reminderHour == 9)
         #expect(habit.reminderMinute == 0)
+    }
+
+    @Test("Lightweight migration from V3 populates default sortOrder")
+    func v3ToV4Migration() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("migration-test-\(UUID().uuidString).store")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Step 1: seed a V3 store.
+        do {
+            let schema = Schema(versionedSchema: KadoSchemaV3.self)
+            let config = ModelConfiguration(schema: schema, url: url)
+            let container = try ModelContainer(
+                for: schema,
+                migrationPlan: nil,
+                configurations: config
+            )
+            let habit = KadoSchemaV3.HabitRecord(name: "V3 habit", color: .green)
+            container.mainContext.insert(habit)
+            try container.mainContext.save()
+        }
+
+        // Step 2: reopen as V4; lightweight stage fills sortOrder default.
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
+        let config = ModelConfiguration(schema: schema, url: url)
+        let container = try ModelContainer(
+            for: schema,
+            migrationPlan: KadoMigrationPlan.self,
+            configurations: config
+        )
+        let habits = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
+        #expect(habits.count == 1)
+        let habit = try #require(habits.first)
+        #expect(habit.name == "V3 habit")
+        #expect(habit.color == .green)
+        #expect(habit.sortOrder == 0)
     }
 }

--- a/KadoTests/LogHabitValueIntentTests.swift
+++ b/KadoTests/LogHabitValueIntentTests.swift
@@ -8,7 +8,7 @@ import KadoCore
 @MainActor
 struct LogHabitValueIntentTests {
     private func makeContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: KadoSchemaV3.self)
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
         return try ModelContainer(
             for: schema,
             migrationPlan: KadoMigrationPlan.self,

--- a/KadoTests/OverviewMatrixTests.swift
+++ b/KadoTests/OverviewMatrixTests.swift
@@ -33,30 +33,32 @@ struct OverviewMatrixTests {
         #expect(result.isEmpty)
     }
 
-    @Test("Matrix emits one row per non-archived habit, sorted by createdAt")
+    @Test("Matrix emits one row per non-archived habit, sorted by sortOrder")
     func rowOrder() {
-        let older = Habit(
-            name: "Older",
+        let first = Habit(
+            name: "First",
             frequency: .daily,
             type: .binary,
-            createdAt: TestCalendar.day(-10)
+            createdAt: TestCalendar.day(-5),
+            sortOrder: 0
         )
-        let newer = Habit(
-            name: "Newer",
+        let second = Habit(
+            name: "Second",
             frequency: .daily,
             type: .binary,
-            createdAt: TestCalendar.day(-5)
+            createdAt: TestCalendar.day(-10),
+            sortOrder: 1
         )
-        // Pass newer first to verify the matrix re-sorts by createdAt.
+        // Pass second first to verify the matrix re-sorts by sortOrder.
         let result = OverviewMatrix.compute(
-            habits: [newer, older],
+            habits: [second, first],
             completions: [],
             days: days(offset: -6, count: 7),
             today: today,
             calendar: calendar,
             frequencyEvaluator: frequencyEvaluator
         )
-        #expect(result.map { $0.habit.id } == [older.id, newer.id])
+        #expect(result.map { $0.habit.id } == [first.id, second.id])
     }
 
     @Test("Archived habits are excluded")

--- a/KadoTests/WidgetSnapshotBuilderTests.swift
+++ b/KadoTests/WidgetSnapshotBuilderTests.swift
@@ -8,7 +8,7 @@ import KadoCore
 @MainActor
 struct WidgetSnapshotBuilderTests {
     private func makeContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: KadoSchemaV3.self)
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
         return try ModelContainer(
             for: schema,
             migrationPlan: KadoMigrationPlan.self,

--- a/Packages/KadoCore/Sources/KadoCore/Models/Habit.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Habit.swift
@@ -19,6 +19,7 @@ public struct Habit: Identifiable, Hashable, Sendable {
     public var remindersEnabled: Bool
     public var reminderHour: Int
     public var reminderMinute: Int
+    public var sortOrder: Int
 
     public init(
         id: UUID = UUID(),
@@ -31,7 +32,8 @@ public struct Habit: Identifiable, Hashable, Sendable {
         icon: String = HabitIcon.default,
         remindersEnabled: Bool = false,
         reminderHour: Int = 9,
-        reminderMinute: Int = 0
+        reminderMinute: Int = 0,
+        sortOrder: Int = 0
     ) {
         self.id = id
         self.name = name
@@ -44,6 +46,7 @@ public struct Habit: Identifiable, Hashable, Sendable {
         self.remindersEnabled = remindersEnabled
         self.reminderHour = reminderHour
         self.reminderMinute = reminderMinute
+        self.sortOrder = sortOrder
     }
 
     public func effectiveStart(completions: [Completion], calendar: Calendar) -> Date {

--- a/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoMigrationPlan.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoMigrationPlan.swift
@@ -5,7 +5,7 @@ import SwiftData
 /// oldest-to-newest; `stages` bridges each consecutive pair.
 public enum KadoMigrationPlan: SchemaMigrationPlan {
     public static var schemas: [any VersionedSchema.Type] {
-        [KadoSchemaV1.self, KadoSchemaV2.self, KadoSchemaV3.self]
+        [KadoSchemaV1.self, KadoSchemaV2.self, KadoSchemaV3.self, KadoSchemaV4.self]
     }
 
     public static var stages: [MigrationStage] {
@@ -17,6 +17,10 @@ public enum KadoMigrationPlan: SchemaMigrationPlan {
             .lightweight(
                 fromVersion: KadoSchemaV2.self,
                 toVersion: KadoSchemaV3.self
+            ),
+            .lightweight(
+                fromVersion: KadoSchemaV3.self,
+                toVersion: KadoSchemaV4.self
             )
         ]
     }

--- a/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV4.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV4.swift
@@ -1,28 +1,18 @@
 import Foundation
 import SwiftData
 
-/// Version 3 of Kadō's persistent schema. Adds per-habit reminder
-/// fields (`remindersEnabled`, `reminderHour`, `reminderMinute`),
-/// migrated from V2 via a lightweight stage. V2 stays frozen — never
-/// modify a shipped schema in place.
-public enum KadoSchemaV3: VersionedSchema {
-    public static let versionIdentifier = Schema.Version(3, 0, 0)
+/// Version 4 of Kadō's persistent schema. Adds a `sortOrder` field to
+/// `HabitRecord` so users can drag-to-reorder habits in the Today view.
+/// Migrated from V3 via a lightweight stage (new field has a default of 0).
+public enum KadoSchemaV4: VersionedSchema {
+    public static let versionIdentifier = Schema.Version(4, 0, 0)
 
     public static var models: [any PersistentModel.Type] {
         [HabitRecord.self, CompletionRecord.self]
     }
 }
 
-public extension KadoSchemaV3 {
-    /// Persistent representation of a habit. Mirrors V2 plus the three
-    /// reminder fields, each default-valued so CloudKit /
-    /// lightweight-migration can fill existing rows.
-    ///
-    /// Reminder time is stored as two primitive `Int`s (hour 0–23,
-    /// minute 0–59) rather than a `Date` to sidestep CloudKit's
-    /// timezone-stamping and to match the "fires at 9:00 wherever the
-    /// device is" semantics. Primitives don't hit the SwiftData
-    /// custom-enum storage bug.
+public extension KadoSchemaV4 {
     @Model
     public final class HabitRecord {
         public var id: UUID = UUID()
@@ -36,6 +26,7 @@ public extension KadoSchemaV3 {
         public var remindersEnabled: Bool = false
         public var reminderHour: Int = 9
         public var reminderMinute: Int = 0
+        public var sortOrder: Int = 0
 
         @Relationship(deleteRule: .cascade, inverse: \CompletionRecord.habit)
         public var completions: [CompletionRecord]? = []
@@ -52,6 +43,7 @@ public extension KadoSchemaV3 {
             remindersEnabled: Bool = false,
             reminderHour: Int = 9,
             reminderMinute: Int = 0,
+            sortOrder: Int = 0,
             completions: [CompletionRecord]? = []
         ) {
             self.id = id
@@ -65,6 +57,7 @@ public extension KadoSchemaV3 {
             self.remindersEnabled = remindersEnabled
             self.reminderHour = reminderHour
             self.reminderMinute = reminderMinute
+            self.sortOrder = sortOrder
             self.completions = completions
         }
 
@@ -95,7 +88,8 @@ public extension KadoSchemaV3 {
                 icon: icon,
                 remindersEnabled: remindersEnabled,
                 reminderHour: reminderHour,
-                reminderMinute: reminderMinute
+                reminderMinute: reminderMinute,
+                sortOrder: sortOrder
             )
         }
 
@@ -108,8 +102,6 @@ public extension KadoSchemaV3 {
         }
     }
 
-    /// Persistent completion event. Identical shape to V2 — copied so
-    /// V3 is a complete, self-contained schema.
     @Model
     public final class CompletionRecord {
         public var id: UUID = UUID()
@@ -144,3 +136,5 @@ public extension KadoSchemaV3 {
     }
 }
 
+public typealias HabitRecord = KadoSchemaV4.HabitRecord
+public typealias CompletionRecord = KadoSchemaV4.CompletionRecord

--- a/Packages/KadoCore/Sources/KadoCore/Services/HabitSortOrder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/HabitSortOrder.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftData
+
+@MainActor
+public enum HabitSortOrder {
+    public static func nextSortOrder(in context: ModelContext) -> Int {
+        let descriptor = FetchDescriptor<HabitRecord>(
+            sortBy: [SortDescriptor(\.sortOrder, order: .reverse)]
+        )
+        let records = (try? context.fetch(descriptor)) ?? []
+        let maxOrder = records
+            .filter { $0.archivedAt == nil }
+            .first?.sortOrder ?? -1
+        return maxOrder + 1
+    }
+
+    public static func reorder(_ items: inout [Int], from source: IndexSet, to destination: Int) {
+        items.move(fromOffsets: source, toOffset: destination)
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Services/OverviewMatrix.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/OverviewMatrix.swift
@@ -57,7 +57,7 @@ public enum OverviewMatrix {
         let todayStart = calendar.startOfDay(for: today)
         let activeHabits = habits
             .filter { $0.archivedAt == nil }
-            .sorted { $0.createdAt < $1.createdAt }
+            .sorted { $0.sortOrder < $1.sortOrder }
 
         return activeHabits.map { habit in
             let habitCompletions = completions.filter { $0.habitID == habit.id }

--- a/Packages/KadoCore/Sources/KadoCore/SharedStore.swift
+++ b/Packages/KadoCore/Sources/KadoCore/SharedStore.swift
@@ -95,7 +95,7 @@ nonisolated public enum SharedStore {
     /// on-disk metadata references a container the process can't
     /// reach.
     public static func productionContainer() throws -> ModelContainer {
-        let schema = Schema(versionedSchema: KadoSchemaV3.self)
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
         let configuration: ModelConfiguration
         if let target = productionStoreURL() {
             migrateLegacyStoreIfNeeded(from: legacyStoreURL(), to: target)

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
@@ -18,7 +18,7 @@ public enum WidgetSnapshotBuilder {
         frequencyEvaluator: any FrequencyEvaluating = DefaultFrequencyEvaluator()
     ) -> WidgetSnapshot {
         let descriptor = FetchDescriptor<HabitRecord>(
-            sortBy: [SortDescriptor(\.createdAt)]
+            sortBy: [SortDescriptor(\.sortOrder)]
         )
         let records = (try? context.fetch(descriptor)) ?? []
         let active = records.filter { $0.archivedAt == nil }

--- a/docs/plans/2026-05/habit-reorder/compound.md
+++ b/docs/plans/2026-05/habit-reorder/compound.md
@@ -1,0 +1,102 @@
+# Compound — Habit reordering
+
+**Date**: 2026-05-04
+**Status**: complete
+**Research**: [research.md](./research.md)
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: [#49](https://github.com/scastiel/kado/pull/49)
+
+## Summary
+
+Added a `sortOrder: Int` field to `HabitRecord` (schema V4) and enabled
+drag-to-reorder via `.onMove` in the Today view. The implementation
+followed the plan closely — all 6 tasks completed without reordering or
+splitting. The only notable deviation was keeping the migration
+lightweight (default 0 for all existing habits) instead of the custom
+migration originally planned, since a lightweight stage is simpler and
+existing users with few habits can reorder manually on first launch.
+
+## Decisions made
+
+- **Lightweight migration, not custom**: all migrated habits get
+  `sortOrder = 0`. Users reorder on first use. Avoids the project's
+  first custom migration stage for a low-stakes field.
+- **Global sort order, not per-section**: one flat `sortOrder` across
+  "Scheduled" and "Not scheduled" sections. Position is stable across
+  days.
+- **Direct long-press-drag, no Edit button**: matches Apple Reminders
+  UX. `.onMove` and `.contextMenu` coexist on the same row — SwiftUI
+  distinguishes by gesture duration.
+- **Integer renumbering on every move**: simple, no precision
+  degradation. The habit list is small enough that renumbering all
+  items in a section is effectively free.
+- **`HabitSortOrder` as a namespace enum**: follows `CompletionToggler`
+  pattern — free functions on a caseless enum, not a protocol. No DI
+  needed since the logic is trivial.
+- **Backup format unchanged**: `sortOrder` not added to
+  `HabitBackup`. Imported habits get `sortOrder = 0` and cluster at
+  the top. Acceptable for now; can be added later without a breaking
+  format change since `Codable` handles missing keys with defaults.
+
+## Surprises and how we handled them
+
+### `.onMove` section-to-global index mapping
+
+- **What happened**: moving a habit within a section requires
+  renumbering the full global ordering, not just the section. The
+  naive approach of renumbering only the moved section would leave
+  gaps or collisions with the other section's sort orders.
+- **What we did**: the `moveHabits` handler rebuilds the full
+  `[due + other]` array with the moved section spliced in, then
+  assigns sequential `sortOrder = index` to every habit.
+- **Lesson**: when a global ordering is split into filtered sections
+  for display, any section-local mutation needs to reconcile back to
+  the global state.
+
+### Test expectation mismatch on `Array.move`
+
+- **What happened**: initial test expectations for `reorder` assumed
+  the array values would shift (thinking about "what position does
+  value X end up at"), but `Array.move(fromOffsets:toOffset:)` moves
+  elements by index position. `[0,1,2,3,4]` moving index 2 to 0
+  becomes `[2,0,1,3,4]`, not `[1,2,0,3,4]`.
+- **What we did**: ran the test, observed actual output, corrected
+  expectations.
+- **Lesson**: matches the CLAUDE.md advice — don't hand-compute
+  expected values, run once and paste actuals.
+
+## What worked well
+
+- **Schema bump checklist in CLAUDE.md**: the documented list of files
+  to update made the V3→V4 bump mechanical. No files missed.
+- **TDD cycle**: writing `HabitSortOrderTests` before implementation
+  caught the `Array.move` semantics confusion immediately.
+- **Small commits per task**: 6 implementation commits, each green.
+  Easy to bisect if needed.
+
+## For the next person
+
+- **`moveHabits` renumbers all active habits on every drag**: this is
+  O(n) writes per move. Fine for tens of habits, would need batching
+  or dirty-tracking if the list grew to hundreds (unlikely for a
+  habit tracker).
+- **Migrated habits all get `sortOrder = 0`**: the list order for
+  pre-V4 users is undefined until they drag-reorder. In practice
+  SwiftData returns them in insertion order when all sort keys are
+  equal, so the visual result is usually the same as before.
+- **Backup import doesn't preserve sort order**: imported habits get
+  `sortOrder = 0`. A future backup format version could include it.
+
+## Generalizable lessons
+
+- **[local]** Section-filtered `.onMove` needs a global reconciliation
+  step. Not a general pattern, specific to this split-list design.
+- **[→ ROADMAP.md]** Backup format could include `sortOrder` in a
+  future version for lossless round-trip.
+
+## Metrics
+
+- Tasks completed: 6 of 6
+- Tests added: 7 (sort order) + 2 (schema V4 migration + version)
+- Commits: 8 (2 docs + 6 implementation)
+- Files touched: 22

--- a/docs/plans/2026-05/habit-reorder/plan.md
+++ b/docs/plans/2026-05/habit-reorder/plan.md
@@ -1,0 +1,161 @@
+# Plan — Habit reordering
+
+**Date**: 2026-05-04
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+
+## Summary
+
+Add a `sortOrder: Int` field to `HabitRecord` (schema V4) and enable
+drag-to-reorder in the Today view via long-press-drag (no edit mode).
+The sort order is global — a habit's position is stable regardless of
+which day it is or which section it falls into. Resolves issue #48.
+
+## Decisions locked in
+
+- Direct long-press-drag interaction (no Edit button / EditMode).
+- Global `sortOrder` — one flat ordering across sections.
+- Integer renumbering on move (not fractional).
+- Custom migration V3→V4 to backfill sequential values from `createdAt`.
+- New habits get `sortOrder = max(existing) + 1`.
+
+## Task list
+
+### Task 1: Schema V4 — add `sortOrder` field
+
+**Goal**: Create `KadoSchemaV4` with the new field and wire the
+migration plan.
+
+**Changes**:
+- `Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV4.swift` (new)
+- `Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoMigrationPlan.swift`
+- Move `HabitRecord` / `CompletionRecord` typealiases to V4
+- `Packages/KadoCore/Sources/KadoCore/Models/Habit.swift` — add `sortOrder: Int`
+- `SharedStore.productionContainer()` and `DevModeController.makeDevContainer()` — bump schema
+- Update `HabitRecord.snapshot` to include `sortOrder`
+
+**Tests / verification**:
+- `KadoSchemaTests.v4Version` — schema version resolves
+- `CloudKitShapeTests` — `sortOrder` has default, no unique constraint
+- V3→V4 migration regression test (custom stage assigns sequential values)
+- Existing tests still compile and pass
+
+**Commit message (suggested)**: `feat(schema): add sortOrder field to HabitRecord (V4)`
+
+---
+
+### Task 2: Sort order assignment logic
+
+**Goal**: Extract a reusable helper that handles assigning sort order
+on creation and renumbering on move.
+
+**Changes**:
+- `Packages/KadoCore/Sources/KadoCore/Services/HabitSortOrderManager.swift` (new) — protocol + default impl with:
+  - `nextSortOrder(in context:) -> Int`
+  - `move(habit:from:to:in habits:)` — renumbers affected items
+
+**Tests / verification**:
+- `KadoTests/HabitSortOrderManagerTests.swift`:
+  - `@Test("nextSortOrder returns max + 1")`
+  - `@Test("nextSortOrder returns 0 when no habits exist")`
+  - `@Test("move from index 2 to 0 renumbers correctly")`
+  - `@Test("move from index 0 to 2 renumbers correctly")`
+  - `@Test("move to same index is a no-op")`
+
+**Commit message (suggested)**: `feat(sort-order): add HabitSortOrderManager with tests`
+
+---
+
+### Task 3: Wire sort order into Today view
+
+**Goal**: Change the Today view to sort by `sortOrder` and enable
+drag-to-reorder.
+
+**Changes**:
+- `Kado/Views/Today/TodayView.swift`:
+  - Change `@Query` sort to `\.sortOrder`
+  - Add `.onMove` to both `ForEach` blocks
+  - Implement move handler that calls `HabitSortOrderManager`
+- `Kado/Views/Today/TodayView.swift` or environment: inject
+  `HabitSortOrderManager` if needed (or use inline since it's simple)
+
+**Tests / verification**:
+- Manual: launch in simulator, long-press-drag a habit, confirm it
+  moves and persists position after app restart
+- `screenshot` before and after a reorder
+- Context menu still works (no regression)
+
+**Commit message (suggested)**: `feat(today): enable drag-to-reorder habits`
+
+---
+
+### Task 4: Wire sort order into new habit creation
+
+**Goal**: New habits appear at the bottom of the list.
+
+**Changes**:
+- `Kado/Views/NewHabit/NewHabitFormModel.swift` or the save call site —
+  assign `sortOrder = nextSortOrder(in: context)` when creating a new
+  `HabitRecord`
+
+**Tests / verification**:
+- Create a new habit, confirm it appears last
+- Existing habits keep their order
+
+**Commit message (suggested)**: `feat(new-habit): assign sortOrder on creation`
+
+---
+
+### Task 5: Update widget snapshot ordering
+
+**Goal**: Widget displays habits in user-defined order.
+
+**Changes**:
+- `Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift` —
+  change `FetchDescriptor` sort from `\.createdAt` to `\.sortOrder`
+
+**Tests / verification**:
+- `WidgetSnapshotBuilderTests` — verify output order matches `sortOrder`
+- Widget preview shows correct order
+
+**Commit message (suggested)**: `fix(widget): respect user sort order in snapshot`
+
+---
+
+### Task 6: Update remaining fetch sites
+
+**Goal**: Every place that lists habits respects the new order.
+
+**Changes**:
+- `HabitEntity.fetchSuggestions` (App Intents) — sort by `sortOrder`
+- Any other `FetchDescriptor` or `@Query` that sorts by `createdAt`
+  for display purposes (grep and fix)
+
+**Tests / verification**:
+- `CompleteHabitIntentTests` — suggestions appear in sort order
+- Full `test_sim` pass
+
+**Commit message (suggested)**: `fix(intents): respect sort order in habit suggestions`
+
+---
+
+## Risks and mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Custom migration fails with CloudKit container | Test with both `.none` and `.private` configurations. If custom stage can't run with CloudKit, fall back to a "lazy backfill on first launch" in the app delegate. |
+| `.onMove` conflicts with `.contextMenu` on same row | SwiftUI handles this natively — context menu fires on short long-press, drag fires on longer hold. Verify in simulator. |
+| Two devices reorder simultaneously → conflict | Accept last-writer-wins. Document in compound if it causes UX issues. |
+
+## Open questions
+
+- [ ] Should the Overview tab also respect `sortOrder`? (Likely yes,
+      but confirm during build.)
+
+## Out of scope
+
+- Reordering archived habits (they don't appear in Today).
+- Section-level reordering (e.g. moving "Not scheduled" above
+  "Scheduled").
+- Drag between sections (section membership is frequency-driven).
+- Animated reorder feedback beyond SwiftUI's default List animation.

--- a/docs/plans/2026-05/habit-reorder/research.md
+++ b/docs/plans/2026-05/habit-reorder/research.md
@@ -1,0 +1,146 @@
+# Research — Habit reordering
+
+**Date**: 2026-05-04
+**Status**: ready for plan
+**Related**: [Issue #48](https://github.com/scastiel/kado/issues/48), `docs/ROADMAP.md`
+
+## Problem
+
+Users expect to control the display order of their habits in the Today
+view. The only current sort is `createdAt` ascending — the user cannot
+move a newly created habit above an older one, or group related habits
+together. Long-press already triggers a context menu, so drag-to-reorder
+feels like the natural missing interaction.
+
+## Current state of the codebase
+
+- **Today view** (`Kado/Views/Today/TodayView.swift`): uses
+  `@Query(sort: \HabitRecord.createdAt)` to fetch active habits. The
+  list splits into "Scheduled" and "Not scheduled today" sections via
+  Swift-side filtering. No `EditMode`, no `.onMove`, no drag support.
+- **HabitRecord** (`KadoSchemaV3`): no sort-order field. Current
+  properties: `id`, `name`, `frequencyData`, `typeData`, `createdAt`,
+  `archivedAt`, `colorRaw`, `icon`, reminder fields, `completions`.
+- **Domain Habit struct** (`Packages/KadoCore/.../Habit.swift`): no
+  sort-order field.
+- **WidgetSnapshotBuilder**: fetches with `sortBy: [SortDescriptor(\.createdAt)]`
+  — would need updating to respect the new order.
+- **Context menu**: lives in `HabitRowView` via `.contextMenu { }`.
+  Does not conflict with drag handles — SwiftUI's `List` supports both
+  simultaneously.
+- **Schema**: currently V3, migration plan uses lightweight stages only.
+
+## Proposed approach
+
+Add a persisted `sortOrder: Int` field to `HabitRecord` (V4 schema) and
+use SwiftUI's built-in `ForEach` + `.onMove` to enable drag-to-reorder.
+
+### Key components
+
+- **KadoSchemaV4**: new schema version with `sortOrder: Int = 0` on
+  `HabitRecord`. Lightweight migration (new field has a default).
+- **Migration backfill**: a `.custom` migration stage that assigns
+  sequential `sortOrder` values based on existing `createdAt` order,
+  so existing users keep their current order.
+- **Habit domain struct**: add `sortOrder: Int` field.
+- **TodayView**: change `@Query` sort to `\.sortOrder`, add `.onMove`
+  modifier on `ForEach` within each section.
+- **WidgetSnapshotBuilder**: update `FetchDescriptor` to sort by
+  `\.sortOrder`.
+- **New habit creation**: assign `sortOrder = max(existing) + 1` so new
+  habits appear at the bottom by default.
+
+### Data model changes
+
+```swift
+// KadoSchemaV4.HabitRecord (additions)
+public var sortOrder: Int = 0
+```
+
+Lightweight migration won't assign sequential values (all existing
+habits get `sortOrder = 0`), so we use a `.custom` stage to:
+1. Fetch all habits sorted by `createdAt`.
+2. Assign `sortOrder = index` to each.
+
+### UI changes
+
+- **TodayView**: add `@Environment(\.editMode)` support. Use an Edit
+  button in the toolbar (or long-press-drag without edit mode if
+  possible). Add `.onMove` to `ForEach` in both sections.
+- **Reorder logic**: when the user moves a habit, renumber `sortOrder`
+  values for affected items and save. Keep ordering per-section — the
+  user reorders within "Scheduled" and within "Not scheduled"
+  independently, both backed by the single `sortOrder` field.
+- **Context menu**: unchanged — `.contextMenu` and `.onMove` coexist
+  in SwiftUI Lists.
+
+### Tests to write
+
+```swift
+@Test("New habit gets sortOrder = max + 1")
+func newHabitSortOrder() { ... }
+
+@Test("Moving habit from index 2 to 0 renumbers correctly")
+func moveHabitUp() { ... }
+
+@Test("Custom migration assigns sequential sortOrder from createdAt")
+func v3ToV4Migration() { ... }
+
+@Test("CloudKit shape: sortOrder is non-unique, has default")
+func cloudKitShape() { ... }
+```
+
+## Alternatives considered
+
+### Alternative A: Sort by `createdAt`, allow editing `createdAt`
+
+- Idea: Reuse the existing sort field. Let the user "fake" a creation
+  date to reorder.
+- Why not: Destroys meaningful data (actual creation date), confusing
+  UX, breaks streaks that depend on `createdAt`.
+
+### Alternative B: Fractional ordering (e.g. `sortOrder: Double`)
+
+- Idea: Insert between two items by averaging their sort values. No
+  renumbering needed.
+- Why not: Precision degrades over time with many reorders. Simpler to
+  just renumber integers — the list is small (tens, not thousands).
+
+### Alternative C: Linked-list ordering (prev/next pointers)
+
+- Idea: Each habit points to the next.
+- Why not: Overkill for a flat list. Harder to query, harder to sync
+  with CloudKit, impossible to use as a SwiftData sort descriptor.
+
+## Risks and unknowns
+
+- **`.onMove` within sectioned Lists**: SwiftUI supports this, but the
+  move indices are section-relative. Need to map back to the global
+  `sortOrder` correctly.
+- **Cross-section moves**: should the user be able to drag a habit from
+  "Not scheduled" to "Scheduled"? Probably not — section membership is
+  frequency-driven, not user-controlled. `.onMove` is per-`ForEach`, so
+  this is naturally prevented.
+- **CloudKit sync conflicts**: two devices reordering simultaneously
+  could conflict. CloudKit last-writer-wins on `sortOrder` is
+  acceptable — worst case the order on one device "resets" to the
+  other's, which the user can fix.
+- **Custom migration**: first non-lightweight migration in the project.
+  Need to verify the custom stage runs correctly with the CloudKit
+  container configuration.
+
+## Open questions
+
+- [ ] Should drag-to-reorder require entering an explicit Edit Mode
+      (toolbar Edit button), or should it work via long-press-drag
+      directly (like Apple Reminders)?
+- [ ] Should the sort order be global (one flat ordering for all
+      habits) or per-section (separate order for "due today" vs
+      "not due")? A global order is simpler and means the habit
+      keeps its relative position regardless of which day it is.
+
+## References
+
+- [SwiftUI List onMove](https://developer.apple.com/documentation/swiftui/foreach/onmove(perform:))
+- [SwiftData VersionedSchema](https://developer.apple.com/documentation/swiftdata/schemamigrationplan)
+- [Issue #48](https://github.com/scastiel/kado/issues/48)


### PR DESCRIPTION
## Why?
- Users expect to control the display order of habits in the Today view (issue #48)
- Currently habits are sorted by creation date with no way to reorder

## What?
- Drag-to-reorder habits via long-press-drag in the Today view (both sections)
- New habits appear at the bottom of the list
- Order is respected everywhere: Today, Overview, widgets, App Intents suggestions

## How?
- New `sortOrder: Int` field on `HabitRecord` (schema V4, lightweight migration from V3)
- `HabitSortOrder` helper for next-order assignment and reorder logic
- `.onMove` on both `ForEach` sections, global renumbering on each move
- All `@Query` and `FetchDescriptor` sort references updated from `createdAt` to `sortOrder`

## Next steps
- Backup format could include `sortOrder` for lossless import/export round-trips
- Verify drag interaction coexists cleanly with context menu on device

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)