### PR TITLE
fix(sync): surface CloudKit failures in Settings + fix iPad crash on sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,17 @@ repo. Guard against that with an explicit
   6. Domain `Habit` struct (`Packages/KadoCore/Sources/KadoCore/Models/Habit.swift`)
      — add the new fields with defaults so existing call sites keep
      compiling. The `@Model`'s `snapshot` must map them through.
+  7. **Deploy the schema to CloudKit Production before the next
+     TestFlight / App Store build ships.** Run a dev build once so
+     the new record fields materialize in the Development
+     environment, then *Deploy Schema Changes* in
+     [CloudKit Console](https://icloud.developer.apple.com/dashboard)
+     for `iCloud.dev.scastiel.kado`. Dev builds talk to Development,
+     App Store builds talk to Production — skipping this step makes
+     sync silently fail for every production user while working
+     perfectly in development (issue #52, two App Store reviews).
+     This is a manual console step; flag it in the PR's "Next steps"
+     whenever a schema version bumps.
 - Queries: prefer `@Query` in simple views, explicit descriptor + fetch
   in services for complex logic.
 - CloudKit-shape from day one: every property has a default value or

--- a/Kado/App/RemindersSync.swift
+++ b/Kado/App/RemindersSync.swift
@@ -15,7 +15,7 @@ enum RemindersSync {
         let habits = (try? context.fetch(FetchDescriptor<HabitRecord>())) ?? []
         let completions = (try? context.fetch(FetchDescriptor<CompletionRecord>())) ?? []
         let habitSnapshots = habits.map(\.snapshot)
-        let completionSnapshots = completions.map(\.snapshot)
+        let completionSnapshots = completions.compactMap(\.snapshot)
         Task.detached { [habitSnapshots, completionSnapshots] in
             await scheduler.rescheduleAll(
                 habits: habitSnapshots,

--- a/Kado/Preview Content/MockCloudAccountStatusObserver.swift
+++ b/Kado/Preview Content/MockCloudAccountStatusObserver.swift
@@ -10,9 +10,14 @@ import KadoCore
 @Observable
 final class MockCloudAccountStatusObserver: CloudAccountStatusObserving {
     var status: CloudAccountStatus
+    var syncHealth: CloudSyncHealth
 
-    init(status: CloudAccountStatus = .couldNotDetermine) {
+    init(
+        status: CloudAccountStatus = .couldNotDetermine,
+        syncHealth: CloudSyncHealth = .unknown
+    ) {
         self.status = status
+        self.syncHealth = syncHealth
     }
 
     func refresh() async {

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -500,6 +500,12 @@
             "state" : "new",
             "value" : "%1$lld/%2$lld"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$lld/%2$lld"
+          }
         }
       }
     },
@@ -1572,6 +1578,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "iCloud est temporairement indisponible"
+          }
+        }
+      }
+    },
+    "iCloud sync isn’t working" : {
+      "comment" : "Settings iCloud row title shown when CloudKit sync events fail despite the account being signed in.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La synchronisation iCloud ne fonctionne pas"
           }
         }
       }
@@ -3478,6 +3495,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ta grille d'habitudes sur les sept derniers jours."
+          }
+        }
+      }
+    },
+    "Your habits are safe on this device, but recent changes aren’t reaching iCloud." : {
+      "comment" : "Settings iCloud row subtitle shown when CloudKit sync events fail; reassures that data is safe locally.",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tes habitudes sont en sécurité sur cet appareil, mais les modifications récentes n'atteignent pas iCloud."
           }
         }
       }

--- a/Kado/Services/CloudAccountStatusObserving.swift
+++ b/Kado/Services/CloudAccountStatusObserving.swift
@@ -14,6 +14,12 @@ import KadoCore
 protocol CloudAccountStatusObserving: AnyObject, Observable {
     var status: CloudAccountStatus { get }
 
+    /// Whether sync is actually working, derived from
+    /// `NSPersistentCloudKitContainer`'s finished sync events. An
+    /// `.available` account with `.failing` health means data is NOT
+    /// reaching iCloud — the UI must not claim "Syncing with iCloud".
+    var syncHealth: CloudSyncHealth { get }
+
     /// Re-query the backing provider. The default observer also
     /// refreshes automatically on `.CKAccountChanged` notifications;
     /// this method is the manual hook for tests and first-launch

--- a/Kado/Services/CloudSyncHealth.swift
+++ b/Kado/Services/CloudSyncHealth.swift
@@ -1,0 +1,54 @@
+import CloudKit
+import Foundation
+
+/// Whether CloudKit sync is actually moving data, as opposed to the
+/// account merely being signed in. `CKContainer.accountStatus()` says
+/// nothing about sync health — an App Store build pointed at a
+/// CloudKit Production environment with no deployed schema reports
+/// `.available` while every import/export fails (issue #52). This
+/// state is derived from `NSPersistentCloudKitContainer`'s finished
+/// sync events instead.
+nonisolated enum CloudSyncHealth: Equatable, Sendable {
+    /// No sync event has finished yet (fresh launch, or sync never
+    /// attempted). The UI treats this as healthy-until-proven-otherwise.
+    case unknown
+
+    /// The most recent finished sync event succeeded.
+    case healthy
+
+    /// The most recent finished sync event failed for a reason that
+    /// won't resolve on its own (schema mismatch, quota exceeded,
+    /// bad container…). Surfaced in Settings so "Syncing with iCloud"
+    /// is never shown while sync is broken.
+    case failing
+}
+
+/// Pure mapping from a finished `NSPersistentCloudKitContainer.Event`
+/// outcome to a `CloudSyncHealth`. Kept as a free-standing enum (no
+/// CloudKit event dependency) so the rules are unit-testable —
+/// `NSPersistentCloudKitContainer.Event` has no public initializer.
+nonisolated enum CloudSyncEventAssessor {
+    /// Transient conditions that recover without user or developer
+    /// action; they keep the previous assessment instead of flagging
+    /// sync as broken while the user rides the subway.
+    private static let transientCodes: Set<CKError.Code> = [
+        .networkUnavailable,
+        .networkFailure,
+        .serviceUnavailable,
+        .requestRateLimited,
+        .zoneBusy,
+        .accountTemporarilyUnavailable,
+    ]
+
+    static func health(
+        after current: CloudSyncHealth,
+        succeeded: Bool,
+        error: Error?
+    ) -> CloudSyncHealth {
+        if succeeded { return .healthy }
+        if let ckError = error as? CKError, transientCodes.contains(ckError.code) {
+            return current
+        }
+        return .failing
+    }
+}

--- a/Kado/Services/DefaultCloudAccountStatusObserver.swift
+++ b/Kado/Services/DefaultCloudAccountStatusObserver.swift
@@ -1,4 +1,5 @@
 import CloudKit
+import CoreData
 import Foundation
 import Observation
 import KadoCore
@@ -40,9 +41,11 @@ nonisolated final class DefaultCKAccountStatusProvider: CKAccountStatusProviding
 @Observable
 final class DefaultCloudAccountStatusObserver: CloudAccountStatusObserving {
     private(set) var status: CloudAccountStatus = .couldNotDetermine
+    private(set) var syncHealth: CloudSyncHealth = .unknown
 
     @ObservationIgnored private let provider: any CKAccountStatusProviding
     @ObservationIgnored private var observerTask: Task<Void, Never>?
+    @ObservationIgnored private var syncEventTask: Task<Void, Never>?
 
     init(provider: any CKAccountStatusProviding = DefaultCKAccountStatusProvider()) {
         self.provider = provider
@@ -52,10 +55,34 @@ final class DefaultCloudAccountStatusObserver: CloudAccountStatusObserving {
                 await self.refresh()
             }
         }
+        // SwiftData's CloudKit mirroring is NSPersistentCloudKitContainer
+        // under the hood, so its sync events flow through the same
+        // notification. Only finished events (endDate set) carry a
+        // success/failure verdict.
+        self.syncEventTask = Task { [weak self] in
+            let eventNotifications = NotificationCenter.default.notifications(
+                named: NSPersistentCloudKitContainer.eventChangedNotification
+            )
+            for await notification in eventNotifications {
+                guard let self else { break }
+                guard
+                    let event = notification.userInfo?[
+                        NSPersistentCloudKitContainer.eventNotificationUserInfoKey
+                    ] as? NSPersistentCloudKitContainer.Event,
+                    event.endDate != nil
+                else { continue }
+                self.syncHealth = CloudSyncEventAssessor.health(
+                    after: self.syncHealth,
+                    succeeded: event.succeeded,
+                    error: event.error
+                )
+            }
+        }
     }
 
     deinit {
         observerTask?.cancel()
+        syncEventTask?.cancel()
     }
 
     func refresh() async {

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -25,7 +25,7 @@ struct HabitDetailView: View {
     private var isArchived: Bool { habit.archivedAt != nil }
 
     private var trackingSinceLabel: String? {
-        let comps = (habit.completions ?? []).map(\.snapshot)
+        let comps = (habit.completions ?? []).compactMap(\.snapshot)
         let effective = habit.snapshot.effectiveStart(completions: comps, calendar: calendar)
         let createdDay = calendar.startOfDay(for: habit.createdAt)
         let effectiveDay = calendar.startOfDay(for: effective)
@@ -45,7 +45,7 @@ struct HabitDetailView: View {
                 quickLogSection
                 MonthlyCalendarView(
                     habit: habit.snapshot,
-                    completions: (habit.completions ?? []).map(\.snapshot),
+                    completions: (habit.completions ?? []).compactMap(\.snapshot),
                     month: $displayedMonth,
                     selectedDay: isArchived ? .constant(nil) : $editingDay,
                     navigable: true,
@@ -329,7 +329,7 @@ struct HabitDetailView: View {
     private var scorePercent: String {
         let score = scoreCalculator.currentScore(
             for: habit.snapshot,
-            completions: (habit.completions ?? []).map(\.snapshot),
+            completions: (habit.completions ?? []).compactMap(\.snapshot),
             asOf: .now
         )
         return "\(Int((score * 100).rounded()))%"
@@ -338,7 +338,7 @@ struct HabitDetailView: View {
     private var currentStreak: Int {
         streakCalculator.current(
             for: habit.snapshot,
-            completions: (habit.completions ?? []).map(\.snapshot),
+            completions: (habit.completions ?? []).compactMap(\.snapshot),
             asOf: .now
         )
     }
@@ -346,7 +346,7 @@ struct HabitDetailView: View {
     private var bestStreak: Int {
         streakCalculator.best(
             for: habit.snapshot,
-            completions: (habit.completions ?? []).map(\.snapshot),
+            completions: (habit.completions ?? []).compactMap(\.snapshot),
             asOf: .now
         )
     }

--- a/Kado/Views/Overview/OverviewView.swift
+++ b/Kado/Views/Overview/OverviewView.swift
@@ -87,7 +87,7 @@ struct OverviewView: View {
         let today = calendar.startOfDay(for: now)
         let days = dayRange(endingAt: today)
         let snapshots = records.map { record -> (Habit, [Completion]) in
-            (record.snapshot, (record.completions ?? []).map(\.snapshot))
+            (record.snapshot, (record.completions ?? []).compactMap(\.snapshot))
         }
         let habits = snapshots.map(\.0)
         let completions = snapshots.flatMap(\.1)

--- a/Kado/Views/Settings/SyncStatusSection.swift
+++ b/Kado/Views/Settings/SyncStatusSection.swift
@@ -16,6 +16,8 @@ struct SyncStatusSection: View {
         Section("iCloud") {
             if isDevMode {
                 devModePausedRow
+            } else if observer.status == .available && observer.syncHealth == .failing {
+                syncFailingRow
             } else {
                 row(for: observer.status)
                 if showsSettingsLink(for: observer.status) {
@@ -30,6 +32,27 @@ struct SyncStatusSection: View {
             }
         }
         .listRowBackground(Color.kadoBackgroundSecondary)
+    }
+
+    private var syncFailingRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "exclamationmark.icloud.fill")
+                .font(.title3)
+                .foregroundStyle(.orange)
+                .frame(width: 28)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("iCloud sync isn’t working")
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                Text("Your habits are safe on this device, but recent changes aren’t reaching iCloud.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.vertical, 2)
+        .accessibilityElement(children: .combine)
     }
 
     private var devModePausedRow: some View {
@@ -152,8 +175,18 @@ struct SyncStatusSection: View {
     SyncStatusPreview(status: .couldNotDetermine)
 }
 
+#Preview("Sync failing") {
+    SyncStatusPreview(status: .available, syncHealth: .failing)
+}
+
+#Preview("Sync failing — Dark") {
+    SyncStatusPreview(status: .available, syncHealth: .failing)
+        .preferredColorScheme(.dark)
+}
+
 private struct SyncStatusPreview: View {
     let status: CloudAccountStatus
+    var syncHealth: CloudSyncHealth = .unknown
 
     var body: some View {
         NavigationStack {
@@ -162,6 +195,9 @@ private struct SyncStatusPreview: View {
             }
             .navigationTitle("Settings")
         }
-        .environment(\.cloudAccountStatus, MockCloudAccountStatusObserver(status: status))
+        .environment(
+            \.cloudAccountStatus,
+            MockCloudAccountStatusObserver(status: status, syncHealth: syncHealth)
+        )
     }
 }

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -144,7 +144,7 @@ struct TodayView: View {
     @ViewBuilder
     private func row(_ record: HabitRecord) -> some View {
         let snap = record.snapshot
-        let comps = (record.completions ?? []).map(\.snapshot)
+        let comps = (record.completions ?? []).compactMap(\.snapshot)
         let state = HabitRowState.resolve(
             habit: snap,
             completions: comps,
@@ -202,7 +202,7 @@ struct TodayView: View {
     /// the row should stay visible with its tick even once the
     /// daysPerWeek rolling quota saturates).
     private func isDueTodayOrCompletedToday(_ record: HabitRecord, on now: Date) -> Bool {
-        let completions = (record.completions ?? []).map(\.snapshot)
+        let completions = (record.completions ?? []).compactMap(\.snapshot)
         if frequencyEvaluator.isDue(habit: record.snapshot, on: now, completions: completions) {
             return true
         }
@@ -314,7 +314,7 @@ struct TodayView: View {
 
     private func checkMilestones(for record: HabitRecord) {
         let snap = record.snapshot
-        let comps = (record.completions ?? []).map(\.snapshot)
+        let comps = (record.completions ?? []).compactMap(\.snapshot)
         let streak = streakCalculator.current(for: snap, completions: comps, asOf: .now)
         if streak == 7 || streak == 30 {
             reviewPromptService.recordMilestone(.streak(days: streak))
@@ -322,7 +322,7 @@ struct TodayView: View {
 
         let allComplete = habitsDueToday.allSatisfy { habit in
             let s = habit.snapshot
-            let c = (habit.completions ?? []).map(\.snapshot)
+            let c = (habit.completions ?? []).compactMap(\.snapshot)
             return HabitRowState.resolve(habit: s, completions: c, calendar: calendar, asOf: .now).status == .complete
         }
         if allComplete {

--- a/KadoTests/CloudSyncHealthTests.swift
+++ b/KadoTests/CloudSyncHealthTests.swift
@@ -1,0 +1,67 @@
+import CloudKit
+import Testing
+@testable import Kado
+
+struct CloudSyncHealthTests {
+    @Test("a finished event that succeeded reports healthy")
+    func successIsHealthy() {
+        #expect(CloudSyncEventAssessor.health(after: .unknown, succeeded: true, error: nil) == .healthy)
+    }
+
+    @Test("a succeeded event recovers from a previous failure")
+    func successRecoversFromFailing() {
+        #expect(CloudSyncEventAssessor.health(after: .failing, succeeded: true, error: nil) == .healthy)
+    }
+
+    @Test("a persistent CloudKit error reports failing")
+    func persistentErrorIsFailing() {
+        let error = CKError(.badContainer)
+        #expect(CloudSyncEventAssessor.health(after: .unknown, succeeded: false, error: error) == .failing)
+        #expect(CloudSyncEventAssessor.health(after: .healthy, succeeded: false, error: error) == .failing)
+    }
+
+    @Test("a partial failure (e.g. record type missing in Production) reports failing")
+    func partialFailureIsFailing() {
+        let error = CKError(.partialFailure)
+        #expect(CloudSyncEventAssessor.health(after: .healthy, succeeded: false, error: error) == .failing)
+    }
+
+    @Test(
+        "transient errors keep the previous assessment",
+        arguments: [
+            CKError.Code.networkUnavailable,
+            .networkFailure,
+            .serviceUnavailable,
+            .requestRateLimited,
+            .zoneBusy,
+            .accountTemporarilyUnavailable,
+        ]
+    )
+    func transientErrorKeepsCurrent(code: CKError.Code) {
+        let error = CKError(code)
+        #expect(CloudSyncEventAssessor.health(after: .healthy, succeeded: false, error: error) == .healthy)
+        #expect(CloudSyncEventAssessor.health(after: .unknown, succeeded: false, error: error) == .unknown)
+        #expect(CloudSyncEventAssessor.health(after: .failing, succeeded: false, error: error) == .failing)
+    }
+
+    @Test("a failed event with a non-CloudKit error reports failing")
+    func nonCKErrorIsFailing() {
+        struct Boom: Error {}
+        #expect(CloudSyncEventAssessor.health(after: .healthy, succeeded: false, error: Boom()) == .failing)
+    }
+
+    @Test("a failed event with no error still reports failing")
+    func nilErrorFailureIsFailing() {
+        #expect(CloudSyncEventAssessor.health(after: .healthy, succeeded: false, error: nil) == .failing)
+    }
+
+    @MainActor
+    @Test("observer starts with unknown sync health")
+    func observerInitialSyncHealth() {
+        struct SeededProvider: CKAccountStatusProviding {
+            func accountStatus() async throws -> CKAccountStatus { .available }
+        }
+        let observer = DefaultCloudAccountStatusObserver(provider: SeededProvider())
+        #expect(observer.syncHealth == .unknown)
+    }
+}

--- a/KadoTests/CompletionRecordTests.swift
+++ b/KadoTests/CompletionRecordTests.swift
@@ -17,7 +17,7 @@ struct CompletionRecordTests {
     }
 
     @Test("Snapshot projects fields and uses the parent's id as habitID")
-    func snapshotUsesParentID() {
+    func snapshotUsesParentID() throws {
         let habit = HabitRecord(name: "X", frequency: .daily, type: .binary)
         container.mainContext.insert(habit)
         let completion = CompletionRecord(
@@ -29,7 +29,7 @@ struct CompletionRecordTests {
         )
         container.mainContext.insert(completion)
 
-        let snapshot = completion.snapshot
+        let snapshot = try #require(completion.snapshot)
         #expect(snapshot.id == completion.id)
         #expect(snapshot.habitID == habit.id)
         #expect(snapshot.value == 0.75)
@@ -42,5 +42,31 @@ struct CompletionRecordTests {
         #expect(record.value == 1.0)
         #expect(record.note == nil)
         #expect(record.habit == nil)
+    }
+
+    // Regression for the iPad-on-load crash (issue #54): a CloudKit
+    // import delivers a CompletionRecord before its parent HabitRecord,
+    // so the optional `habit` inverse is transiently nil. `snapshot`
+    // used to force-unwrap `habit!`, trapping with EXC_BREAKPOINT the
+    // moment any view mapped over it. It must instead yield nil.
+    @Test("Snapshot is nil when the habit relationship is nil (mid-import / orphan)")
+    func snapshotNilWhenOrphaned() {
+        let orphan = CompletionRecord(date: .now, value: 1.0, habit: nil)
+        container.mainContext.insert(orphan)
+        #expect(orphan.snapshot == nil)
+    }
+
+    @Test("compactMap over mixed attached + orphaned completions drops orphans, no crash")
+    func compactMapDropsOrphans() {
+        let habit = HabitRecord(name: "X", frequency: .daily, type: .binary)
+        container.mainContext.insert(habit)
+        let attached = CompletionRecord(date: .now, value: 1.0, habit: habit)
+        let orphan = CompletionRecord(date: .now, value: 1.0, habit: nil)
+        container.mainContext.insert(attached)
+        container.mainContext.insert(orphan)
+
+        let snapshots = [attached, orphan].compactMap(\.snapshot)
+        #expect(snapshots.count == 1)
+        #expect(snapshots.first?.id == attached.id)
     }
 }

--- a/Packages/KadoCore/Sources/KadoCore/Models/Persistence/CompletionRecord.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Persistence/CompletionRecord.swift
@@ -4,9 +4,9 @@ import SwiftData
 public extension KadoSchemaV1 {
     /// Persistent representation of a single completion event.
     /// `habit` is optional because CloudKit forbids required
-    /// relationships — but a completion without a parent is a bug
-    /// (cascade delete should remove orphans), so `snapshot`
-    /// force-unwraps `habit?.id`.
+    /// relationships, and during a CloudKit import the inverse is
+    /// transiently nil while records arrive out of order, so
+    /// `snapshot` returns nil rather than force-unwrapping (issue #54).
     @Model
     public final class CompletionRecord {
         public var id: UUID = UUID()
@@ -29,13 +29,14 @@ public extension KadoSchemaV1 {
             self.habit = habit
         }
 
-        /// Pure value-type projection. Traps if the completion has no
-        /// parent habit — that state should not exist outside
-        /// transient CloudKit sync windows the app does not project from.
-        public var snapshot: Completion {
-            Completion(
+        /// Pure value-type projection, or nil when the parent `habit`
+        /// inverse isn't set (e.g. mid CloudKit import). Map with
+        /// `compactMap(\.snapshot)`.
+        public var snapshot: Completion? {
+            guard let habitID = habit?.id else { return nil }
+            return Completion(
                 id: id,
-                habitID: habit!.id,
+                habitID: habitID,
                 date: date,
                 value: value,
                 note: note

--- a/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV2.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV2.swift
@@ -120,10 +120,11 @@ public extension KadoSchemaV2 {
             self.habit = habit
         }
 
-        public var snapshot: Completion {
-            Completion(
+        public var snapshot: Completion? {
+            guard let habitID = habit?.id else { return nil }
+            return Completion(
                 id: id,
-                habitID: habit!.id,
+                habitID: habitID,
                 date: date,
                 value: value,
                 note: note

--- a/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV3.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV3.swift
@@ -132,10 +132,11 @@ public extension KadoSchemaV3 {
             self.habit = habit
         }
 
-        public var snapshot: Completion {
-            Completion(
+        public var snapshot: Completion? {
+            guard let habitID = habit?.id else { return nil }
+            return Completion(
                 id: id,
-                habitID: habit!.id,
+                habitID: habitID,
                 date: date,
                 value: value,
                 note: note

--- a/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV4.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Persistence/KadoSchemaV4.swift
@@ -124,10 +124,17 @@ public extension KadoSchemaV4 {
             self.habit = habit
         }
 
-        public var snapshot: Completion {
-            Completion(
+        /// Projects to a value-type `Completion`, or `nil` when the
+        /// `habit` inverse isn't set. The relationship is optional
+        /// because CloudKit forbids required ones — and during a
+        /// CloudKit import the inverse is transiently nil while records
+        /// arrive out of order, so callers must tolerate that rather
+        /// than force-unwrap (issue #54). Map with `compactMap(\.snapshot)`.
+        public var snapshot: Completion? {
+            guard let habitID = habit?.id else { return nil }
+            return Completion(
                 id: id,
-                habitID: habit!.id,
+                habitID: habitID,
                 date: date,
                 value: value,
                 note: note

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
@@ -30,7 +30,7 @@ public enum WidgetSnapshotBuilder {
         var statsByID: [UUID: HabitStats] = [:]
         for record in active {
             let snap = record.snapshot
-            let comps = (record.completions ?? []).map(\.snapshot)
+            let comps = (record.completions ?? []).compactMap(\.snapshot)
             statsByID[snap.id] = HabitStats(
                 current: streakCalculator.current(for: snap, completions: comps, asOf: reference),
                 best: streakCalculator.best(for: snap, completions: comps, asOf: reference),
@@ -74,7 +74,7 @@ public enum WidgetSnapshotBuilder {
         var completed = 0
         for record in active {
             let snap = record.snapshot
-            let comps = (record.completions ?? []).map(\.snapshot)
+            let comps = (record.completions ?? []).compactMap(\.snapshot)
             guard frequencyEvaluator.isDue(habit: snap, on: reference, completions: comps) else {
                 continue
             }
@@ -105,7 +105,7 @@ public enum WidgetSnapshotBuilder {
             calendar.date(byAdding: .day, value: -offset, to: today)
         }
         let habits = active.map(\.snapshot)
-        let allCompletions = active.flatMap { ($0.completions ?? []).map(\.snapshot) }
+        let allCompletions = active.flatMap { ($0.completions ?? []).compactMap(\.snapshot) }
         let matrix = OverviewMatrix.compute(
             habits: habits,
             completions: allCompletions,


### PR DESCRIPTION
Two CloudKit sync fixes surfaced by App Store feedback (#52) and by testing the Production sync end-to-end (#54).

Closes #54. Closes #52.

## Why?

- Two App Store reviews report iCloud sync not working — one *while Settings displayed sync as active* (#52).
- After deploying the schema to Production and syncing, the App Store build **crashed on launch on iPad** (#54) — confirmed from the device crash report, symbolicated against the build-8 dSYM.

## What?

**1. Honest sync status (#52).** Settings now shows an **"iCloud sync isn't working"** row (orange, with a "safe on this device" reassurance) when sync events persistently fail, instead of a false green "Syncing with iCloud" based only on account availability.

**2. Crash fix (#54) — `CompletionRecord.snapshot` force-unwrapped a nil parent.** `habit` is optional (CloudKit forbids required relationships), and `NSPersistentCloudKitContainer` imports records out of order, so a completion can arrive before its parent — `habit!` then trapped (`EXC_BREAKPOINT`). iPad-only-on-load because its split layout renders `HabitDetailView` (score/streak/calendar, all of which map completions) immediately while the import is still settling; the iPhone was the data source with intact relationships. Data is safe on disk — only the in-memory projection trapped.

Drive-by: missing FR translation for `%lld/%lld` (note character count), which was failing `LocalizationCoverageTests` on `main`.

## How?

- **Sync health:** new `CloudSyncHealth` + `CloudSyncEventAssessor` (pure mapping from finished `NSPersistentCloudKitContainer` events to healthy/failing). Transient errors (network, rate-limit, zone-busy) keep the prior state; persistent ones (schema mismatch, quota, bad container) flip to failing; any success recovers. `DefaultCloudAccountStatusObserver` observes `eventChangedNotification` alongside `.CKAccountChanged`. `SyncStatusSection` shows the failing row only when the account is `.available`.
- **Crash:** `CompletionRecord.snapshot` is now failable (`Completion?`, nil when the inverse isn't set) across all schema versions; the 15 call sites (`HabitDetailView`, `TodayView`, `OverviewView`, `WidgetSnapshotBuilder`, `RemindersSync`) switched to `.compactMap(\.snapshot)`. Not-yet-parented completions are skipped until the import hydrates the inverse and the view re-renders.
- Tests: 9 sync-health cases + 2 crash regression cases (nil-habit snapshot → nil, mixed compactMap drops orphans). 350/350 green on iPhone 17 Pro. Clean `build_sim` on iPhone 17 Pro and iPad Air 13" (M4).

## Next steps

- [ ] **Deploy the schema to CloudKit Production** for the *next* schema bump too — done manually for V4; now step 7 of the CLAUDE.md schema-bump checklist.
- The failing-sync row needs real failing CloudKit events to see live; verified via the "Sync failing" light/dark previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)