### PR TITLE
feat(csv-export): lossless CSV round-trip

### DIFF
--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -3985,6 +3985,108 @@
           }
         }
       }
+    },
+    "JSON" : {
+      "comment" : "Export format option in the Settings Data menu.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JSON"
+          }
+        }
+      }
+    },
+    "CSV" : {
+      "comment" : "Export format option in the Settings Data menu.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CSV"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CSV"
+          }
+        }
+      }
+    },
+    "Not a Kadō CSV export" : {
+      "comment" : "Alert title when an imported CSV isn't a Kadō export.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not a Kadō CSV export"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas un export CSV Kadō"
+          }
+        }
+      }
+    },
+    "The file couldn't be read as a Kadō CSV export. Check that its header row is intact." : {
+      "comment" : "Alert message when a CSV file fails to parse as a Kadō export.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The file couldn't be read as a Kadō CSV export. Check that its header row is intact."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le fichier n'a pas pu être lu comme un export CSV Kadō. Vérifie que sa ligne d'en-tête est intacte."
+          }
+        }
+      }
+    },
+    "Malformed row" : {
+      "comment" : "Alert title when a CSV row has the wrong column count.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Malformed row"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ligne mal formée"
+          }
+        }
+      }
+    },
+    "Line %lld doesn't have the expected number of columns." : {
+      "comment" : "Alert message naming the CSV line with a wrong column count.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line %lld doesn't have the expected number of columns."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La ligne %lld n'a pas le nombre de colonnes attendu."
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Kado/Views/Settings/BackupSection.swift
+++ b/Kado/Views/Settings/BackupSection.swift
@@ -367,6 +367,35 @@ private struct ShareSheet: UIViewControllerRepresentable {
         .preferredColorScheme(.dark)
 }
 
+/// The export format picker is a `Menu`, which a preview can't open,
+/// and the import alerts are driven by private `@State`. These two
+/// previews at least make the new CSV failure copy reviewable without
+/// running the app — the tap-driven simulator path is unavailable on
+/// this XcodeBuildMCP install (see CLAUDE.md).
+#Preview("CSV parse failure alert") {
+    Color.clear
+        .alert(
+            ImportFailure.invalidCSV.title,
+            isPresented: .constant(true)
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(ImportFailure.invalidCSV.message)
+        }
+}
+
+#Preview("Malformed row alert") {
+    Color.clear
+        .alert(
+            ImportFailure.malformedRow(line: 42).title,
+            isPresented: .constant(true)
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(ImportFailure.malformedRow(line: 42).message)
+        }
+}
+
 #Preview("Confirmation sheet") {
     Color.clear.sheet(isPresented: .constant(true)) {
         ImportConfirmSheet(

--- a/Kado/Views/Settings/BackupSection.swift
+++ b/Kado/Views/Settings/BackupSection.swift
@@ -25,8 +25,17 @@ struct BackupSection: View {
 
     var body: some View {
         Section("Data") {
-            Button {
-                performExport()
+            Menu {
+                Button {
+                    performExport(format: .json)
+                } label: {
+                    Label("JSON", systemImage: "curlybraces")
+                }
+                Button {
+                    performExport(format: .csv)
+                } label: {
+                    Label("CSV", systemImage: "tablecells")
+                }
             } label: {
                 Label("Export Data", systemImage: "square.and.arrow.up")
             }
@@ -46,7 +55,7 @@ struct BackupSection: View {
         .listRowBackground(Color.kadoBackgroundSecondary)
         .fileImporter(
             isPresented: $isShowingImporter,
-            allowedContentTypes: [.json]
+            allowedContentTypes: [.json, .commaSeparatedText]
         ) { result in
             handleFileImport(result)
         }
@@ -87,10 +96,20 @@ struct BackupSection: View {
         return formatter.string(from: date)
     }
 
-    private func performExport() {
+    private func performExport(format: BackupFormat) {
         do {
-            let data = try exporter.exportData(from: modelContext)
-            let filename = "kado-backup-\(Self.filenameDate(from: .now)).json"
+            let document = try exporter.export(from: modelContext)
+            let data: Data
+            switch format {
+            case .json:
+                data = try exporter.encode(document)
+            case .csv:
+                // The coder is a pure value type with no collaborators,
+                // so it's constructed here rather than injected — there
+                // is nothing to stub in a preview.
+                data = CSVBackupCoder().encode(document)
+            }
+            let filename = "kado-backup-\(Self.filenameDate(from: .now)).\(format.fileExtension)"
             let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
             try data.write(to: url, options: .atomic)
             lastExportAt = Date.now.timeIntervalSince1970
@@ -129,12 +148,27 @@ struct BackupSection: View {
                 return
             }
 
+            // The extension is a hint — some file providers rename on
+            // export — so fall back to sniffing the contents.
+            let format = BackupFormat.detect(pathExtension: url.pathExtension)
+                ?? BackupFormat.sniff(data)
+
             do {
-                let document = try importer.parse(data: data)
+                let document: BackupDocument
+                switch format {
+                case .json:
+                    document = try importer.parse(data: data)
+                case .csv:
+                    document = try CSVBackupCoder().decode(data)
+                }
                 let summary = try importer.summary(for: document, in: modelContext)
                 presentedSheet = .confirmImport(document: document, summary: summary)
             } catch BackupError.invalidJSON {
                 presentedAlert = .importFailed(.invalidJSON)
+            } catch BackupError.invalidCSV {
+                presentedAlert = .importFailed(.invalidCSV)
+            } catch BackupError.malformedRow(let line) {
+                presentedAlert = .importFailed(.malformedRow(line: line))
             } catch BackupError.unsupportedVersion {
                 presentedAlert = .importFailed(.unsupportedVersion)
             } catch {
@@ -263,12 +297,16 @@ private enum PresentedAlert: Identifiable {
 /// Why an import couldn't proceed.
 private enum ImportFailure {
     case invalidJSON
+    case invalidCSV
+    case malformedRow(line: Int)
     case unsupportedVersion
     case readFailed
 
     var id: String {
         switch self {
         case .invalidJSON: return "invalidJSON"
+        case .invalidCSV: return "invalidCSV"
+        case .malformedRow(let line): return "malformedRow-\(line)"
         case .unsupportedVersion: return "unsupportedVersion"
         case .readFailed: return "readFailed"
         }
@@ -277,6 +315,8 @@ private enum ImportFailure {
     var title: LocalizedStringKey {
         switch self {
         case .invalidJSON: return "Not a Kadō backup"
+        case .invalidCSV: return "Not a Kadō CSV export"
+        case .malformedRow: return "Malformed row"
         case .unsupportedVersion: return "Newer Kadō version"
         case .readFailed: return "Couldn't read file"
         }
@@ -286,6 +326,10 @@ private enum ImportFailure {
         switch self {
         case .invalidJSON:
             return "The file couldn't be decoded as a Kadō backup."
+        case .invalidCSV:
+            return "The file couldn't be read as a Kadō CSV export. Check that its header row is intact."
+        case .malformedRow(let line):
+            return "Line \(line) doesn't have the expected number of columns."
         case .unsupportedVersion:
             return "This backup was created by a newer Kadō version. Update Kadō to import."
         case .readFailed:

--- a/Kado/Views/Settings/BackupSection.swift
+++ b/Kado/Views/Settings/BackupSection.swift
@@ -14,13 +14,14 @@ struct BackupSection: View {
 
     @AppStorage("lastExportAt") private var lastExportAt: Double = 0
 
-    @State private var shareItem: ShareItem?
-    @State private var exportError: String?
-
     @State private var isShowingImporter = false
-    @State private var pendingImport: PendingImport?
-    @State private var importAlert: ImportAlert?
-    @State private var importSuccessSummary: ImportSummary?
+
+    // One slot each for the presented sheet and alert. The states are
+    // mutually exclusive, and stacking a modifier per case (this view
+    // was up to two sheets and three alerts) is how presentation stacks
+    // start dropping presentations — see the PR #16 compound.
+    @State private var presentedSheet: PresentedSheet?
+    @State private var presentedAlert: PresentedAlert?
 
     var body: some View {
         Section("Data") {
@@ -43,56 +44,36 @@ struct BackupSection: View {
             }
         }
         .listRowBackground(Color.kadoBackgroundSecondary)
-        .sheet(item: $shareItem) { item in
-            ShareSheet(activityItems: [item.url])
-                .ignoresSafeArea()
-        }
-        .alert("Export failed", isPresented: Binding(
-            get: { exportError != nil },
-            set: { if !$0 { exportError = nil } }
-        )) {
-            Button("OK", role: .cancel) { exportError = nil }
-        } message: {
-            if let exportError {
-                Text(exportError)
-            }
-        }
         .fileImporter(
             isPresented: $isShowingImporter,
             allowedContentTypes: [.json]
         ) { result in
             handleFileImport(result)
         }
-        .sheet(item: $pendingImport) { pending in
-            ImportConfirmSheet(
-                summary: pending.summary,
-                onCancel: { pendingImport = nil },
-                onConfirm: { commitImport(pending.document) }
-            )
+        .sheet(item: $presentedSheet) { sheet in
+            switch sheet {
+            case .share(let url):
+                ShareSheet(activityItems: [url])
+                    .ignoresSafeArea()
+            case .confirmImport(let document, let summary):
+                ImportConfirmSheet(
+                    summary: summary,
+                    onCancel: { presentedSheet = nil },
+                    onConfirm: { commitImport(document) }
+                )
+            }
         }
         .alert(
-            importAlert?.title ?? "",
+            presentedAlert?.title ?? "",
             isPresented: Binding(
-                get: { importAlert != nil },
-                set: { if !$0 { importAlert = nil } }
+                get: { presentedAlert != nil },
+                set: { if !$0 { presentedAlert = nil } }
             ),
-            presenting: importAlert
+            presenting: presentedAlert
         ) { _ in
-            Button("OK", role: .cancel) { importAlert = nil }
+            Button("OK", role: .cancel) { presentedAlert = nil }
         } message: { alert in
-            Text(alert.message)
-        }
-        .alert(
-            "Import complete",
-            isPresented: Binding(
-                get: { importSuccessSummary != nil },
-                set: { if !$0 { importSuccessSummary = nil } }
-            ),
-            presenting: importSuccessSummary
-        ) { _ in
-            Button("OK", role: .cancel) { importSuccessSummary = nil }
-        } message: { summary in
-            Text("Habits: \(summary.totalHabits) (\(summary.newHabits) new, \(summary.updatedHabits) updated)\nCompletions: \(summary.totalCompletions) (\(summary.newCompletions) new, \(summary.updatedCompletions) updated)")
+            alert.message
         }
     }
 
@@ -113,9 +94,9 @@ struct BackupSection: View {
             let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
             try data.write(to: url, options: .atomic)
             lastExportAt = Date.now.timeIntervalSince1970
-            shareItem = ShareItem(url: url)
+            presentedSheet = .share(url)
         } catch {
-            exportError = error.localizedDescription
+            presentedAlert = .exportFailed(error.localizedDescription)
         }
     }
 
@@ -135,7 +116,7 @@ struct BackupSection: View {
     private func handleFileImport(_ result: Result<URL, Error>) {
         switch result {
         case .failure:
-            importAlert = .readFailed
+            presentedAlert = .importFailed(.readFailed)
         case .success(let url):
             let didStartAccess = url.startAccessingSecurityScopedResource()
             defer { if didStartAccess { url.stopAccessingSecurityScopedResource() } }
@@ -144,20 +125,20 @@ struct BackupSection: View {
             do {
                 data = try Data(contentsOf: url)
             } catch {
-                importAlert = .readFailed
+                presentedAlert = .importFailed(.readFailed)
                 return
             }
 
             do {
                 let document = try importer.parse(data: data)
                 let summary = try importer.summary(for: document, in: modelContext)
-                pendingImport = PendingImport(document: document, summary: summary)
+                presentedSheet = .confirmImport(document: document, summary: summary)
             } catch BackupError.invalidJSON {
-                importAlert = .invalidJSON
+                presentedAlert = .importFailed(.invalidJSON)
             } catch BackupError.unsupportedVersion {
-                importAlert = .unsupportedVersion
+                presentedAlert = .importFailed(.unsupportedVersion)
             } catch {
-                importAlert = .readFailed
+                presentedAlert = .importFailed(.readFailed)
             }
         }
     }
@@ -165,12 +146,12 @@ struct BackupSection: View {
     private func commitImport(_ document: BackupDocument) {
         do {
             let summary = try importer.apply(document, to: modelContext)
-            pendingImport = nil
+            presentedSheet = nil
             WidgetReloader.reloadAll(using: modelContext)
-            importSuccessSummary = summary
+            presentedAlert = .importSucceeded(summary)
         } catch {
-            pendingImport = nil
-            importAlert = .readFailed
+            presentedSheet = nil
+            presentedAlert = .importFailed(.readFailed)
         }
     }
 }
@@ -227,18 +208,69 @@ private struct ImportConfirmSheet: View {
     }
 }
 
-// MARK: - Alert
+// MARK: - Presentation state
 
-private enum ImportAlert: Identifiable {
+/// Every sheet this section can present, in one slot.
+private enum PresentedSheet: Identifiable {
+    case share(URL)
+    case confirmImport(document: BackupDocument, summary: ImportSummary)
+
+    var id: String {
+        switch self {
+        case .share(let url): return "share-\(url.absoluteString)"
+        case .confirmImport: return "confirmImport"
+        }
+    }
+}
+
+/// Every alert this section can present, in one slot.
+private enum PresentedAlert: Identifiable {
+    case exportFailed(String)
+    case importFailed(ImportFailure)
+    case importSucceeded(ImportSummary)
+
+    var id: String {
+        switch self {
+        case .exportFailed: return "exportFailed"
+        case .importFailed(let failure): return "importFailed-\(failure.id)"
+        case .importSucceeded: return "importSucceeded"
+        }
+    }
+
+    var title: LocalizedStringKey {
+        switch self {
+        case .exportFailed: return "Export failed"
+        case .importFailed(let failure): return failure.title
+        case .importSucceeded: return "Import complete"
+        }
+    }
+
+    /// Returns `Text` rather than `LocalizedStringKey` so the dynamic
+    /// export-error description reaches the non-localizing initializer
+    /// while the fixed strings stay on the localized path.
+    var message: Text {
+        switch self {
+        case .exportFailed(let description):
+            return Text(description)
+        case .importFailed(let failure):
+            return Text(failure.message)
+        case .importSucceeded(let summary):
+            return Text("Habits: \(summary.totalHabits) (\(summary.newHabits) new, \(summary.updatedHabits) updated)\nCompletions: \(summary.totalCompletions) (\(summary.newCompletions) new, \(summary.updatedCompletions) updated)")
+        }
+    }
+}
+
+/// Why an import couldn't proceed.
+private enum ImportFailure {
     case invalidJSON
     case unsupportedVersion
     case readFailed
 
-    var id: Int {
+    var id: String {
         switch self {
-        case .invalidJSON: return 0
-        case .unsupportedVersion: return 1
-        case .readFailed: return 2
+        case .invalidJSON: return "invalidJSON"
+        case .unsupportedVersion: return "unsupportedVersion"
+        case .readFailed: return "readFailed"
         }
     }
 
@@ -260,23 +292,6 @@ private enum ImportAlert: Identifiable {
             return "The file couldn't be read. Try a different file."
         }
     }
-}
-
-// MARK: - Pending import
-
-private struct PendingImport: Identifiable {
-    let id = UUID()
-    let document: BackupDocument
-    let summary: ImportSummary
-}
-
-// MARK: - Share item
-
-/// Wraps a temp file URL in an `Identifiable` so SwiftUI's
-/// `.sheet(item:)` can present it as a one-shot share sheet.
-private struct ShareItem: Identifiable {
-    let id = UUID()
-    let url: URL
 }
 
 // MARK: - UIActivityViewController bridge

--- a/KadoTests/BackupFormatTests.swift
+++ b/KadoTests/BackupFormatTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+import UniformTypeIdentifiers
+@testable import Kado
+import KadoCore
+
+@Suite("BackupFormat")
+struct BackupFormatTests {
+    @Test("File extensions match the raw values")
+    func fileExtensions() {
+        #expect(BackupFormat.json.fileExtension == "json")
+        #expect(BackupFormat.csv.fileExtension == "csv")
+    }
+
+    @Test("Content types map to the system UTTypes")
+    func contentTypes() {
+        #expect(BackupFormat.json.contentType == .json)
+        #expect(BackupFormat.csv.contentType == .commaSeparatedText)
+    }
+
+    @Test("Detection from a path extension is case-insensitive")
+    func detectionIsCaseInsensitive() {
+        #expect(BackupFormat.detect(pathExtension: "csv") == .csv)
+        #expect(BackupFormat.detect(pathExtension: "CSV") == .csv)
+        #expect(BackupFormat.detect(pathExtension: "Json") == .json)
+    }
+
+    @Test("Unrecognized extension does not resolve")
+    func detectionFallsThrough() {
+        #expect(BackupFormat.detect(pathExtension: "txt") == nil)
+        #expect(BackupFormat.detect(pathExtension: "") == nil)
+    }
+
+    @Test("Sniffing finds JSON by its opening brace, skipping whitespace")
+    func sniffJSON() throws {
+        #expect(BackupFormat.sniff(Data(#"{"formatVersion":1}"#.utf8)) == .json)
+        #expect(BackupFormat.sniff(Data("\n  {\"a\":1}".utf8)) == .json)
+    }
+
+    @Test("Sniffing treats anything else, including empty input, as CSV")
+    func sniffCSV() {
+        #expect(BackupFormat.sniff(Data("format_version,habit_id\n".utf8)) == .csv)
+        #expect(BackupFormat.sniff(Data()) == .csv)
+    }
+}

--- a/KadoTests/BackupFormatTests.swift
+++ b/KadoTests/BackupFormatTests.swift
@@ -37,6 +37,15 @@ struct BackupFormatTests {
         #expect(BackupFormat.sniff(Data("\n  {\"a\":1}".utf8)) == .json)
     }
 
+    /// A JSON backup saved by a tool that writes a byte order mark still
+    /// starts with `{` once the BOM is skipped.
+    @Test("Sniffing sees past a UTF-8 BOM")
+    func sniffSkipsByteOrderMark() {
+        var data = Data([0xEF, 0xBB, 0xBF])
+        data.append(Data(#"{"formatVersion":1}"#.utf8))
+        #expect(BackupFormat.sniff(data) == .json)
+    }
+
     @Test("Sniffing treats anything else, including empty input, as CSV")
     func sniffCSV() {
         #expect(BackupFormat.sniff(Data("format_version,habit_id\n".utf8)) == .csv)

--- a/KadoTests/CSVBackupCoderTests.swift
+++ b/KadoTests/CSVBackupCoderTests.swift
@@ -1,0 +1,250 @@
+import Testing
+import Foundation
+@testable import Kado
+import KadoCore
+
+@Suite("CSVBackupCoder")
+struct CSVBackupCoderTests {
+    // MARK: - Fixtures
+
+    private let habitID = UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!
+    private let otherHabitID = UUID(uuidString: "CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC")!
+    private let completionID = UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!
+    private let createdAt = Date(timeIntervalSince1970: 1_700_000_000)
+    private let completedAt = Date(timeIntervalSince1970: 1_700_086_400)
+
+    private let coder = CSVBackupCoder(now: { Date(timeIntervalSince1970: 0) })
+
+    private func habit(
+        id: UUID? = nil,
+        name: String = "Meditate",
+        frequency: Frequency = .daily,
+        type: HabitType = .binary,
+        archivedAt: Date? = nil,
+        completions: [CompletionBackup] = []
+    ) -> HabitBackup {
+        HabitBackup(
+            id: id ?? habitID,
+            name: name,
+            frequency: frequency,
+            type: type,
+            createdAt: createdAt,
+            archivedAt: archivedAt,
+            color: .blue,
+            icon: "leaf",
+            remindersEnabled: true,
+            reminderHour: 7,
+            reminderMinute: 30,
+            completions: completions
+        )
+    }
+
+    private func document(_ habits: [HabitBackup]) -> BackupDocument {
+        BackupDocument(
+            exportedAt: Date(timeIntervalSince1970: 1_700_100_000),
+            appVersion: "1.6.0",
+            habits: habits
+        )
+    }
+
+    /// Round-trips a document and returns the habits that came back.
+    /// The envelope (`exportedAt` / `appVersion`) is deliberately not
+    /// carried by CSV, so only habits are comparable.
+    private func roundTrip(_ habits: [HabitBackup]) throws -> [HabitBackup] {
+        try coder.decode(coder.encode(document(habits))).habits
+    }
+
+    // MARK: - Union type encoding
+
+    @Test("Every Frequency case round-trips through its CSV encoding")
+    func frequencyRoundTrip() throws {
+        let frequencies: [Frequency] = [
+            .daily,
+            .daysPerWeek(5),
+            .specificDays([.monday, .wednesday, .friday]),
+            .specificDays([.sunday, .saturday]),
+            .everyNDays(3)
+        ]
+        for frequency in frequencies {
+            let restored = try roundTrip([habit(frequency: frequency)])
+            #expect(restored.first?.frequency == frequency, "failed for \(frequency)")
+        }
+    }
+
+    @Test("Every HabitType case round-trips through its CSV encoding")
+    func habitTypeRoundTrip() throws {
+        let types: [HabitType] = [
+            .binary,
+            .negative,
+            .counter(target: 8),
+            .timer(targetSeconds: 600)
+        ]
+        for type in types {
+            let restored = try roundTrip([habit(type: type)])
+            #expect(restored.first?.type == type, "failed for \(type)")
+        }
+    }
+
+    // MARK: - Shape and optionality
+
+    @Test("Habit with zero completions survives the round-trip")
+    func habitWithoutCompletions() throws {
+        let restored = try roundTrip([habit()])
+        #expect(restored.count == 1)
+        #expect(restored.first?.id == habitID)
+        #expect(restored.first?.completions.isEmpty == true)
+    }
+
+    @Test("Nil archivedAt and nil note decode back as nil")
+    func nilFieldsStayNil() throws {
+        let completion = CompletionBackup(id: completionID, date: completedAt, value: 1, note: nil)
+        let restored = try roundTrip([habit(archivedAt: nil, completions: [completion])])
+        #expect(restored.first?.archivedAt == nil)
+        #expect(restored.first?.completions.first?.note == nil)
+    }
+
+    @Test("Set archivedAt round-trips")
+    func archivedHabit() throws {
+        let restored = try roundTrip([habit(archivedAt: completedAt)])
+        #expect(restored.first?.archivedAt == completedAt)
+    }
+
+    @Test("Note containing a comma, quote, and newline round-trips")
+    func nastyNote() throws {
+        let note = "went well, \"really\"\nsecond line"
+        let completion = CompletionBackup(id: completionID, date: completedAt, value: 2.5, note: note)
+        let restored = try roundTrip([habit(completions: [completion])])
+        #expect(restored.first?.completions.first?.note == note)
+        #expect(restored.first?.completions.first?.value == 2.5)
+    }
+
+    @Test("Habit name containing the delimiter round-trips")
+    func nameWithDelimiter() throws {
+        let restored = try roundTrip([habit(name: "Read, then write")])
+        #expect(restored.first?.name == "Read, then write")
+    }
+
+    @Test("Multiple habits and completions keep their order")
+    func multipleHabits() throws {
+        let first = CompletionBackup(id: completionID, date: completedAt, value: 1, note: nil)
+        let second = CompletionBackup(id: UUID(), date: completedAt.addingTimeInterval(86_400), value: 1, note: nil)
+        let restored = try roundTrip([
+            habit(completions: [first, second]),
+            habit(id: otherHabitID, name: "Run")
+        ])
+        #expect(restored.map(\.id) == [habitID, otherHabitID])
+        #expect(restored.first?.completions.count == 2)
+        #expect(restored.first?.completions.map(\.id) == [first.id, second.id])
+    }
+
+    // MARK: - Malformed input
+
+    @Test("Conflicting habit metadata across rows resolves to the first row")
+    func firstRowWins() throws {
+        let csv = String(decoding: coder.encode(document([
+            habit(completions: [
+                CompletionBackup(id: completionID, date: completedAt, value: 1, note: nil),
+                CompletionBackup(id: UUID(), date: completedAt, value: 1, note: nil)
+            ])
+        ])), as: UTF8.self)
+
+        // Rewrite the habit name on the *second* data row only. Safe to
+        // split on newlines here: no field in this fixture is quoted.
+        var lines = csv.split(separator: "\n").map(String.init)
+        #expect(lines.count == 3, "fixture should be a header plus two rows")
+        lines[2] = lines[2].replacingOccurrences(of: "Meditate", with: "Renamed")
+        let edited = lines.joined(separator: "\n") + "\n"
+
+        let restored = try coder.decode(Data(edited.utf8)).habits
+        #expect(restored.count == 1)
+        #expect(restored.first?.name == "Meditate")
+    }
+
+    @Test("format_version higher than current throws unsupportedVersion")
+    func unsupportedVersion() throws {
+        let csv = String(decoding: coder.encode(document([habit()])), as: UTF8.self)
+        let bumped = csv.replacingOccurrences(of: "\n1,", with: "\n99,")
+        #expect(throws: BackupError.unsupportedVersion(99)) {
+            try coder.decode(Data(bumped.utf8))
+        }
+    }
+
+    @Test("Row with the wrong column count throws malformedRow")
+    func malformedRow() throws {
+        let csv = String(decoding: coder.encode(document([habit()])), as: UTF8.self)
+        #expect(throws: BackupError.malformedRow(line: 3)) {
+            try coder.decode(Data((csv + "1,2,3\n").utf8))
+        }
+    }
+
+    @Test("Unparseable frequency payload throws invalidCSV")
+    func badFrequency() throws {
+        let csv = String(decoding: coder.encode(document([habit(frequency: .everyNDays(3))])), as: UTF8.self)
+        let broken = csv.replacingOccurrences(of: "every_n_days:3", with: "every_n_days:banana")
+        #expect(throws: BackupError.invalidCSV) {
+            try coder.decode(Data(broken.utf8))
+        }
+    }
+
+    @Test("Unparseable UUID throws invalidCSV")
+    func badUUID() throws {
+        let csv = String(decoding: coder.encode(document([habit()])), as: UTF8.self)
+        let broken = csv.replacingOccurrences(of: habitID.uuidString, with: "not-a-uuid")
+        #expect(throws: BackupError.invalidCSV) {
+            try coder.decode(Data(broken.utf8))
+        }
+    }
+
+    @Test("Missing header throws invalidCSV")
+    func missingHeader() {
+        #expect(throws: BackupError.invalidCSV) {
+            try coder.decode(Data("nope,not,a,header\n".utf8))
+        }
+    }
+
+    @Test("Empty input throws invalidCSV")
+    func emptyInput() {
+        #expect(throws: BackupError.invalidCSV) {
+            try coder.decode(Data())
+        }
+    }
+
+    @Test("Unterminated quote surfaces as invalidCSV, not a CSVParseError")
+    func unterminatedQuoteMapsToBackupError() {
+        #expect(throws: BackupError.invalidCSV) {
+            try coder.decode(Data("\"unclosed".utf8))
+        }
+    }
+
+    // MARK: - Canonical shape
+
+    @Test("Header lists the sixteen columns in order")
+    func header() {
+        let csv = String(decoding: coder.encode(document([])), as: UTF8.self)
+        #expect(csv == """
+        format_version,habit_id,habit_name,frequency,type,created_at,archived_at,color,icon,reminders_enabled,reminder_hour,reminder_minute,completion_id,completion_date,value,note
+
+        """)
+    }
+
+    /// Golden file. The expected string below was produced by running
+    /// the encoder and pasting its output — never by hand-computing the
+    /// ISO8601 timestamps, which is how PR #16 burned two test cycles.
+    @Test("Canonical CSV shape")
+    func canonicalShape() {
+        let completion = CompletionBackup(id: completionID, date: completedAt, value: 1, note: "felt good")
+        let csv = String(decoding: coder.encode(document([
+            habit(
+                frequency: .specificDays([.monday, .wednesday, .friday]),
+                type: .timer(targetSeconds: 600),
+                completions: [completion]
+            )
+        ])), as: UTF8.self)
+
+        #expect(csv == """
+        format_version,habit_id,habit_name,frequency,type,created_at,archived_at,color,icon,reminders_enabled,reminder_hour,reminder_minute,completion_id,completion_date,value,note
+        1,AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA,Meditate,specific_days:2|4|6,timer:600.0,2023-11-14T22:13:20Z,,blue,leaf,true,7,30,BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB,2023-11-15T22:13:20Z,1.0,felt good
+
+        """)
+    }
+}

--- a/KadoTests/CSVBackupCoderTests.swift
+++ b/KadoTests/CSVBackupCoderTests.swift
@@ -150,8 +150,10 @@ struct CSVBackupCoderTests {
 
         // Rewrite the habit name on the *second* data row only. Safe to
         // split on newlines here: no field in this fixture is quoted.
+        // #require, not #expect: a non-fatal check here would let the
+        // next line index out of bounds and trap the whole test runner.
         var lines = csv.split(separator: "\n").map(String.init)
-        #expect(lines.count == 3, "fixture should be a header plus two rows")
+        try #require(lines.count == 3, "fixture should be a header plus two rows")
         lines[2] = lines[2].replacingOccurrences(of: "Meditate", with: "Renamed")
         let edited = lines.joined(separator: "\n") + "\n"
 
@@ -214,6 +216,50 @@ struct CSVBackupCoderTests {
         #expect(throws: BackupError.invalidCSV) {
             try coder.decode(Data("\"unclosed".utf8))
         }
+    }
+
+    // MARK: - Spreadsheet round-trip
+
+    /// Excel's "Save As → CSV UTF-8" prepends a byte order mark. Without
+    /// tolerance for it the strict header match fails and the user is
+    /// told their header row is damaged, which it isn't.
+    @Test("Leading UTF-8 BOM is tolerated")
+    func byteOrderMarkTolerated() throws {
+        var bomPrefixed = Data([0xEF, 0xBB, 0xBF])
+        bomPrefixed.append(coder.encode(document([habit()])))
+
+        let restored = try coder.decode(bomPrefixed).habits
+        #expect(restored.first?.id == habitID)
+    }
+
+    /// Spreadsheets normalize a boolean column to TRUE / FALSE on save.
+    @Test("Boolean columns accept spreadsheet TRUE and FALSE")
+    func spreadsheetBooleans() throws {
+        let csv = String(decoding: coder.encode(document([habit()])), as: UTF8.self)
+        let shouted = csv.replacingOccurrences(of: ",true,", with: ",TRUE,")
+        try #require(shouted != csv, "fixture should contain a lowercase boolean to rewrite")
+
+        let restored = try coder.decode(Data(shouted.utf8)).habits
+        #expect(restored.first?.remindersEnabled == true)
+    }
+
+    /// Copy-pasting a row in Numbers is the advertised workflow, and two
+    /// rows carrying the same completion_id must not become two
+    /// CompletionRecords sharing a UUID — CloudKit forbids
+    /// `@Attribute(.unique)`, so nothing downstream would catch it.
+    @Test("Duplicate completion rows collapse to a single completion")
+    func duplicateCompletionRows() throws {
+        let completion = CompletionBackup(id: completionID, date: completedAt, value: 1, note: nil)
+        let csv = String(decoding: coder.encode(document([habit(completions: [completion])])), as: UTF8.self)
+
+        var lines = csv.split(separator: "\n").map(String.init)
+        try #require(lines.count == 2, "fixture should be a header plus one row")
+        lines.append(lines[1])
+
+        let restored = try coder.decode(Data((lines.joined(separator: "\n") + "\n").utf8)).habits
+        #expect(restored.count == 1)
+        #expect(restored.first?.completions.count == 1)
+        #expect(restored.first?.completions.first?.id == completionID)
     }
 
     // MARK: - Canonical shape

--- a/KadoTests/CSVReaderTests.swift
+++ b/KadoTests/CSVReaderTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import Foundation
+@testable import Kado
+import KadoCore
+
+@Suite("CSVReader RFC 4180")
+struct CSVReaderTests {
+    @Test("Reader accepts LF line endings")
+    func lineFeedEndings() throws {
+        #expect(try CSVReader.parse("a,b\nc,d\n") == [["a", "b"], ["c", "d"]])
+    }
+
+    @Test("Reader accepts CRLF line endings")
+    func carriageReturnLineFeedEndings() throws {
+        #expect(try CSVReader.parse("a,b\r\nc,d\r\n") == [["a", "b"], ["c", "d"]])
+    }
+
+    @Test("Trailing newline does not produce a phantom empty row")
+    func noPhantomRow() throws {
+        #expect(try CSVReader.parse("a,b\n").count == 1)
+    }
+
+    @Test("Missing trailing newline still yields the last row")
+    func lastRowWithoutNewline() throws {
+        #expect(try CSVReader.parse("a,b\nc,d") == [["a", "b"], ["c", "d"]])
+    }
+
+    @Test("Reader handles a quoted field containing the delimiter")
+    func quotedDelimiter() throws {
+        #expect(try CSVReader.parse("\"a,b\",c\n") == [["a,b", "c"]])
+    }
+
+    @Test("Reader handles a quoted field spanning multiple lines")
+    func quotedNewline() throws {
+        #expect(try CSVReader.parse("\"line one\nline two\",c\n") == [["line one\nline two", "c"]])
+    }
+
+    @Test("Reader unescapes doubled quotes")
+    func doubledQuotes() throws {
+        #expect(try CSVReader.parse("\"say \"\"hi\"\"\"\n") == [["say \"hi\""]])
+    }
+
+    @Test("Empty fields are preserved, including at row edges")
+    func emptyFields() throws {
+        #expect(try CSVReader.parse(",b,\n") == [["", "b", ""]])
+    }
+
+    @Test("Empty input yields no rows")
+    func emptyInput() throws {
+        #expect(try CSVReader.parse("").isEmpty)
+    }
+
+    @Test("A row of only a newline is not a row")
+    func blankLineSkipped() throws {
+        #expect(try CSVReader.parse("a,b\n\nc,d\n") == [["a", "b"], ["c", "d"]])
+    }
+
+    @Test("Unterminated quote throws")
+    func unterminatedQuote() {
+        #expect(throws: CSVParseError.unterminatedQuote(line: 1)) {
+            try CSVReader.parse("\"never closed\n")
+        }
+    }
+}

--- a/KadoTests/CSVRoundTripTests.swift
+++ b/KadoTests/CSVRoundTripTests.swift
@@ -1,0 +1,187 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import Kado
+import KadoCore
+
+/// The CSV counterpart to `BackupRoundTripTests`: an export followed by
+/// an import into a fresh store must restore every habit and every
+/// completion, field for field.
+///
+/// `HabitBackup` is `Hashable` over all of its fields *and* its nested
+/// completions, so comparing the decoded `habits` array against the
+/// original is a complete field-for-field check — any future field that
+/// ships without CSV coverage fails here.
+@Suite("CSV round-trip")
+@MainActor
+struct CSVRoundTripTests {
+    private let coder = CSVBackupCoder(now: { Date(timeIntervalSince1970: 0) })
+
+    private func freshContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: HabitRecord.self, CompletionRecord.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    /// One habit of each `HabitType`, an archived habit, and a habit
+    /// with no completions at all — the row shape that only exists in
+    /// the CSV format.
+    private func seed(into container: ModelContainer) throws {
+        let context = container.mainContext
+
+        let timer = HabitRecord(
+            name: "Meditate, daily",
+            frequency: .daily,
+            type: .timer(targetSeconds: 600),
+            createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+            color: HabitColor.blue,
+            icon: "leaf",
+            remindersEnabled: true,
+            reminderHour: 7,
+            reminderMinute: 30
+        )
+        let counter = HabitRecord(
+            name: "Water",
+            frequency: .daysPerWeek(5),
+            type: .counter(target: 8),
+            createdAt: Date(timeIntervalSince1970: 1_700_100_000),
+            color: HabitColor.teal,
+            icon: "drop.fill",
+            remindersEnabled: false
+        )
+        let binary = HabitRecord(
+            name: "Floss",
+            frequency: .specificDays([.monday, .wednesday, .friday]),
+            type: .binary,
+            createdAt: Date(timeIntervalSince1970: 1_700_200_000),
+            color: HabitColor.green,
+            icon: "checkmark.circle"
+        )
+        let negative = HabitRecord(
+            name: "Soda",
+            frequency: .everyNDays(3),
+            type: .negative,
+            createdAt: Date(timeIntervalSince1970: 1_700_300_000),
+            color: HabitColor.red,
+            icon: "xmark.circle"
+        )
+        let archived = HabitRecord(
+            name: "Old habit",
+            frequency: .daily,
+            type: .binary,
+            createdAt: Date(timeIntervalSince1970: 1_690_000_000),
+            archivedAt: Date(timeIntervalSince1970: 1_695_000_000),
+            color: HabitColor.purple,
+            icon: "archivebox"
+        )
+        // No completions — exercises the metadata-only row.
+        let untouched = HabitRecord(
+            name: "Never done",
+            frequency: .daily,
+            type: .binary,
+            createdAt: Date(timeIntervalSince1970: 1_700_400_000),
+            color: HabitColor.orange,
+            icon: "star"
+        )
+
+        for record in [timer, counter, binary, negative, archived, untouched] {
+            context.insert(record)
+        }
+
+        for index in 0..<3 {
+            let date = Date(timeIntervalSince1970: 1_700_000_000 + Double(index) * 86_400)
+            // Notes that exercise every CSV escape at once.
+            let note: String? = index == 0 ? "went well, \"really\"\nsecond line" : nil
+            context.insert(CompletionRecord(date: date, value: 600 - Double(index) * 10, note: note, habit: timer))
+            context.insert(CompletionRecord(date: date, value: Double(index + 1), note: nil, habit: counter))
+            context.insert(CompletionRecord(date: date, value: 1, note: "plain note", habit: binary))
+            context.insert(CompletionRecord(date: date, value: 1, note: nil, habit: negative))
+        }
+        context.insert(CompletionRecord(
+            date: Date(timeIntervalSince1970: 1_692_000_000),
+            value: 1,
+            note: "last time",
+            habit: archived
+        ))
+
+        try context.save()
+    }
+
+    // MARK: - Tests
+
+    @Test("BackupDocument to CSV and back preserves every field")
+    func documentRoundTrip() throws {
+        let source = try freshContainer()
+        try seed(into: source)
+
+        let original = try DefaultBackupExporter(appVersion: "test").export(from: source.mainContext)
+        let decoded = try coder.decode(coder.encode(original))
+
+        #expect(decoded.habits == original.habits)
+        #expect(decoded.formatVersion == original.formatVersion)
+    }
+
+    @Test("Store to CSV to an empty store restores every habit and completion")
+    func storeRoundTrip() throws {
+        let source = try freshContainer()
+        try seed(into: source)
+
+        let exported = try DefaultBackupExporter(appVersion: "test").export(from: source.mainContext)
+        let csv = coder.encode(exported)
+
+        let destination = try freshContainer()
+        let document = try coder.decode(csv)
+        let summary = try DefaultBackupImporter().apply(document, to: destination.mainContext)
+
+        #expect(summary.totalHabits == 6)
+        #expect(summary.newHabits == 6)
+        #expect(summary.totalCompletions == 13)
+
+        // Re-export the destination and compare against the source's
+        // document: equal habit arrays means every field survived the
+        // store to CSV to store trip.
+        let reExported = try DefaultBackupExporter(appVersion: "test").export(from: destination.mainContext)
+        #expect(reExported.habits == exported.habits)
+    }
+
+    @Test("Empty store produces a header-only CSV that re-imports cleanly")
+    func emptyRoundTrip() throws {
+        let source = try freshContainer()
+        let exported = try DefaultBackupExporter(appVersion: "test").export(from: source.mainContext)
+        let csv = coder.encode(exported)
+
+        #expect(String(decoding: csv, as: UTF8.self) == CSVBackupCoder.columns.joined(separator: ",") + "\n")
+
+        let destination = try freshContainer()
+        let summary = try DefaultBackupImporter().apply(try coder.decode(csv), to: destination.mainContext)
+        #expect(summary.totalHabits == 0)
+        #expect(try destination.mainContext.fetch(FetchDescriptor<HabitRecord>()).isEmpty)
+    }
+
+    @Test("The habit with no completions survives as a metadata-only row")
+    func habitWithoutCompletionsSurvives() throws {
+        let source = try freshContainer()
+        try seed(into: source)
+
+        let exported = try DefaultBackupExporter(appVersion: "test").export(from: source.mainContext)
+        let decoded = try coder.decode(coder.encode(exported))
+
+        let untouched = try #require(decoded.habits.first { $0.name == "Never done" })
+        #expect(untouched.completions.isEmpty)
+    }
+
+    @Test("CSV and JSON exports of the same store carry identical habit data")
+    func csvMatchesJSON() throws {
+        let source = try freshContainer()
+        try seed(into: source)
+
+        let exporter = DefaultBackupExporter(appVersion: "test")
+        let document = try exporter.export(from: source.mainContext)
+
+        let viaCSV = try coder.decode(coder.encode(document))
+        let viaJSON = try DefaultBackupImporter().parse(data: try exporter.encode(document))
+
+        #expect(viaCSV.habits == viaJSON.habits)
+    }
+}

--- a/KadoTests/CSVWriterTests.swift
+++ b/KadoTests/CSVWriterTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import Kado
+import KadoCore
+
+@Suite("CSVWriter RFC 4180")
+struct CSVWriterTests {
+    @Test("Plain field is written unquoted")
+    func plainFieldUnquoted() {
+        #expect(CSVWriter.write([["alpha", "beta"]]) == "alpha,beta\n")
+    }
+
+    @Test("Empty field is written as an empty unquoted field")
+    func emptyFieldUnquoted() {
+        #expect(CSVWriter.write([["alpha", "", "beta"]]) == "alpha,,beta\n")
+    }
+
+    @Test("Field containing a comma is quoted")
+    func commaIsQuoted() {
+        #expect(CSVWriter.write([["a,b", "c"]]) == "\"a,b\",c\n")
+    }
+
+    @Test("Field containing a quote doubles it and quotes the field")
+    func quoteIsDoubled() {
+        #expect(CSVWriter.write([["say \"hi\""]]) == "\"say \"\"hi\"\"\"\n")
+    }
+
+    @Test("Field containing a newline is quoted")
+    func newlineIsQuoted() {
+        #expect(CSVWriter.write([["line one\nline two"]]) == "\"line one\nline two\"\n")
+    }
+
+    @Test("Field containing a carriage return is quoted")
+    func carriageReturnIsQuoted() {
+        #expect(CSVWriter.write([["a\rb"]]) == "\"a\rb\"\n")
+    }
+
+    /// Regression: Swift clusters `\r\n` into a single `Character` that
+    /// equals neither `"\r"` nor `"\n"`, so a character-wise check
+    /// leaves a CRLF-containing field unquoted and corrupts the row.
+    @Test("Field containing a CRLF pair is quoted")
+    func carriageReturnLineFeedIsQuoted() {
+        #expect(CSVWriter.write([["a\r\nb"]]) == "\"a\r\nb\"\n")
+    }
+
+    @Test("Rows are separated by a newline and the output ends with one")
+    func rowSeparation() {
+        let csv = CSVWriter.write([["a", "b"], ["c", "d"]])
+        #expect(csv == "a,b\nc,d\n")
+    }
+
+    @Test("No rows produces empty output")
+    func noRows() {
+        #expect(CSVWriter.write([]).isEmpty)
+    }
+
+    // MARK: - Round-trip through the reader
+
+    @Test("Fields needing every escape survive a writer/reader round-trip")
+    func nastyFieldsRoundTrip() throws {
+        let rows = [
+            ["header", "note"],
+            ["plain", ""],
+            ["with,comma", "with \"quote\""],
+            ["with\nnewline", "with\r\ncrlf"],
+            ["", "trailing space "]
+        ]
+        let parsed = try CSVReader.parse(CSVWriter.write(rows))
+        #expect(parsed == rows)
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Backup/BackupError.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Backup/BackupError.swift
@@ -8,4 +8,12 @@ public enum BackupError: Error, Equatable, Sendable {
     /// to read. Associated value carries the offending version for the
     /// error message.
     case unsupportedVersion(Int)
+    /// The bytes aren't parseable as Kadō's CSV backup — unreadable as
+    /// CSV at all, a missing or unrecognized header, or a field whose
+    /// contents don't decode.
+    case invalidCSV
+    /// A CSV row didn't carry the expected number of columns. The
+    /// associated value is the 1-based line number, so the message can
+    /// point the user at the row they broke.
+    case malformedRow(line: Int)
 }

--- a/Packages/KadoCore/Sources/KadoCore/Backup/BackupFormat.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Backup/BackupFormat.swift
@@ -34,7 +34,13 @@ nonisolated public enum BackupFormat: String, CaseIterable, Hashable, Sendable {
     /// resolve. A JSON backup always starts with `{` once whitespace is
     /// skipped; anything else is treated as CSV.
     public static func sniff(_ data: Data) -> BackupFormat {
-        let leading = data.prefix(64)
+        var leading = data.prefix(64)
+        // Excel's "CSV UTF-8" and some JSON writers prepend a byte order
+        // mark. `String(data:encoding:.utf8)` strips it on the decode
+        // path, but this one reads raw bytes and has to skip it itself.
+        if leading.starts(with: [0xEF, 0xBB, 0xBF]) {
+            leading = leading.dropFirst(3)
+        }
         for byte in leading {
             // Skip ASCII whitespace: space, tab, LF, CR.
             if byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D { continue }

--- a/Packages/KadoCore/Sources/KadoCore/Backup/BackupFormat.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Backup/BackupFormat.swift
@@ -1,0 +1,45 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// The serializations a backup can take on disk.
+///
+/// JSON is the lossless archival format; CSV carries the same habit and
+/// completion data in a shape spreadsheets can open. Both round-trip
+/// through `BackupDocument`, so the choice only affects encoding.
+nonisolated public enum BackupFormat: String, CaseIterable, Hashable, Sendable {
+    case json
+    case csv
+
+    /// Filename extension, without the dot.
+    public var fileExtension: String { rawValue }
+
+    /// Content type for `fileImporter` and the share sheet.
+    public var contentType: UTType {
+        switch self {
+        case .json: .json
+        case .csv: .commaSeparatedText
+        }
+    }
+
+    /// Resolve a format from a file's path extension, case-insensitively.
+    ///
+    /// Returns `nil` for anything unrecognized so the caller can fall
+    /// back to sniffing the contents — some file providers rename on
+    /// export, and an extension is a hint rather than a guarantee.
+    public static func detect(pathExtension: String) -> BackupFormat? {
+        BackupFormat(rawValue: pathExtension.lowercased())
+    }
+
+    /// Sniff a format from the leading bytes when the extension didn't
+    /// resolve. A JSON backup always starts with `{` once whitespace is
+    /// skipped; anything else is treated as CSV.
+    public static func sniff(_ data: Data) -> BackupFormat {
+        let leading = data.prefix(64)
+        for byte in leading {
+            // Skip ASCII whitespace: space, tab, LF, CR.
+            if byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D { continue }
+            return byte == UInt8(ascii: "{") ? .json : .csv
+        }
+        return .csv
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVBackupCoder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVBackupCoder.swift
@@ -1,0 +1,295 @@
+import Foundation
+
+/// Serializes a `BackupDocument` as consolidated CSV, and reads one
+/// back.
+///
+/// The shape is one row per completion, with the owning habit's
+/// metadata denormalized onto every row. A habit with no completions
+/// still emits a single row with the four completion columns empty, so
+/// it survives the round-trip.
+///
+/// **What "lossless" covers here**: habits and completions. The
+/// envelope fields `exportedAt` and `appVersion` are provenance rather
+/// than user data and are not carried — a decoded document stamps
+/// `exportedAt` from the injected clock and leaves `appVersion` empty.
+///
+/// Timestamps use the same ISO8601 seconds precision as the JSON
+/// encoder's `.iso8601` strategy, so sub-second components are dropped
+/// by both formats identically. Completion *days* — all the score and
+/// streak logic depends on — are unaffected.
+nonisolated public struct CSVBackupCoder: Sendable {
+    /// The column contract. Order is part of the format: `decode`
+    /// requires an exact match, which doubles as the "is this even a
+    /// Kadō CSV" check.
+    public static let columns = [
+        "format_version",
+        "habit_id",
+        "habit_name",
+        "frequency",
+        "type",
+        "created_at",
+        "archived_at",
+        "color",
+        "icon",
+        "reminders_enabled",
+        "reminder_hour",
+        "reminder_minute",
+        "completion_id",
+        "completion_date",
+        "value",
+        "note"
+    ]
+
+    private let now: @Sendable () -> Date
+
+    public init(now: @escaping @Sendable () -> Date = Date.init) {
+        self.now = now
+    }
+
+    // MARK: - Encoding
+
+    public func encode(_ document: BackupDocument) -> Data {
+        var rows: [[String]] = [Self.columns]
+
+        for habit in document.habits {
+            let metadata = [
+                String(document.formatVersion),
+                habit.id.uuidString,
+                habit.name,
+                Self.encode(frequency: habit.frequency),
+                Self.encode(type: habit.type),
+                Self.encode(date: habit.createdAt),
+                habit.archivedAt.map(Self.encode(date:)) ?? "",
+                habit.color.rawValue,
+                habit.icon,
+                String(habit.remindersEnabled),
+                String(habit.reminderHour),
+                String(habit.reminderMinute)
+            ]
+
+            if habit.completions.isEmpty {
+                rows.append(metadata + ["", "", "", ""])
+            } else {
+                for completion in habit.completions {
+                    rows.append(metadata + [
+                        completion.id.uuidString,
+                        Self.encode(date: completion.date),
+                        String(completion.value),
+                        completion.note ?? ""
+                    ])
+                }
+            }
+        }
+
+        return Data(CSVWriter.write(rows).utf8)
+    }
+
+    // MARK: - Decoding
+
+    public func decode(_ data: Data) throws -> BackupDocument {
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw BackupError.invalidCSV
+        }
+
+        let rows: [[String]]
+        do {
+            rows = try CSVReader.parse(text)
+        } catch {
+            // CSVParseError is an implementation detail of the RFC 4180
+            // layer; the UI only knows BackupError.
+            throw BackupError.invalidCSV
+        }
+
+        guard let header = rows.first, header == Self.columns else {
+            throw BackupError.invalidCSV
+        }
+
+        var order: [UUID] = []
+        var habits: [UUID: HabitBackup] = [:]
+        var formatVersion = BackupDocument.currentFormatVersion
+
+        for (offset, row) in rows.dropFirst().enumerated() {
+            // Header occupies line 1, so the first data row is line 2.
+            // Assumes no blank lines, which the reader skips silently.
+            let line = offset + 2
+
+            guard row.count == Self.columns.count else {
+                throw BackupError.malformedRow(line: line)
+            }
+
+            guard let version = Int(row[0]) else { throw BackupError.invalidCSV }
+            guard version <= BackupDocument.currentFormatVersion else {
+                throw BackupError.unsupportedVersion(version)
+            }
+            formatVersion = version
+
+            guard let habitID = UUID(uuidString: row[1]) else {
+                throw BackupError.invalidCSV
+            }
+
+            // First row for a habit id wins. Later rows contribute only
+            // their completion, so a hand-edited file with inconsistent
+            // metadata resolves deterministically instead of by
+            // whichever row happened to land last.
+            if habits[habitID] == nil {
+                habits[habitID] = HabitBackup(
+                    id: habitID,
+                    name: row[2],
+                    frequency: try Self.decodeFrequency(row[3]),
+                    type: try Self.decodeType(row[4]),
+                    createdAt: try Self.decodeDate(row[5]),
+                    archivedAt: try Self.decodeOptionalDate(row[6]),
+                    color: try Self.decodeColor(row[7]),
+                    icon: row[8],
+                    remindersEnabled: try Self.decodeBool(row[9]),
+                    reminderHour: try Self.decodeInt(row[10]),
+                    reminderMinute: try Self.decodeInt(row[11]),
+                    completions: []
+                )
+                order.append(habitID)
+            }
+
+            // An empty completion id marks a metadata-only row, which is
+            // how a habit with no completions survives.
+            guard !row[12].isEmpty else { continue }
+            guard let completionID = UUID(uuidString: row[12]) else {
+                throw BackupError.invalidCSV
+            }
+            guard let value = Double(row[14]) else { throw BackupError.invalidCSV }
+
+            habits[habitID]?.completions.append(
+                CompletionBackup(
+                    id: completionID,
+                    date: try Self.decodeDate(row[13]),
+                    value: value,
+                    note: row[15].isEmpty ? nil : row[15]
+                )
+            )
+        }
+
+        return BackupDocument(
+            formatVersion: formatVersion,
+            exportedAt: now(),
+            appVersion: "",
+            habits: order.compactMap { habits[$0] }
+        )
+    }
+
+    // MARK: - Field encoding
+
+    static func encode(date: Date) -> String {
+        date.formatted(.iso8601)
+    }
+
+    static func encode(frequency: Frequency) -> String {
+        switch frequency {
+        case .daily:
+            return "daily"
+        case .daysPerWeek(let count):
+            return "days_per_week:\(count)"
+        case .specificDays(let days):
+            let raw = days.map(\.rawValue).sorted().map(String.init).joined(separator: "|")
+            return "specific_days:\(raw)"
+        case .everyNDays(let interval):
+            return "every_n_days:\(interval)"
+        }
+    }
+
+    static func encode(type: HabitType) -> String {
+        switch type {
+        case .binary:
+            return "binary"
+        case .negative:
+            return "negative"
+        case .counter(let target):
+            return "counter:\(target)"
+        case .timer(let targetSeconds):
+            return "timer:\(targetSeconds)"
+        }
+    }
+
+    // MARK: - Field decoding
+
+    /// Split a `kind:payload` field. `omittingEmptySubsequences: false`
+    /// so `specific_days:` with no days still yields a payload rather
+    /// than collapsing to a bare kind.
+    private static func parts(_ field: String) -> (kind: String, payload: String?) {
+        let pieces = field.split(
+            separator: ":",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        ).map(String.init)
+        return (pieces[0], pieces.count > 1 ? pieces[1] : nil)
+    }
+
+    static func decodeFrequency(_ field: String) throws -> Frequency {
+        let (kind, payload) = parts(field)
+        switch kind {
+        case "daily":
+            return .daily
+        case "days_per_week":
+            guard let payload, let count = Int(payload) else { throw BackupError.invalidCSV }
+            return .daysPerWeek(count)
+        case "specific_days":
+            guard let payload else { throw BackupError.invalidCSV }
+            let days = try payload
+                .split(separator: "|")
+                .map { raw -> Weekday in
+                    guard let value = Int(raw), let day = Weekday(rawValue: value) else {
+                        throw BackupError.invalidCSV
+                    }
+                    return day
+                }
+            return .specificDays(Set(days))
+        case "every_n_days":
+            guard let payload, let interval = Int(payload) else { throw BackupError.invalidCSV }
+            return .everyNDays(interval)
+        default:
+            throw BackupError.invalidCSV
+        }
+    }
+
+    static func decodeType(_ field: String) throws -> HabitType {
+        let (kind, payload) = parts(field)
+        switch kind {
+        case "binary":
+            return .binary
+        case "negative":
+            return .negative
+        case "counter":
+            guard let payload, let target = Double(payload) else { throw BackupError.invalidCSV }
+            return .counter(target: target)
+        case "timer":
+            guard let payload, let seconds = Double(payload) else { throw BackupError.invalidCSV }
+            return .timer(targetSeconds: seconds)
+        default:
+            throw BackupError.invalidCSV
+        }
+    }
+
+    static func decodeDate(_ field: String) throws -> Date {
+        guard let date = try? Date(field, strategy: .iso8601) else {
+            throw BackupError.invalidCSV
+        }
+        return date
+    }
+
+    static func decodeOptionalDate(_ field: String) throws -> Date? {
+        field.isEmpty ? nil : try decodeDate(field)
+    }
+
+    static func decodeColor(_ field: String) throws -> HabitColor {
+        guard let color = HabitColor(rawValue: field) else { throw BackupError.invalidCSV }
+        return color
+    }
+
+    static func decodeBool(_ field: String) throws -> Bool {
+        guard let value = Bool(field) else { throw BackupError.invalidCSV }
+        return value
+    }
+
+    static func decodeInt(_ field: String) throws -> Int {
+        guard let value = Int(field) else { throw BackupError.invalidCSV }
+        return value
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVBackupCoder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVBackupCoder.swift
@@ -106,6 +106,7 @@ nonisolated public struct CSVBackupCoder: Sendable {
 
         var order: [UUID] = []
         var habits: [UUID: HabitBackup] = [:]
+        var seenCompletionIDs: Set<UUID> = []
         var formatVersion = BackupDocument.currentFormatVersion
 
         for (offset, row) in rows.dropFirst().enumerated() {
@@ -155,6 +156,17 @@ nonisolated public struct CSVBackupCoder: Sendable {
             guard let completionID = UUID(uuidString: row[12]) else {
                 throw BackupError.invalidCSV
             }
+
+            // First row for a completion id wins, matching the habit
+            // metadata rule above. Duplicates are reachable by
+            // copy-pasting a row in a spreadsheet, and letting both
+            // through would insert two CompletionRecords sharing a
+            // UUID: CloudKit forbids `@Attribute(.unique)`, and
+            // `DefaultBackupImporter.apply` snapshots the existing
+            // completions once before its loop, so neither insert sees
+            // the other.
+            guard seenCompletionIDs.insert(completionID).inserted else { continue }
+
             guard let value = Double(row[14]) else { throw BackupError.invalidCSV }
 
             habits[habitID]?.completions.append(
@@ -283,8 +295,11 @@ nonisolated public struct CSVBackupCoder: Sendable {
         return color
     }
 
+    /// Lowercased before parsing: spreadsheets normalize a boolean
+    /// column to `TRUE` / `FALSE` on save, and rejecting those would
+    /// break the round-trip that motivates shipping CSV at all.
     static func decodeBool(_ field: String) throws -> Bool {
-        guard let value = Bool(field) else { throw BackupError.invalidCSV }
+        guard let value = Bool(field.lowercased()) else { throw BackupError.invalidCSV }
         return value
     }
 

--- a/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVReader.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVReader.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Failures raised while parsing CSV text.
+///
+/// Deliberately separate from `BackupError`: these primitives know
+/// nothing about backups, and the coder layer maps them onto its own
+/// error surface.
+nonisolated public enum CSVParseError: Error, Equatable, Sendable {
+    /// A quoted field was opened and never closed. The associated value
+    /// is the 1-based line on which the quote *started*, which is what
+    /// a user needs in order to find it — not the line where the file
+    /// happened to run out.
+    case unterminatedQuote(line: Int)
+}
+
+/// Parses RFC 4180 CSV text into rows of fields.
+///
+/// This is a character-by-character state machine rather than a
+/// `split(separator:)` pass, because a quoted field may legitimately
+/// contain the delimiter *and* line breaks. Kadō completion notes are
+/// free text, so multi-line fields are a real case here, not a
+/// theoretical one.
+///
+/// Accepts `\n`, `\r\n`, and lone `\r` line endings. Entirely blank
+/// lines are skipped.
+nonisolated public enum CSVReader {
+    public static func parse(_ text: String) throws -> [[String]] {
+        var rows: [[String]] = []
+        var fields: [String] = []
+        var field = ""
+        var inQuotes = false
+        var rowIsEmpty = true
+        var line = 1
+        var quoteStartLine = 1
+
+        func endField() {
+            fields.append(field)
+            field = ""
+        }
+
+        func endRow() {
+            guard !rowIsEmpty else {
+                fields = []
+                field = ""
+                return
+            }
+            endField()
+            rows.append(fields)
+            fields = []
+            rowIsEmpty = true
+        }
+
+        var index = text.startIndex
+        while index < text.endIndex {
+            let character = text[index]
+
+            if inQuotes {
+                if character == "\"" {
+                    let next = text.index(after: index)
+                    if next < text.endIndex, text[next] == "\"" {
+                        // Doubled quote: one literal quote, skip the pair.
+                        field.append("\"")
+                        index = next
+                    } else {
+                        inQuotes = false
+                    }
+                } else {
+                    if Self.isLineBreak(character) { line += 1 }
+                    field.append(character)
+                }
+            } else {
+                switch character {
+                case "\"":
+                    inQuotes = true
+                    rowIsEmpty = false
+                    quoteStartLine = line
+                case CSVWriter.delimiter:
+                    rowIsEmpty = false
+                    endField()
+                case "\r\n", "\r", "\n":
+                    // `\r\n` is matched as its own case because Swift
+                    // clusters it into a single `Character` equal to
+                    // neither `"\r"` nor `"\n"` — no lookahead needed,
+                    // but omitting the case drops the row break.
+                    line += 1
+                    endRow()
+                default:
+                    rowIsEmpty = false
+                    field.append(character)
+                }
+            }
+
+            index = text.index(after: index)
+        }
+
+        if inQuotes {
+            throw CSVParseError.unterminatedQuote(line: quoteStartLine)
+        }
+
+        // A final row not terminated by a newline still counts.
+        endRow()
+
+        return rows
+    }
+
+    /// True for `\n`, `\r`, and the clustered `\r\n` character. Checked
+    /// over unicode scalars so the CRLF grapheme counts as one break
+    /// rather than none.
+    private static func isLineBreak(_ character: Character) -> Bool {
+        character.unicodeScalars.contains { $0 == "\n" || $0 == "\r" }
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVWriter.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVWriter.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Serializes rows of fields as RFC 4180 CSV text.
+///
+/// Rows are terminated with `\n` rather than the RFC's `\r\n`: the file
+/// is produced and consumed on Apple platforms, Numbers and Excel both
+/// accept bare line feeds, and LF keeps golden-file tests and `git
+/// diff` readable. `CSVReader` accepts either ending on the way back
+/// in.
+///
+/// `nonisolated` because these are pure functions with no MainActor
+/// state, and the project defaults every type to MainActor isolation.
+nonisolated public enum CSVWriter {
+    /// Field separator. Fixed, never localized — a `;` delimiter for
+    /// French Excel was considered and rejected during research, since
+    /// one machine-readable format matters more than one spreadsheet's
+    /// import defaults.
+    public static let delimiter: Character = ","
+
+    /// Join `rows` into CSV text, escaping each field as needed. Every
+    /// row, including the last, is terminated with a newline. An empty
+    /// `rows` array produces an empty string rather than a lone
+    /// newline.
+    public static func write(_ rows: [[String]]) -> String {
+        rows.reduce(into: "") { output, row in
+            output += row.map(escape).joined(separator: String(delimiter))
+            output += "\n"
+        }
+    }
+
+    /// Quote a field iff it contains the delimiter, a double quote, or
+    /// a line break; embedded quotes are doubled.
+    ///
+    /// Note the one shape CSV cannot represent unambiguously: a row
+    /// holding a single empty field serializes to a bare newline, which
+    /// reads back as no row at all. Kadō's backup format always writes
+    /// a fixed column count, so the case can't arise there.
+    /// The line-break check runs over unicode scalars, not characters:
+    /// Swift clusters `\r\n` into a *single* `Character` that equals
+    /// neither `"\r"` nor `"\n"`, so a character-wise check silently
+    /// fails to quote a field containing a CRLF pair.
+    static func escape(_ field: String) -> String {
+        let hasLineBreak = field.unicodeScalars.contains { $0 == "\n" || $0 == "\r" }
+        let needsQuoting = hasLineBreak || field.contains(delimiter) || field.contains("\"")
+        guard needsQuoting else { return field }
+        return "\"" + field.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+    }
+}

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -158,7 +158,7 @@ schema deploy.
 
 ---
 
-### Task 8: Format picker and CSV import routing
+### Task 8: Format picker and CSV import routing ✅
 
 **Goal**: Wire CSV into the UI.
 
@@ -175,7 +175,7 @@ schema deploy.
 
 ---
 
-### Task 9: Localization
+### Task 9: Localization ✅
 
 **Goal**: EN + FR entries for every new user-facing string.
 

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -143,7 +143,7 @@ schema deploy.
 
 ---
 
-### Task 7: Consolidate BackupSection's presentation stack
+### Task 7: Consolidate BackupSection's presentation stack ✅
 
 **Goal**: Pure refactor, no behavior change — collapse four `.alert` and two `.sheet(item:)` modifiers into single `PresentedAlert` / `PresentedSheet` enums.
 

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -1,0 +1,237 @@
+# Plan — CSV export (lossless round-trip)
+
+**Date**: 2026-09-04
+**Status**: ready to build
+**Research**: [research.md](./research.md)
+**Branch / PR**: `feature/csv-export` — [PR #62](https://github.com/scastiel/kado/pull/62)
+
+## Summary
+
+Add a consolidated, lossless CSV serialization of the existing
+`BackupDocument`, with both export and import wired into Settings →
+Data behind a format picker. The merge pipeline, `ImportSummary`, and
+confirmation sheet are reused untouched — the new code is an RFC 4180
+reader/writer and the row⇄document mapping. This closes the CSV claim
+`docs/PRODUCT.md` and `site/index.html` already make.
+
+No `@Model` change, so no `KadoSchemaV5` and no CloudKit Production
+schema deploy.
+
+## Decisions locked in
+
+- Consolidated single file; one row per completion, habit metadata denormalized onto every row.
+- Habits with zero completions emit a metadata-only row (empty completion columns) so they survive the round-trip.
+- Lossless with respect to **habits and completions**; `exportedAt` / `appVersion` are envelope provenance and are not carried.
+- `format_version` is a repeated column on every row, not a header sniff — it survives column reordering and yields `.unsupportedVersion(Int)` for free.
+- Union types encode as `kind:payload`; weekdays are pipe-separated so the field never needs quoting.
+- Conflicting denormalized metadata across rows: **first row for a `habit_id` wins**.
+- Dates are ISO8601 UTC, matching the JSON encoder's `.iso8601` strategy.
+- Delimiter is a fixed `,` with `.` decimals — not localized to `;` for French Excel.
+- **No CSV-injection escaping.** A leading `=` stays verbatim; losslessness wins. Documented, not silently accepted.
+- Empty field decodes to `nil` for both `archived_at` and `note`; the `""`-vs-empty distinction is not preserved (Excel and Numbers destroy it on re-save).
+- Export filename stays `kado-backup-<yyyy-MM-dd>.<ext>` for both formats.
+- Import means Kadō's own CSV only. Generic column-mapping import and Loop import stay separate roadmap items.
+
+## Task list
+
+### Task 1: RFC 4180 primitives — tests
+
+**Goal**: Pin the quoting and parsing contract before any implementation exists.
+
+**Changes**:
+- `KadoTests/CSVWriterTests.swift` (new)
+- `KadoTests/CSVReaderTests.swift` (new)
+
+**Tests / verification**:
+- `@Test("Field containing a comma is quoted")`
+- `@Test("Field containing a quote doubles it")`
+- `@Test("Field containing a newline is quoted and round-trips")`
+- `@Test("Plain field is written unquoted")`
+- `@Test("Reader accepts CRLF and LF line endings")`
+- `@Test("Reader handles a quoted field containing the delimiter")`
+- `@Test("Reader handles a quoted field spanning multiple lines")`
+- `@Test("Trailing newline does not produce a phantom empty row")`
+- `test_sim` confirms red.
+
+**Commit message (suggested)**: `test(csv): add RFC 4180 writer and reader cases`
+
+---
+
+### Task 2: RFC 4180 primitives — implementation
+
+**Goal**: Make Task 1 green with a hand-written reader/writer (no third-party deps).
+
+**Changes**:
+- `Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVWriter.swift` (new)
+- `Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVReader.swift` (new)
+
+**Tests / verification**:
+- Task 1 suite green.
+- The reader must be a character-state machine, **not** `split(separator: "\n")` — a note containing a newline is a real case here, not a hypothetical.
+
+**Commit message (suggested)**: `feat(csv): add RFC 4180 reader and writer primitives`
+
+---
+
+### Task 3: Format and error scaffolding
+
+**Goal**: Introduce the two small types the coder and UI both depend on.
+
+**Changes**:
+- `Packages/KadoCore/Sources/KadoCore/Backup/BackupFormat.swift` (new): `.json` | `.csv`, with `fileExtension` and `UTType`.
+- `Packages/KadoCore/Sources/KadoCore/Backup/BackupError.swift` (extend): add `.invalidCSV`, `.malformedRow(line: Int)`. Existing cases untouched.
+
+**Tests / verification**:
+- Existing 434 tests stay green; `BackupError` is `Equatable`, so confirm no exhaustive-switch break at call sites.
+
+**Commit message (suggested)**: `feat(backup): add BackupFormat and CSV error cases`
+
+---
+
+### Task 4: CSV backup coder — tests
+
+**Goal**: Pin the column contract and every field-encoding rule before implementing.
+
+**Changes**:
+- `KadoTests/CSVBackupCoderTests.swift` (new)
+
+**Tests / verification**:
+- `@Test("Every Frequency case round-trips through its CSV encoding")`
+- `@Test("Every HabitType case round-trips through its CSV encoding")`
+- `@Test("Habit with zero completions survives the round-trip")`
+- `@Test("Nil archivedAt and nil note decode back as nil")`
+- `@Test("Note containing a comma, quote, and newline round-trips")`
+- `@Test("Conflicting habit metadata across rows resolves to the first row")`
+- `@Test("format_version higher than current throws unsupportedVersion")`
+- `@Test("Row with the wrong column count throws malformedRow")`
+- `@Test("Unparseable frequency payload throws invalidCSV")`
+- `@Test("Canonical CSV shape")` — golden file. **Generate the expected string by running the encoder once and pasting the output.** Per the PR #16 compound, hand-computing an ISO8601 timestamp burned two `test_sim` cycles.
+- `test_sim` confirms red.
+
+**Commit message (suggested)**: `test(csv): add backup coder column and encoding cases`
+
+---
+
+### Task 5: CSV backup coder — implementation
+
+**Goal**: `encode(BackupDocument) -> Data` and `decode(Data) throws -> BackupDocument`.
+
+**Changes**:
+- `Packages/KadoCore/Sources/KadoCore/Backup/CSV/CSVBackupCoder.swift` (new)
+
+**Tests / verification**:
+- Task 4 suite green.
+- Row order: habits by `createdAt`, completions by `date` — same as `DefaultBackupExporter`, so exports stay diffable.
+
+**Commit message (suggested)**: `feat(csv): encode and decode BackupDocument as CSV`
+
+---
+
+### Task 6: Round-trip integration tests
+
+**Goal**: Prove "lossless" at document *and* store level, not just per-field.
+
+**Changes**:
+- `KadoTests/CSVRoundTripTests.swift` (new)
+
+**Tests / verification**:
+- `@Test("BackupDocument → CSV → BackupDocument preserves every field")` — reuse the `Set<Fingerprint>` comparison from `BackupRoundTripTests.fullRoundTrip`, which enumerates every field explicitly and so catches any future field that ships without CSV coverage.
+- `@Test("Store → CSV → empty store restores every habit and completion")` — export from a seeded in-memory container, decode, `apply` into a fresh one, compare fingerprints.
+- `@Test("CSV and JSON exports of the same store carry identical habit data")`.
+
+**Commit message (suggested)**: `test(csv): add document and store round-trip coverage`
+
+---
+
+### Task 7: Consolidate BackupSection's presentation stack
+
+**Goal**: Pure refactor, no behavior change — collapse four `.alert` and two `.sheet(item:)` modifiers into single `PresentedAlert` / `PresentedSheet` enums.
+
+**Changes**:
+- `Kado/Views/Settings/BackupSection.swift`
+
+**Tests / verification**:
+- Manual: exercise all four existing alert paths (export failure, read failure, invalid JSON, unsupported version) and both sheets (share, import confirm) before adding anything new.
+- This is the PR #16 compound's standing warning coming due: *"if you add a fifth alert or a third sheet, consolidate into a single `PresentedAlert` / `PresentedSheet` enum before the presentation stack gets confused."* Doing it as its own commit keeps the diff reviewable and makes a regression bisectable.
+
+**Commit message (suggested)**: `refactor(backup): consolidate BackupSection presentation state`
+
+---
+
+### Task 8: Format picker and CSV import routing
+
+**Goal**: Wire CSV into the UI.
+
+**Changes**:
+- `Kado/Views/Settings/BackupSection.swift`
+
+**Tests / verification**:
+- "Export Data" becomes a `Menu` with JSON and CSV entries; each writes `kado-backup-<date>.<ext>` and presents the existing share sheet.
+- `.fileImporter` accepts `[.json, .commaSeparatedText]`; route on `url.pathExtension`, falling back to sniffing a leading `{` for JSON.
+- Keep the `startAccessingSecurityScopedResource()` / `defer stopAccessing...` pairing in `handleFileImport` intact.
+- CSV import must reach the same `commitImport` path so it inherits `WidgetReloader.reloadAll` for free — verify widgets and reminders refresh after a CSV import.
+
+**Commit message (suggested)**: `feat(backup): add JSON/CSV format picker to export and import`
+
+---
+
+### Task 9: Localization
+
+**Goal**: EN + FR entries for every new user-facing string.
+
+**Changes**:
+- `Kado/Resources/Localizable.xcstrings`
+
+**Tests / verification**:
+- Hand-author both languages — `.xcstrings` is source code and is **not** auto-populated under `xcodebuild`; only the Xcode IDE runs that sync.
+- New keys: the two picker labels, plus the CSV error messages.
+- FR conventions per CLAUDE.md: `tu`, `habitude` feminine agreement.
+- `LocalizationCoverageTests` must pass — it fails the build on any EN key without a non-empty FR translation.
+
+**Commit message (suggested)**: `feat(l10n): add FR strings for CSV export and import`
+
+---
+
+### Task 10: Previews, build, and visual verification
+
+**Goal**: Meet the project's definition of done.
+
+**Changes**:
+- `Kado/Views/Settings/BackupSection.swift` previews (including one `#Preview("Dark")`).
+
+**Tests / verification**:
+- `build_sim` clean with no new warnings on iPhone 17 Pro **and** iPad Air (M4).
+- `test_sim` fully green.
+- `screenshot` of the Data section with the picker open.
+- XcodeBuildMCP tap primitives are not enabled on this install, so the picker cannot be driven from the agent — cover the states with previews and ask for one hand-check of an actual CSV export → import cycle on device.
+
+**Commit message (suggested)**: `feat(csv): add previews and verify on iPhone and iPad`
+
+## Risks and mitigation
+
+- **The classic CSV bug is a newline inside a quoted field.** Notes are free text and can contain newlines, so this path is live from day one. Mitigation: Task 1 tests it before Task 2 exists, and the reader is specified as a state machine rather than a line split.
+- **The Task 7 refactor could regress the shipped JSON flows.** Mitigation: separate commit, no behavior change, all six presentation paths exercised manually before Task 8 adds to them.
+- **Golden-file test drift.** Mitigation: generate expected output from the encoder and paste it, never compute it by hand (PR #16 lesson).
+- **`BackupError` gaining cases** could break exhaustive switches. Mitigation: Task 3 lands the cases alone so any break surfaces in a tiny diff.
+- **No agent-driven UI verification.** Documented XcodeBuildMCP limitation, hit on PRs #5 and #8. Mitigation: previews plus one user hand-check.
+
+## Integration checkpoints
+
+- **SwiftData**: no schema change, no migration, **no CloudKit Production deploy**. If that stops being true, the CLAUDE.md schema-bump checklist applies in full.
+- **Widgets**: CSV import routes through the existing `commitImport`, which already calls `WidgetReloader.reloadAll`. Verify rather than re-implement.
+- **Localization**: `LocalizationCoverageTests` is the gate.
+
+## Open questions
+
+None. All research open questions were resolved before planning:
+delimiter stays fixed, CSV injection stays unescaped and documented,
+filename stays `kado-backup-<date>`.
+
+## Out of scope
+
+- Generic CSV import with column mapping (separate roadmap item).
+- Loop Habit Tracker and Streaks import (separate roadmap items).
+- Per-habit CSV files and zip archives (Alternative C in research).
+- Localized delimiter / decimal separator for French Excel.
+- CSV-injection escaping.
+- Carrying `exportedAt` / `appVersion` through the CSV envelope.

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -1,7 +1,7 @@
 # Plan — CSV export (lossless round-trip)
 
 **Date**: 2026-09-04
-**Status**: ready to build
+**Status**: done — build complete, awaiting compound
 **Research**: [research.md](./research.md)
 **Branch / PR**: `feature/csv-export` — [PR #62](https://github.com/scastiel/kado/pull/62)
 
@@ -192,7 +192,7 @@ schema deploy.
 
 ---
 
-### Task 10: Previews, build, and visual verification
+### Task 10: Previews, build, and visual verification ✅
 
 **Goal**: Meet the project's definition of done.
 
@@ -251,8 +251,34 @@ schema deploy.
   byte-identical to the JSON encoder's `.iso8601` strategy, so both
   formats drop sub-second precision the same way.
 
+- **Task 7 turned out to be three alerts and two sheets**, not the
+  four alerts the compound remembered. The consolidation was worth
+  doing regardless — Task 8 adds two more failure cases, which would
+  have made five.
+
+- **Tasks 8–9 landed as one commit.** Task 8 alone introduces EN
+  catalog keys with no FR translations, which fails
+  `LocalizationCoverageTests`. Same reasoning as Tasks 1–2: don't leave
+  a red commit on the branch.
+
+- **`CSVBackupCoder` is constructed at the call site, not injected.**
+  Every other service here is protocol-defined and injected via
+  `@Entry`, but the coder is a pure value type with no collaborators
+  and nothing to stub — a preview or test gains nothing from a mock,
+  and the round-trip tests use the real type already.
+
+- **Task 10: the format picker could not be visually verified.**
+  It's a `Menu`, which a preview cannot open, and this XcodeBuildMCP
+  install has no tap primitives, so Settings → Data is unreachable from
+  the agent (the limitation CLAUDE.md records from PRs #5 and #8). What
+  *was* verified: clean `build_sim` on iPhone 17 Pro and iPad Air
+  11-inch (M4) with no new warnings, a clean launch, and two new
+  previews covering the CSV failure copy. **The export → import cycle
+  still needs one human hand-check.**
+
 - **Test count**: 434 baseline → 455 after Tasks 1–2 → 461 after
-  Task 3 → 479 after Tasks 4–5.
+  Task 3 → 479 after Tasks 4–5 → 484 after Task 6, holding through
+  Tasks 7–10.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -127,7 +127,7 @@ schema deploy.
 
 ---
 
-### Task 6: Round-trip integration tests
+### Task 6: Round-trip integration tests ✅
 
 **Goal**: Prove "lossless" at document *and* store level, not just per-field.
 

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -276,9 +276,34 @@ schema deploy.
   previews covering the CSV failure copy. **The export → import cycle
   still needs one human hand-check.**
 
+- **Post-build code review found three real bugs, all on the
+  spreadsheet path** — the one the feature exists for. Fixed with
+  tests first (all three reproduced red before the fix):
+  - **Duplicate `completion_id` rows inserted two `CompletionRecord`s
+    sharing a UUID.** `decode` appended every row, and
+    `DefaultBackupImporter.apply` snapshots `existingCompletions` once
+    *before* its loop, so neither insert saw the other. CloudKit
+    forbids `@Attribute(.unique)`, so nothing downstream would have
+    caught it — the day would just be double-counted in the score.
+    Reachable by copy-pasting a row in Numbers, which is the
+    advertised workflow. Now first-row-wins, matching the habit
+    metadata rule.
+  - **`decodeBool` rejected `TRUE` / `FALSE`.** Spreadsheets normalize
+    boolean columns on save, so a file that had been through Excel
+    failed to import — with a message blaming the header row, which
+    was intact.
+  - **`BackupFormat.sniff` misclassified BOM-prefixed JSON as CSV.**
+
+- **One review finding was wrong, and the test caught it.** The review
+  claimed a UTF-8 BOM also breaks `decode`'s strict header match.
+  Written as a test, it passed immediately: Foundation's
+  `String(data:encoding:.utf8)` already strips a leading BOM. Only
+  `sniff`, which reads raw bytes, needed the fix. Worth writing the
+  failing test before accepting a reported bug.
+
 - **Test count**: 434 baseline → 455 after Tasks 1–2 → 461 after
   Task 3 → 479 after Tasks 4–5 → 484 after Task 6, holding through
-  Tasks 7–10.
+  Tasks 7–10 → 488 after the review fixes.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -34,7 +34,7 @@ schema deploy.
 
 ## Task list
 
-### Task 1: RFC 4180 primitives — tests
+### Task 1: RFC 4180 primitives — tests ✅
 
 **Goal**: Pin the quoting and parsing contract before any implementation exists.
 
@@ -57,7 +57,7 @@ schema deploy.
 
 ---
 
-### Task 2: RFC 4180 primitives — implementation
+### Task 2: RFC 4180 primitives — implementation ✅
 
 **Goal**: Make Task 1 green with a hand-written reader/writer (no third-party deps).
 
@@ -206,6 +206,38 @@ schema deploy.
 - XcodeBuildMCP tap primitives are not enabled on this install, so the picker cannot be driven from the agent — cover the states with previews and ask for one hand-check of an actual CSV export → import cycle on device.
 
 **Commit message (suggested)**: `feat(csv): add previews and verify on iPhone and iPad`
+
+## Notes during build
+
+- **Tasks 1–2 landed as one commit, not two.** The plan proposed a red
+  test commit followed by an implementation commit, but tests
+  referencing types that don't exist yet don't *compile*, so the
+  intermediate commit would have left the branch unbuildable and
+  unbisectable. Ran the red/green loop exactly as planned (`test_sim`
+  confirmed 22 compile failures, then 455/455 green) — only the commit
+  boundary moved. Later tasks with the same shape will do the same.
+
+- **Task 2: Swift clusters `\r\n` into a single `Character`.** It
+  equals neither `"\r"` nor `"\n"`, which broke both primitives at
+  once: `CSVWriter.escape` didn't quote a field containing a CRLF pair,
+  and `CSVReader` fell through to `default` and appended the pair as
+  field content instead of ending the row. The two bugs cancelled out
+  in the writer/reader round-trip test, which passed for the wrong
+  reason — only the reader's standalone CRLF test caught it. Fixed by
+  checking line breaks over `unicodeScalars` in the writer and matching
+  an explicit `case "\r\n"` in the reader. Added
+  `carriageReturnLineFeedIsQuoted` as a regression test.
+
+  This is worth carrying to compound: it's a Swift-specific trap that
+  any hand-written text parser in this codebase can hit, and the
+  round-trip test masking it is the more interesting half.
+
+- **`CSVParseError` is separate from `BackupError`** (a refinement to
+  Task 3's scope): the RFC 4180 layer stays dependency-free and knows
+  nothing about backups. The coder in Task 5 maps `CSVParseError` onto
+  `BackupError.invalidCSV`.
+
+- **Test count**: 434 baseline → 455 after Tasks 1–2.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -73,7 +73,7 @@ schema deploy.
 
 ---
 
-### Task 3: Format and error scaffolding
+### Task 3: Format and error scaffolding ✅
 
 **Goal**: Introduce the two small types the coder and UI both depend on.
 

--- a/docs/plans/2026-09/csv-export/plan.md
+++ b/docs/plans/2026-09/csv-export/plan.md
@@ -88,7 +88,7 @@ schema deploy.
 
 ---
 
-### Task 4: CSV backup coder — tests
+### Task 4: CSV backup coder — tests ✅
 
 **Goal**: Pin the column contract and every field-encoding rule before implementing.
 
@@ -112,7 +112,7 @@ schema deploy.
 
 ---
 
-### Task 5: CSV backup coder — implementation
+### Task 5: CSV backup coder — implementation ✅
 
 **Goal**: `encode(BackupDocument) -> Data` and `decode(Data) throws -> BackupDocument`.
 
@@ -237,7 +237,22 @@ schema deploy.
   nothing about backups. The coder in Task 5 maps `CSVParseError` onto
   `BackupError.invalidCSV`.
 
-- **Test count**: 434 baseline → 455 after Tasks 1–2.
+- **Task 5: the golden canonical-shape test passed on the first run.**
+  The PR #16 lesson says to generate the expected string rather than
+  compute it. A cheaper variant worked here: write the fixture
+  timestamps, then verify them with `date -u -r 1700000000` before
+  running anything. Two seconds of shell beats a two-minute
+  `test_sim` cycle, and it generalizes to any test asserting a
+  serialized timestamp.
+
+- **`Date.ISO8601FormatStyle` over `ISO8601DateFormatter`.** The value-
+  type format style needs no shared formatter instance, which keeps
+  `CSVBackupCoder` `Sendable` with no static mutable state. Output is
+  byte-identical to the JSON encoder's `.iso8601` strategy, so both
+  formats drop sub-second precision the same way.
+
+- **Test count**: 434 baseline → 455 after Tasks 1–2 → 461 after
+  Task 3 → 479 after Tasks 4–5.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-09/csv-export/research.md
+++ b/docs/plans/2026-09/csv-export/research.md
@@ -1,0 +1,260 @@
+# Research — CSV export (lossless round-trip)
+
+**Date**: 2026-09-04
+**Status**: ready for plan
+**Related**: [ROADMAP v0.2 Import/Export](../../../ROADMAP.md#v02--visible-ios-native) (deferred CSV bullets), [import-export research](../../2026-04/import-export/research.md), [import-export compound](../../2026-04/import-export/compound.md)
+
+## Problem
+
+The v0.2 import/export feature shipped the JSON half and explicitly
+deferred CSV: "CSV export, generic CSV import, and Loop CSV import are
+the next natural slices" ([import-export
+compound](../../2026-04/import-export/compound.md)). Nothing has been
+built since — there is no occurrence of the string `csv` in any Swift
+file in the repo.
+
+Meanwhile `docs/PRODUCT.md`'s competitive gap table already marks Kadō
+✅ for **"Export CSV/JSON (core)"**, and `site/index.html` repeats the
+claim. That is currently an overclaim: only JSON exists. Closing it is
+the point of this feature — CSV is the format spreadsheets, R/pandas,
+and every other habit tracker actually speak, and "you can leave at any
+time with all your data" (PRODUCT.md differentiator #5) is weaker when
+the only exit is a bespoke JSON shape.
+
+Scope decided with the user at research time:
+
+- **Consolidated**: one file for every habit, not a zip of per-habit files.
+- **Lossless**: the CSV must be re-importable by Kadō, not just
+  readable in Numbers.
+- **Format picker**: one "Export Data" affordance in Settings → Data
+  that offers JSON or CSV, rather than a second button.
+- **Full round-trip**: export *and* import ship together. Import here
+  means *Kadō's own CSV*; generic column-mapping import and Loop import
+  remain separate roadmap items.
+
+"Done" from the user's perspective: Settings → Data → Export Data →
+**CSV**, share sheet, open the file in Numbers and read it. Then import
+that same file into a fresh install and get every habit and completion
+back.
+
+## Current state of the codebase
+
+**The backup layer already exists and is well-factored** —
+`Packages/KadoCore/Sources/KadoCore/Backup/`:
+
+- `BackupDocument` (`formatVersion: 1`, `exportedAt`, `appVersion`,
+  `habits: [HabitBackup]`) — the wire-format root, deliberately
+  decoupled from the SwiftData schema.
+- `HabitBackup` nests `completions: [CompletionBackup]`, so there are no
+  orphan-completion or dangling-`habitID` cases to handle.
+- `BackupExporting.export(from:) -> BackupDocument` — one fetch, sorted
+  by `createdAt`. `encode(_:)` is the JSON-specific step.
+- `BackupImporting.parse(data:) -> BackupDocument` is the JSON-specific
+  step; `summary(for:in:)` and `apply(_:to:)` are **format-agnostic**
+  merge logic (UUID-keyed upsert, incoming wins, never deletes).
+- `ImportSummary` and the `ImportConfirmSheet` dry-run flow are done.
+- `BackupError` = `.invalidJSON` | `.unsupportedVersion(Int)`.
+
+**Domain types are already CSV-friendly** — the two hard ones carry
+hand-owned, stable `Codable` with a `kind` discriminator:
+`Frequency` (`.daily` / `.daysPerWeek(Int)` / `.specificDays(Set<Weekday>)`
+/ `.everyNDays(Int)`) and `HabitType` (`.binary` / `.counter(target:)` /
+`.timer(targetSeconds:)` / `.negative`). `HabitColor` is a String
+raw-value enum, `Weekday` an Int raw-value enum (Sunday = 1 … Saturday = 7),
+`icon` is a plain SF Symbol string.
+
+**Settings UI** — `Kado/Views/Settings/BackupSection.swift`: "Export
+Data" writes a temp `kado-backup-<yyyy-MM-dd>.json` and presents a
+share sheet; "Import Data" is a `.fileImporter` limited to `[.json]`.
+
+**What's missing**: any CSV reader/writer. Zero third-party
+dependencies are allowed for v0.x, so RFC 4180 quoting is ours to write.
+
+## Proposed approach
+
+**Reuse `BackupDocument` as the intermediate representation.** CSV is a
+new *serialization* of an existing document type, not a new pipeline:
+
+```
+export:  ModelContext → [existing] export(from:) → BackupDocument → [new] CSVBackupCoder.encode → Data
+import:  Data → [new] CSVBackupCoder.decode → BackupDocument → [existing] summary/apply → ModelContext
+```
+
+This is the load-bearing decision of the feature. It means **no new
+merge logic, no new confirmation sheet, no new `ImportSummary`**, and
+the round-trip test can compare `BackupDocument` values directly. The
+only genuinely new code is the RFC 4180 layer and the row⇄document
+mapping.
+
+### The format
+
+One row per completion, with habit metadata denormalized onto every
+row. A habit with no completions emits a single row with the completion
+columns empty, so it survives the round-trip.
+
+```
+format_version,habit_id,habit_name,frequency,type,created_at,archived_at,
+color,icon,reminders_enabled,reminder_hour,reminder_minute,
+completion_id,completion_date,value,note
+```
+
+Union types encode as `kind:payload`, mirroring the JSON discriminator:
+
+| Value | Encoding |
+|---|---|
+| `.daily` | `daily` |
+| `.daysPerWeek(5)` | `days_per_week:5` |
+| `.specificDays([mon, wed, fri])` | `specific_days:2\|4\|6` |
+| `.everyNDays(3)` | `every_n_days:3` |
+| `.binary` / `.negative` | `binary` / `negative` |
+| `.counter(target: 8)` | `counter:8.0` |
+| `.timer(targetSeconds: 600)` | `timer:600.0` |
+
+Pipe (not comma) separates weekdays so the field never needs quoting.
+Dates are ISO8601 UTC, matching the JSON encoder's `.iso8601` strategy.
+`archived_at` and `note` are empty when nil.
+
+**Rules that need to be written down and tested:**
+
+- `format_version` repeats on every row. Redundant, but it survives
+  column reordering and gives `.unsupportedVersion(Int)` for free,
+  exactly like the JSON gate.
+- Denormalized habit metadata can disagree between rows (a user edited
+  the file). **First row for a `habit_id` wins**; later rows contribute
+  only their completion.
+- Row order: habits by `createdAt`, completions by `date` — same as
+  `DefaultBackupExporter`, so exports are diffable.
+- `exportedAt` / `appVersion` are **not** carried. They are envelope
+  provenance, not user data; a re-export regenerates them. "Lossless"
+  in this doc means lossless with respect to habits and completions.
+
+### Key components
+
+- `CSVWriter` / `CSVReader` (new, `KadoCore/Backup/CSV/`): RFC 4180
+  primitives — quote a field iff it contains `,` `"` CR or LF, double
+  embedded quotes, accept both CRLF and LF on read.
+- `CSVBackupCoder` (new): `encode(BackupDocument) -> Data` and
+  `decode(Data) throws -> BackupDocument`. Owns the column contract.
+- `BackupFormat` enum (new): `.json` | `.csv`, with `fileExtension` and
+  `UTType`. Picks the coder and the export filename.
+- `BackupError` (extended): `.invalidCSV`, `.malformedRow(line: Int)`.
+  Existing cases untouched.
+- `BackupSection` (modified): "Export Data" becomes a `Menu` with JSON
+  and CSV; `.fileImporter` accepts `[.json, .commaSeparatedText]` and
+  routes on the file extension.
+
+### Data model changes
+
+**None.** No `@Model` change, no `KadoSchemaV5`, therefore no CloudKit
+Production schema deploy. Given issue #52 cost two App Store reviews,
+this being a pure serialization feature is worth stating explicitly.
+
+Existing public signatures stay working: `BackupExporting.encode(_:)`
+and `BackupImporting.parse(data:)` remain the JSON path. The coder
+abstraction is added alongside, not swapped in.
+
+### UI changes
+
+`BackupSection` only. But note the compound doc's standing warning:
+that file already carries **four `.alert` and two `.sheet(item:)`
+modifiers**, with an explicit "consolidate into a single
+`PresentedAlert` / `PresentedSheet` enum before you add a fifth alert."
+Adding CSV error cases crosses that line, so the consolidation is part
+of this feature, not a follow-up.
+
+New catalog keys (EN + FR hand-authored — `.xcstrings` is source code
+and is not auto-populated under `xcodebuild`): the two picker labels
+and the CSV error messages. `LocalizationCoverageTests` fails the build
+if FR is missing.
+
+### Tests to write
+
+RFC 4180 is where this feature will actually break, so the writer and
+reader get the most coverage:
+
+- `@Test("Field containing a comma is quoted")`
+- `@Test("Field containing a quote doubles it")`
+- `@Test("Note containing a newline round-trips")`
+- `@Test("Reader accepts CRLF and LF line endings")`
+- `@Test("Every Frequency case round-trips through its CSV encoding")`
+- `@Test("Every HabitType case round-trips through its CSV encoding")`
+- `@Test("Habit with zero completions survives the round-trip")`
+- `@Test("Nil archivedAt and nil note decode back as nil")`
+- `@Test("Conflicting habit metadata across rows resolves to the first row")`
+- `@Test("format_version higher than current throws unsupportedVersion")`
+- `@Test("Row with the wrong column count throws malformedRow")`
+- `@Test("Canonical CSV shape")` — golden file. Per the compound's
+  lesson, generate the expected string by running the encoder once and
+  pasting the output; do not hand-compute ISO8601 timestamps.
+- `@Test("BackupDocument → CSV → BackupDocument preserves every field")`
+  — reuse the `Set<Fingerprint>` comparison from
+  `BackupRoundTripTests.fullRoundTrip`.
+- `@Test("Store → CSV → empty store restores every habit and completion")`
+
+Current suite: 434 `@Test` cases across 47 files.
+
+## Alternatives considered
+
+### Alternative A: analysis-oriented flat CSV (lossy)
+
+- Idea: `habit_name,date,value,note` only. Human-first, trivially
+  parseable, no union encoding.
+- Why not: user chose lossless. JSON would remain the only real exit
+  path, and the round-trip claim in PRODUCT.md would stay an overclaim.
+
+### Alternative B: version via header sniffing instead of a column
+
+- Idea: validate the header row against the known v1 column list;
+  mismatch means unsupported.
+- Why not: can't report *which* version was found, and breaks if a
+  spreadsheet reorders columns. Kept as a fallback if the repeated
+  column proves too noisy in practice.
+
+### Alternative C: one file per habit, zipped
+
+- Idea: Loop's shape — `Habits.csv` plus a file per habit.
+- Why not: user chose consolidated. Also needs a zip writer, which
+  means either `AppleArchive` or hand-rolling — real work for no gain
+  when one file round-trips fine.
+
+### Alternative D: heterogeneous rows with a `record_type` column
+
+- Idea: `habit` rows and `completion` rows in one file, no
+  denormalization, no metadata-conflict rule.
+- Why not: unusable in a spreadsheet (columns mean different things per
+  row), which forfeits the main reason to want CSV at all.
+
+## Risks and unknowns
+
+- **CSV injection vs losslessness.** A habit named `=cmd|...` is a
+  formula when opened in Excel. The standard mitigation — prefixing
+  `= + - @` fields with `'` — *mutates user data* and breaks the
+  lossless guarantee. Recommendation: stay lossless, document the
+  behavior. This is a personal data export the user asked for, not a
+  file served to third parties.
+- **Empty string vs nil `note`.** RFC 4180 can distinguish `""` from an
+  empty field, but Excel and Numbers destroy the difference on
+  re-save. Recommendation: treat empty as nil, add a test pinning that
+  behavior, and confirm the UI can't produce a non-nil empty note.
+- **Whole file built in memory.** Same characteristic as the JSON path
+  today; fine at realistic store sizes.
+- **Import format detection.** Routing on `url.pathExtension` fails if
+  a file manager renames on export. Cheap mitigation: fall back to
+  sniffing a leading `{` for JSON.
+
+## Open questions
+
+- [ ] CSV injection: confirm we accept unescaped `=`-leading fields as
+      the cost of losslessness. (Recommendation: yes, document it.)
+- [ ] Should the FR export use `;` as delimiter and `,` as decimal
+      separator, as French Excel expects? Lossless argues for one fixed
+      machine format; French users opening the file in Excel argue the
+      other way. (Recommendation: fixed `,` + `.`, revisit on feedback.)
+- [ ] Does the export filename stay `kado-backup-<date>.csv`, or become
+      `kado-export-<date>.csv` now that two formats exist?
+
+## References
+
+- [RFC 4180 — Common Format and MIME Type for CSV Files](https://www.rfc-editor.org/rfc/rfc4180)
+- [Apple — UTType.commaSeparatedText](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype/3551586-commaseparatedtext)
+- Prior work: `BackupDocument` / `DefaultBackupExporter` / `DefaultBackupImporter`, `BackupRoundTripTests` (`Set<Fingerprint>` pattern), [PR #16](https://github.com/scastiel/kado/pull/16)

--- a/docs/plans/2026-09/csv-export/research.md
+++ b/docs/plans/2026-09/csv-export/research.md
@@ -244,14 +244,18 @@ Current suite: 434 `@Test` cases across 47 files.
 
 ## Open questions
 
-- [ ] CSV injection: confirm we accept unescaped `=`-leading fields as
-      the cost of losslessness. (Recommendation: yes, document it.)
-- [ ] Should the FR export use `;` as delimiter and `,` as decimal
-      separator, as French Excel expects? Lossless argues for one fixed
-      machine format; French users opening the file in Excel argue the
-      other way. (Recommendation: fixed `,` + `.`, revisit on feedback.)
-- [ ] Does the export filename stay `kado-backup-<date>.csv`, or become
-      `kado-export-<date>.csv` now that two formats exist?
+All resolved with the user before the plan stage — carried into
+[plan.md](./plan.md) as locked decisions.
+
+- [x] CSV injection: **accept unescaped `=`-leading fields** as the cost
+      of losslessness, and document the behavior.
+- [x] FR delimiter: **fixed `,` with `.` decimals**, not localized to
+      `;` for French Excel. Revisit on user feedback.
+- [x] Export filename: **stays `kado-backup-<date>.<ext>`** for both
+      formats — no change to the shipped JSON path.
+- [x] Empty vs nil `note`: empty field decodes to `nil`; the `""`
+      distinction is not preserved, since Excel and Numbers destroy it
+      on re-save.
 
 ## References
 


### PR DESCRIPTION
## Why?

- `docs/PRODUCT.md`'s competitive gap table marks Kadō ✅ for **"Export CSV/JSON (core)"**, and `site/index.html` repeats it. Until this PR only JSON existed — the claim was an overclaim.
- The v0.2 import/export feature shipped the JSON half and deferred CSV as "the next natural slice."
- "You can leave at any time with all your data" (PRODUCT.md differentiator #5) is weaker when the only exit is a bespoke JSON shape. CSV is what spreadsheets, pandas, and other habit trackers speak.

## What?

Settings → Data → **Export Data** is now a menu offering **JSON** or **CSV**. Import accepts either. A CSV export re-imports into a fresh install with every habit and completion intact.

- Consolidated single file — one row per completion, habit metadata denormalized onto every row.
- A habit with no completions emits a metadata-only row, so it survives the round-trip.
- Lossless with respect to habits and completions. `exportedAt` / `appVersion` are envelope provenance and aren't carried.
- Import here means Kadō's own CSV. Generic column-mapping import and Loop import remain separate roadmap items.

## How?

- **CSV is a new serialization of the existing `BackupDocument`, not a new pipeline.** Export is `export(from:) → BackupDocument → CSV encode`; import is `CSV decode → BackupDocument → summary/apply`. The UUID-keyed merge, `ImportSummary`, and confirmation sheet are reused untouched — CSV import inherits `WidgetReloader.reloadAll` for free.
- New: `CSVWriter` / `CSVReader` (RFC 4180, hand-written — no third-party deps), `CSVBackupCoder` (the column contract), `BackupFormat`.
- Union types encode as `kind:payload` (`days_per_week:5`, `specific_days:2|4|6`, `timer:600.0`), mirroring the discriminator `Frequency` and `HabitType` already use. Weekdays are pipe-separated so the field never needs quoting.
- `Date.ISO8601FormatStyle` rather than `ISO8601DateFormatter`: no shared formatter instance, so the coder stays `Sendable`, and output is byte-identical to the JSON encoder.
- **No schema change** — no `KadoSchemaV5`, so no CloudKit Production deploy.
- **Tests: 434 → 484.** Includes document-level and store-level round-trips; `HabitBackup` is `Hashable` over all fields and nested completions, so comparing decoded habits against the original is a complete field-for-field check that fails if a future field ships without CSV coverage.

Two notes for the reviewer:

- **Task 7 is a pure refactor with no CSV in it.** The PR #16 compound left a standing warning to consolidate `BackupSection`'s presentation stack "before you add a fifth alert." CSV error cases were that trigger, so the consolidation landed as its own commit — two sheets and three alerts collapsed into one `PresentedSheet` and one `PresentedAlert` slot, no behavior change.
- **Swift clusters `\r\n` into a single `Character`** equal to neither `"\r"` nor `"\n"`. This broke the writer (didn't quote CRLF-containing fields) and the reader (appended the pair as content instead of ending the row) simultaneously, and the two cancelled out in the round-trip test — it passed for the wrong reason. Only the standalone CRLF test caught it.

## Next steps

- ✅ **Hand-check done.** Exported from the Dev Mode sandbox and imported into the production store on iPhone 17 Pro: 6 habits and 102 completion rows round-tripped. The on-disk file has the expected header, `specific_days:2|4|6` frequency encoding, ISO8601 timestamps, and empty `archived_at` / `note` columns. Agent-side verification was already green — clean `build_sim` on iPhone 17 Pro and iPad Air 11-inch (M4), no new warnings, 484/484 tests.
- A crash was observed during that session, investigated, and found **unrelated to this PR** — the Dev Mode container swap invalidates `HabitRecord`s held by `TodayView`'s `ForEach`. Filed as #63. `DefaultBackupImporter.apply` is merge-only and never deletes, so the import path leaves every existing record valid.
- Update `docs/ROADMAP.md` — its status block is still dated 2026-04-20 and says "next: v0.3 remaining tracks" while the app is at v1.6. The two CSV export bullets can be ticked.
### Deferred code-review findings

A review pass found three real bugs on the spreadsheet path, all fixed in `5ab0c32` with failing tests first: duplicate `completion_id` rows inserting two `CompletionRecord`s with the same UUID, `decodeBool` rejecting the `TRUE`/`FALSE` that spreadsheets write, and `sniff` misclassifying BOM-prefixed JSON. These remain open, deliberately out of scope for this PR:

- **`unsupportedVersion` is unreachable for the realistic upgrade path.** The exact 16-column header match runs before the per-row version check, so a future file with a 17th column fails as `invalidCSV` on an old build rather than "update Kadō to import" — defeating the stated rationale for carrying `format_version` as a column. Fix: match the header as a prefix, or read `row[0]` first.
- **`formatVersion` is last-row-wins**, and a header-only (empty-store) export carries no version at all.
- **Error line numbers drift.** `line = offset + 2` maps a parsed-row index to a file line, but the reader skips blank lines and a quoted note may span several — so `malformedRow(line:)` can point at the wrong row. Fix: have `CSVReader` return each row's starting line.
- **Format dispatch lives in the view.** `CSVBackupCoder()` is constructed inline in two places, bypassing the injected exporter/importer. Cleaner: `encode(_:as: BackupFormat)` on `BackupExporting` and `parse(data:format:)` on `BackupImporting`.
- **Coding runs synchronously on MainActor.** `CSVReader.parse` walks the file character-by-character; a very large store could block the UI. Iterate `text.utf8` and/or move the call off MainActor.
- **`BackupFormat.sniff` is effectively unreachable** — `.fileImporter` already restricts to `[.json, .commaSeparatedText]`, so a renamed file can't be picked in the first place. Either widen the allowed types or drop `sniff`.
- **`commitImport` dismisses a sheet and presents an alert in one state update**, which iOS often swallows. Pre-existing and faithfully preserved by the Task 7 refactor, but it's the exact hazard that refactor was meant to address.
- Minor: the injected `now` clock has no production effect (nothing reads `exportedAt`); the empty-string-note rule is documented but untested; the CSV round-trip test seed duplicates ~80 lines of `BackupRoundTripTests`' fixture.

- **Known and deliberate**: no CSV-injection escaping. A habit named `=cmd|...` stays verbatim, because the standard `'`-prefix mitigation mutates user data and would break the lossless guarantee. Revisit only if the export is ever handed to third parties.
- Deferred: generic column-mapping CSV import, Loop / Streaks import, localized `;` delimiter for French Excel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LicPqSrQWwTy3wysxNRqXP
