### PR TITLE
fix(dev-mode): address habits by id so a store swap can't trap a live view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,20 @@ repo. Guard against that with an explicit
   `.id(flag)` as a defensive swap-trigger (as the Dev mode work
   initially did) quietly resets all of that. Trust the swap; don't
   rebuild the tree unless you've reproduced a real staleness bug.
+- **…but a swap invalidates every `@Model` object the old container
+  vended, so retained SwiftUI state must never hold one.** `@Query`
+  re-fetching is only half the story: `ForEach` retains the collection
+  it was handed and re-reads `Identifiable.id` during the *list diff*,
+  which runs after the swap. Reading any persisted property on an
+  invalidated object traps inside SwiftData — `EXC_BREAKPOINT`, not a
+  catchable exception. The same applies to a `NavigationPath` entry, a
+  `.sheet(item:)` payload, or any `@State` holding a record. Rule:
+  **views address habits by `UUID` and snapshot to value types for
+  display**; resolve the id back to a live record only inside the
+  mutation, against the current `@Query`. Canonical: `TodayRow` /
+  `HabitRoute` / `HabitDetailLoader` (issue #63). The fix is *not*
+  `.id(devModeFlag)` — that stops the crash by resetting exactly the
+  navigation and scroll state the note above exists to preserve.
 - **`ProgressView`'s indeterminate indicator takes its color from
   `.tint`, not `.foregroundStyle` / `.foregroundColor`.** A spinner
   placed on a tinted fill (e.g. a `Color.kadoAccent` capsule) needs an

--- a/Kado/Extensions/ModelContext+Habits.swift
+++ b/Kado/Extensions/ModelContext+Habits.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftData
+import KadoCore
+
+/// Turning an id back into a live managed object, against whichever
+/// store is mounted right now.
+///
+/// Screens address habits and completions by `UUID` and render from
+/// value-type snapshots, so a dev-mode `ModelContainer` swap can't
+/// leave them holding an object the old store vended — reading one
+/// traps inside SwiftData (issue #63). These lookups are where the id
+/// becomes a record again: inside a mutation, never in a `body`.
+extension ModelContext {
+    /// The live `HabitRecord` for this id, or `nil` if the store that
+    /// is mounted now doesn't have it.
+    ///
+    /// No `#Predicate`: matching a `UUID` inside one is a shape this
+    /// project stays away from, and the habit list is small enough
+    /// that filtering in Swift costs nothing.
+    func habitRecord(id: UUID) -> HabitRecord? {
+        let all = try? fetch(FetchDescriptor<HabitRecord>())
+        return all?.first { $0.id == id }
+    }
+
+    /// The live `CompletionRecord` for this id, same rules.
+    func completionRecord(id: UUID) -> CompletionRecord? {
+        let all = try? fetch(FetchDescriptor<CompletionRecord>())
+        return all?.first { $0.id == id }
+    }
+}

--- a/Kado/Preview Content/PreviewContainer.swift
+++ b/Kado/Preview Content/PreviewContainer.swift
@@ -22,6 +22,14 @@ enum PreviewContainer {
         }
     }()
 
+    /// Id of the first seeded habit, for previews of screens that
+    /// address a habit by id rather than by managed object (e.g.
+    /// `HabitDetailLoader`).
+    static var firstHabitID: UUID {
+        let descriptor = FetchDescriptor<HabitRecord>(sortBy: [SortDescriptor(\.sortOrder)])
+        return (try? shared.mainContext.fetch(descriptor))?.first?.id ?? UUID()
+    }
+
     /// In-memory container with no habits — exercises the empty state.
     static func emptyContainer() -> ModelContainer {
         do {

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -1,6 +1,40 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Habit unavailable" : {
+      "comment" : "Title of the placeholder shown when a screen's habit no longer exists.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habit unavailable"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Habitude indisponible"
+          }
+        }
+      }
+    },
+    "This habit is no longer available." : {
+      "comment" : "Description under the 'Habit unavailable' placeholder.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This habit is no longer available."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette habitude n'est plus disponible."
+          }
+        }
+      }
+    },
     "SUPPORT" : {
       "comment" : "Eyebrow label above the Tip Jar screen title. Displayed uppercased.",
       "localizations" : {

--- a/Kado/UIComponents/HabitUnavailableView.swift
+++ b/Kado/UIComponents/HabitUnavailableView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import KadoCore
+
+/// Placeholder for a screen whose habit id no longer resolves to a
+/// record — the store was swapped underneath it (dev mode) or the
+/// habit was deleted while the screen was still on the stack.
+///
+/// Screens address habits by id rather than by managed object so a
+/// container swap can't trap them (issue #63); this is what they show
+/// when the lookup comes back empty.
+struct HabitUnavailableView: View {
+    var body: some View {
+        ContentUnavailableView {
+            Label("Habit unavailable", systemImage: "questionmark.circle")
+        } description: {
+            Text("This habit is no longer available.")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.kadoBackground.ignoresSafeArea())
+    }
+}
+
+#Preview {
+    HabitUnavailableView()
+}
+
+#Preview("Dark") {
+    HabitUnavailableView()
+        .preferredColorScheme(.dark)
+}

--- a/Kado/Views/HabitDetail/CompletionHistoryList.swift
+++ b/Kado/Views/HabitDetail/CompletionHistoryList.swift
@@ -5,15 +5,22 @@ import KadoCore
 /// Scrollable list of completions for a habit, sorted newest first.
 /// Swipe-to-delete removes a completion. Empty state shows a neutral
 /// "No history yet" row.
+///
+/// Takes value-type snapshots for the same reason `HabitDetailView`
+/// does: its `ForEach` would otherwise hold `CompletionRecord`s from
+/// a store a dev-mode swap has already replaced, and re-reading one
+/// during an update pass traps inside SwiftData (issue #63). Deletion
+/// resolves the record by id against the current context.
 struct CompletionHistoryList: View {
-    @Bindable var habit: HabitRecord
+    let habitType: HabitType
+    let completions: [Completion]
 
     @Environment(\.modelContext) private var modelContext
     @Environment(\.calendar) private var calendar
     @Environment(\.today) private var today
 
-    private var sortedCompletions: [CompletionRecord] {
-        (habit.completions ?? []).sorted { $0.date > $1.date }
+    private var sortedCompletions: [Completion] {
+        completions.sorted { $0.date > $1.date }
     }
 
     var body: some View {
@@ -50,7 +57,7 @@ struct CompletionHistoryList: View {
     }
 
     @ViewBuilder
-    private func row(for completion: CompletionRecord) -> some View {
+    private func row(for completion: Completion) -> some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(relativeDate(for: completion.date))
@@ -87,8 +94,9 @@ struct CompletionHistoryList: View {
         }
     }
 
-    private func delete(_ completion: CompletionRecord) {
-        CompletionLogger(calendar: calendar).delete(completion, in: modelContext)
+    private func delete(_ completion: Completion) {
+        guard let record = modelContext.completionRecord(id: completion.id) else { return }
+        CompletionLogger(calendar: calendar).delete(record, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
@@ -123,8 +131,8 @@ struct CompletionHistoryList: View {
         return formatter.string(from: date)
     }
 
-    private func valueLabel(for completion: CompletionRecord) -> String {
-        switch habit.type {
+    private func valueLabel(for completion: Completion) -> String {
+        switch habitType {
         case .binary:
             return String(localized: "Done")
         case .negative:
@@ -155,8 +163,10 @@ struct CompletionHistoryList: View {
 }
 
 #Preview("Empty") {
-    CompletionHistoryListPreviewWrapperEmpty()
-        .modelContainer(PreviewContainer.emptyContainer())
+    ScrollView {
+        CompletionHistoryList(habitType: .binary, completions: [])
+            .padding()
+    }
 }
 
 #Preview("Dark") {
@@ -178,24 +188,14 @@ private struct CompletionHistoryListPreviewWrapper: View {
     var body: some View {
         ScrollView {
             if let habit = habits.first {
-                CompletionHistoryList(habit: habit)
-                    .padding()
+                CompletionHistoryList(
+                    habitType: habit.type,
+                    completions: (habit.completions ?? []).compactMap(\.snapshot)
+                )
+                .padding()
             } else {
                 Text("Seed habit not found")
             }
         }
-    }
-}
-
-private struct CompletionHistoryListPreviewWrapperEmpty: View {
-    @Environment(\.modelContext) private var context
-    @State private var habit = HabitRecord(name: "Fresh")
-
-    var body: some View {
-        ScrollView {
-            CompletionHistoryList(habit: habit)
-                .padding()
-        }
-        .onAppear { context.insert(habit) }
     }
 }

--- a/Kado/Views/HabitDetail/HabitDetailLoader.swift
+++ b/Kado/Views/HabitDetail/HabitDetailLoader.swift
@@ -1,0 +1,45 @@
+import SwiftData
+import SwiftUI
+import KadoCore
+
+/// Resolves a habit id to the live `HabitRecord` in whichever store is
+/// currently mounted, then renders `HabitDetailView`.
+///
+/// Today pushes a `HabitRoute` (an id) rather than the record itself: a
+/// `NavigationPath` survives a dev-mode `ModelContainer` swap, and a
+/// record it retained from the previous store traps as soon as SwiftUI
+/// re-reads it (issue #63). Re-resolving on every render means the
+/// pushed screen follows the swap instead of holding a dead object.
+struct HabitDetailLoader: View {
+    let habitID: UUID
+
+    /// Deliberately unfiltered. A `#Predicate` matching on `UUID` is
+    /// exactly the kind of thing this project has been bitten by
+    /// before, the habit list is small enough that a Swift-side lookup
+    /// costs nothing, and archived habits must stay reachable here —
+    /// the detail screen renders them read-only.
+    @Query(sort: \HabitRecord.sortOrder) private var allHabits: [HabitRecord]
+
+    var body: some View {
+        if let record = allHabits.first(where: { $0.id == habitID }) {
+            HabitDetailView(habit: record)
+        } else {
+            HabitUnavailableView()
+        }
+    }
+}
+
+#Preview("Found") {
+    NavigationStack {
+        HabitDetailLoader(habitID: PreviewContainer.firstHabitID)
+    }
+    .modelContainer(PreviewContainer.shared)
+}
+
+#Preview("Dark") {
+    NavigationStack {
+        HabitDetailLoader(habitID: UUID())
+    }
+    .modelContainer(PreviewContainer.shared)
+    .preferredColorScheme(.dark)
+}

--- a/Kado/Views/HabitDetail/HabitDetailLoader.swift
+++ b/Kado/Views/HabitDetail/HabitDetailLoader.swift
@@ -22,7 +22,17 @@ struct HabitDetailLoader: View {
 
     var body: some View {
         if let record = allHabits.first(where: { $0.id == habitID }) {
-            HabitDetailView(habit: record)
+            // Snapshotted here, at the boundary. Re-resolving the id is
+            // necessary but not sufficient on its own: handing the
+            // record down let SwiftUI re-run the detail screen's
+            // retained body against the previous store's object before
+            // this re-resolution reached it. Only `@Query` is safe to
+            // read a record from, because SwiftUI refreshes it before
+            // evaluating this body.
+            HabitDetailView(
+                habit: record.snapshot,
+                completions: (record.completions ?? []).compactMap(\.snapshot)
+            )
         } else {
             HabitUnavailableView()
         }

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -6,8 +6,19 @@ import KadoCore
 /// type, and a current-month completion grid. Toolbar actions open
 /// the edit sheet and present an archive confirmation dialog; both
 /// are disabled once the habit is archived.
+///
+/// Renders from value-type snapshots and never stores a
+/// `HabitRecord`. `HabitDetailLoader` re-resolving the id on every
+/// render is necessary but *not* sufficient on its own: SwiftUI
+/// re-evaluates this view's retained struct against the previous
+/// store's record before the loader's re-resolution reaches it, and
+/// reading `habit.name` off an invalidated object traps inside
+/// SwiftData. Holding only structs means there is nothing left to
+/// invalidate; mutations resolve the record by id against the current
+/// context (issue #63).
 struct HabitDetailView: View {
-    @Bindable var habit: HabitRecord
+    let habit: Habit
+    let completions: [Completion]
 
     @Environment(\.habitScoreCalculator) private var scoreCalculator
     @Environment(\.streakCalculator) private var streakCalculator
@@ -30,9 +41,15 @@ struct HabitDetailView: View {
 
     private var isArchived: Bool { habit.archivedAt != nil }
 
+    /// The live record behind this screen, resolved against the store
+    /// that is mounted now. Called from mutations only — never from a
+    /// `body`, which is the whole point.
+    private var record: HabitRecord? {
+        modelContext.habitRecord(id: habit.id)
+    }
+
     private var trackingSinceLabel: String? {
-        let comps = (habit.completions ?? []).compactMap(\.snapshot)
-        let effective = habit.snapshot.effectiveStart(completions: comps, calendar: calendar)
+        let effective = habit.effectiveStart(completions: completions, calendar: calendar)
         let createdDay = calendar.startOfDay(for: habit.createdAt)
         let effectiveDay = calendar.startOfDay(for: effective)
         guard effectiveDay != createdDay else { return nil }
@@ -50,8 +67,8 @@ struct HabitDetailView: View {
                 metricsRow
                 quickLogSection
                 MonthlyCalendarView(
-                    habit: habit.snapshot,
-                    completions: (habit.completions ?? []).compactMap(\.snapshot),
+                    habit: habit,
+                    completions: completions,
                     month: Binding(
                         get: { displayedMonth ?? today },
                         set: { displayedMonth = $0 }
@@ -60,7 +77,7 @@ struct HabitDetailView: View {
                     navigable: true,
                     popoverContent: { day in
                         DayEditPopover(
-                            habit: habit.snapshot,
+                            habit: habit,
                             date: day,
                             currentValue: currentValue(on: day),
                             currentNote: currentNote(on: day),
@@ -73,7 +90,7 @@ struct HabitDetailView: View {
                         .presentationCompactAdaptation(.popover)
                     }
                 )
-                CompletionHistoryList(habit: habit)
+                CompletionHistoryList(habitType: habit.type, completions: completions)
             }
             .padding()
         }
@@ -100,10 +117,18 @@ struct HabitDetailView: View {
             }
         }
         .sheet(isPresented: $showingEdit) {
-            NewHabitFormView(model: NewHabitFormModel(editing: habit))
+            if let record {
+                NewHabitFormView(model: NewHabitFormModel(editing: record))
+            } else {
+                HabitUnavailableView()
+            }
         }
         .sheet(isPresented: $showingTimerSheet) {
-            TimerLogSheet(habit: habit)
+            if let record {
+                TimerLogSheet(habit: record)
+            } else {
+                HabitUnavailableView()
+            }
         }
         .confirmationDialog(
             String(localized: "Archive this habit?"),
@@ -126,7 +151,8 @@ struct HabitDetailView: View {
     }
 
     private func archive() {
-        habit.archivedAt = loggingInstant
+        guard let record else { return }
+        record.archivedAt = loggingInstant
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
         dismiss()
@@ -167,45 +193,48 @@ struct HabitDetailView: View {
     }
 
     private var todayCounterValue: Double {
-        habit.completions?
-            .first { calendar.isDate($0.date, inSameDayAs: today) }?
-            .value ?? 0
+        completion(on: today)?.value ?? 0
     }
 
     private func incrementCounter() {
-        CompletionLogger(calendar: calendar).incrementCounter(for: habit, on: loggingInstant, in: modelContext)
+        guard let record else { return }
+        CompletionLogger(calendar: calendar).incrementCounter(for: record, on: loggingInstant, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
     private func decrementCounter() {
-        CompletionLogger(calendar: calendar).decrementCounter(for: habit, on: loggingInstant, in: modelContext)
+        guard let record else { return }
+        CompletionLogger(calendar: calendar).decrementCounter(for: record, on: loggingInstant, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
     // MARK: - Past-day popover mutations
 
+    /// The snapshotted completion covering a day, if there is one.
+    private func completion(on day: Date) -> Completion? {
+        completions.first { calendar.isDate($0.date, inSameDayAs: day) }
+    }
+
     private func currentValue(on day: Date) -> Double {
-        habit.completions?
-            .first { calendar.isDate($0.date, inSameDayAs: day) }?
-            .value ?? 0
+        completion(on: day)?.value ?? 0
     }
 
     private func currentNote(on day: Date) -> String? {
-        habit.completions?
-            .first { calendar.isDate($0.date, inSameDayAs: day) }?
-            .note
+        completion(on: day)?.note
     }
 
     private func toggle(on day: Date) {
-        CompletionToggler(calendar: calendar).toggleToday(for: habit, on: day, in: modelContext)
+        guard let record else { return }
+        CompletionToggler(calendar: calendar).toggleToday(for: record, on: day, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
     private func setCounter(_ value: Double, on day: Date) {
-        CompletionLogger(calendar: calendar).setCounter(for: habit, on: day, to: value, in: modelContext)
+        guard let record else { return }
+        CompletionLogger(calendar: calendar).setCounter(for: record, on: day, to: value, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
@@ -217,8 +246,9 @@ struct HabitDetailView: View {
             clear(on: day)
             return
         }
+        guard let record else { return }
         CompletionLogger(calendar: calendar).logTimerSession(
-            for: habit,
+            for: record,
             seconds: seconds,
             on: day,
             in: modelContext
@@ -228,15 +258,19 @@ struct HabitDetailView: View {
     }
 
     private func setNote(_ note: String?, on day: Date) {
-        CompletionLogger(calendar: calendar).setNote(for: habit, on: day, to: note, in: modelContext)
+        guard let record else { return }
+        CompletionLogger(calendar: calendar).setNote(for: record, on: day, to: note, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
     private func clear(on day: Date) {
-        guard let existing = habit.completions?.first(where: {
-            calendar.isDate($0.date, inSameDayAs: day)
-        }) else { return }
+        // Resolved from the snapshot's id rather than by walking the
+        // record's relationship, so the day being cleared is the one
+        // the user was actually looking at.
+        guard let snapshot = completion(on: day),
+              let existing = modelContext.completionRecord(id: snapshot.id)
+        else { return }
         if existing.note != nil {
             existing.value = 0
         } else {
@@ -344,27 +378,19 @@ struct HabitDetailView: View {
 
     private var scorePercent: String {
         let score = scoreCalculator.currentScore(
-            for: habit.snapshot,
-            completions: (habit.completions ?? []).compactMap(\.snapshot),
+            for: habit,
+            completions: completions,
             asOf: today
         )
         return "\(Int((score * 100).rounded()))%"
     }
 
     private var currentStreak: Int {
-        streakCalculator.current(
-            for: habit.snapshot,
-            completions: (habit.completions ?? []).compactMap(\.snapshot),
-            asOf: today
-        )
+        streakCalculator.current(for: habit, completions: completions, asOf: today)
     }
 
     private var bestStreak: Int {
-        streakCalculator.best(
-            for: habit.snapshot,
-            completions: (habit.completions ?? []).compactMap(\.snapshot),
-            asOf: today
-        )
+        streakCalculator.best(for: habit, completions: completions, asOf: today)
     }
 
     private var frequencyLabel: String {
@@ -431,10 +457,13 @@ private struct HabitDetailPreviewWrapper: View {
 
     var body: some View {
         if let habit = habits.first {
-            HabitDetailView(habit: habit)
-                .onAppear {
-                    if archived { habit.archivedAt = .now }
-                }
+            HabitDetailView(
+                habit: habit.snapshot,
+                completions: (habit.completions ?? []).compactMap(\.snapshot)
+            )
+            .onAppear {
+                if archived { habit.archivedAt = .now }
+            }
         } else {
             ContentUnavailableView(
                 "Seed habit not found",

--- a/Kado/Views/Today/TodayRow.swift
+++ b/Kado/Views/Today/TodayRow.swift
@@ -1,0 +1,80 @@
+import Foundation
+import KadoCore
+
+/// Value-type snapshot of one row in the Today list.
+///
+/// `ForEach` retains the collection it was handed and re-reads
+/// `Identifiable.id` during the list diff — and that diff can run
+/// *after* a dev-mode `ModelContainer` swap has invalidated every
+/// `HabitRecord` the previous store vended. Reading any persisted
+/// property on an invalidated managed object traps inside SwiftData,
+/// so the list must never hold one (issue #63).
+///
+/// Handing `ForEach` plain structs leaves nothing to invalidate.
+/// Mutations resolve the record by `id` against the live `@Query`,
+/// which always reflects whichever store is currently mounted.
+struct TodayRow: Identifiable {
+    let habit: Habit
+    let completions: [Completion]
+
+    var id: UUID { habit.id }
+
+    init(habit: Habit, completions: [Completion]) {
+        self.habit = habit
+        self.completions = completions
+    }
+
+    init(_ record: HabitRecord) {
+        self.init(
+            habit: record.snapshot,
+            completions: (record.completions ?? []).compactMap(\.snapshot)
+        )
+    }
+}
+
+extension TodayRow {
+    /// Snapshots every record, then splits the rows into the two
+    /// sections Today renders: the ones the schedule asks for today
+    /// (or that already have progress logged today), and the rest.
+    ///
+    /// The snapshot happens once, up front, so the two sections and
+    /// every derived metric read the same frozen data — and so nothing
+    /// downstream keeps a reference to a managed object.
+    static func sections(
+        from records: [HabitRecord],
+        on now: Date,
+        evaluator: any FrequencyEvaluating,
+        calendar: Calendar
+    ) -> (due: [TodayRow], other: [TodayRow]) {
+        var due: [TodayRow] = []
+        var other: [TodayRow] = []
+        // Spelled out rather than `map(TodayRow.init)`: passing a
+        // MainActor-isolated initializer as a function value to a
+        // nonisolated generic loses the isolation and warns.
+        for row in records.map({ TodayRow($0) }) {
+            let isDue = evaluator.isDueOrLogged(
+                habit: row.habit,
+                on: now,
+                completions: row.completions,
+                calendar: calendar
+            )
+            if isDue {
+                due.append(row)
+            } else {
+                other.append(row)
+            }
+        }
+        return (due, other)
+    }
+}
+
+/// Navigation value for a pushed habit-detail screen.
+///
+/// Carries the habit's id rather than the `HabitRecord` itself: a
+/// `NavigationPath` outlives a dev-mode container swap, and a managed
+/// object it retained from the previous store traps the moment SwiftUI
+/// re-reads it. `HabitDetailLoader` turns the id back into a live
+/// record against the store that is mounted now.
+struct HabitRoute: Hashable {
+    let id: UUID
+}

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -6,6 +6,14 @@ import KadoCore
 /// for binary and negative habits, inline counter / timer logging,
 /// and a long-press context menu for the secondary actions
 /// (specific-value sheets, edit, archive).
+///
+/// Every piece of state this view retains — the list rows, the
+/// navigation path, the presented sheet, the pending archive
+/// confirmation — holds a habit **id**, never a `HabitRecord`. A
+/// dev-mode `ModelContainer` swap invalidates every managed object the
+/// previous store vended, and SwiftUI re-reads its retained data
+/// during the next list diff, which traps inside SwiftData. Ids
+/// survive the swap; records don't (issue #63).
 struct TodayView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.frequencyEvaluator) private var frequencyEvaluator
@@ -24,23 +32,23 @@ struct TodayView: View {
 
     @State private var path = NavigationPath()
     @State private var sheet: TodaySheet?
-    @State private var confirmingArchiveOf: HabitRecord?
+    @State private var confirmingArchiveOf: UUID?
 
     /// Single source of truth for sheets the Today surface presents.
     /// Replaces the boolean soup that would otherwise emerge from
     /// New / Edit / Log-counter / Log-timer running in parallel.
     enum TodaySheet: Identifiable {
         case newHabit
-        case editHabit(HabitRecord)
-        case logCounter(HabitRecord)
-        case logTimer(HabitRecord)
+        case editHabit(UUID)
+        case logCounter(UUID)
+        case logTimer(UUID)
 
         var id: String {
             switch self {
             case .newHabit: "new"
-            case .editHabit(let h): "edit-\(h.id)"
-            case .logCounter(let h): "counter-\(h.id)"
-            case .logTimer(let h): "timer-\(h.id)"
+            case .editHabit(let habitID): "edit-\(habitID)"
+            case .logCounter(let habitID): "counter-\(habitID)"
+            case .logTimer(let habitID): "timer-\(habitID)"
             }
         }
     }
@@ -51,8 +59,8 @@ struct TodayView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color.kadoBackground.ignoresSafeArea())
                 .navigationTitle(Text("Today"))
-                .navigationDestination(for: HabitRecord.self) { habit in
-                    HabitDetailView(habit: habit)
+                .navigationDestination(for: HabitRoute.self) { route in
+                    HabitDetailLoader(habitID: route.id)
                 }
                 .toolbar {
                     ToolbarItem(placement: .primaryAction) {
@@ -71,9 +79,9 @@ struct TodayView: View {
                     isPresented: archiveDialogBinding,
                     titleVisibility: .visible,
                     presenting: confirmingArchiveOf
-                ) { habit in
+                ) { habitID in
                     Button(String(localized: "Archive"), role: .destructive) {
-                        archive(habit)
+                        archive(habitID)
                     }
                     Button(String(localized: "Cancel"), role: .cancel) {}
                 } message: { _ in
@@ -87,12 +95,24 @@ struct TodayView: View {
         switch sheet {
         case .newHabit:
             NewHabitFormView(model: NewHabitFormModel())
-        case .editHabit(let habit):
-            NewHabitFormView(model: NewHabitFormModel(editing: habit))
-        case .logCounter(let habit):
-            CounterLogSheet(habit: habit)
-        case .logTimer(let habit):
-            TimerLogSheet(habit: habit)
+        case .editHabit(let habitID):
+            if let record = record(for: habitID) {
+                NewHabitFormView(model: NewHabitFormModel(editing: record))
+            } else {
+                HabitUnavailableView()
+            }
+        case .logCounter(let habitID):
+            if let record = record(for: habitID) {
+                CounterLogSheet(habit: record)
+            } else {
+                HabitUnavailableView()
+            }
+        case .logTimer(let habitID):
+            if let record = record(for: habitID) {
+                TimerLogSheet(habit: record)
+            } else {
+                HabitUnavailableView()
+            }
         }
     }
 
@@ -112,8 +132,7 @@ struct TodayView: View {
                 .buttonStyle(.borderedProminent)
             }
         } else {
-            let due = habitsDueToday
-            let other = habitsNotDueToday
+            let (due, other) = sections
             List {
                 // Sampled once and passed down: letting the guard and
                 // the view each read `.now` lets them straddle the
@@ -153,42 +172,40 @@ struct TodayView: View {
     }
 
     @ViewBuilder
-    private func row(_ record: HabitRecord) -> some View {
-        let snap = record.snapshot
-        let comps = (record.completions ?? []).compactMap(\.snapshot)
+    private func row(_ item: TodayRow) -> some View {
         let state = HabitRowState.resolve(
-            habit: snap,
-            completions: comps,
+            habit: item.habit,
+            completions: item.completions,
             calendar: calendar,
             asOf: today
         )
-        NavigationLink(value: record) {
+        NavigationLink(value: HabitRoute(id: item.id)) {
             HabitRowView(
-                habit: snap,
+                habit: item.habit,
                 state: state,
                 streak: streakCalculator.current(
-                    for: snap, completions: comps, asOf: today
+                    for: item.habit, completions: item.completions, asOf: today
                 ),
                 scorePercent: Int(
                     (scoreCalculator.currentScore(
-                        for: snap, completions: comps, asOf: today
+                        for: item.habit, completions: item.completions, asOf: today
                     ) * 100).rounded()
                 ),
-                onToggle: canToggle(record) ? { toggle(record) } : nil,
-                onCounterIncrement: isCounter(record) ? { incrementCounter(record) } : nil,
-                onCounterDecrement: isCounter(record) ? { decrementCounter(record) } : nil,
-                onTimerAddFiveMinutes: isTimer(record) ? { addFiveMinutes(record) } : nil,
-                onLogSpecificValue: logSheetCallback(for: record),
-                onOpenDetail: { path.append(record) },
-                onEdit: { sheet = .editHabit(record) },
-                onArchive: { confirmingArchiveOf = record }
+                onToggle: canToggle(item) ? { toggle(item.id) } : nil,
+                onCounterIncrement: isCounter(item) ? { incrementCounter(item.id) } : nil,
+                onCounterDecrement: isCounter(item) ? { decrementCounter(item.id) } : nil,
+                onTimerAddFiveMinutes: isTimer(item) ? { addFiveMinutes(item.id) } : nil,
+                onLogSpecificValue: logSheetCallback(for: item),
+                onOpenDetail: { path.append(HabitRoute(id: item.id)) },
+                onEdit: { sheet = .editHabit(item.id) },
+                onArchive: { confirmingArchiveOf = item.id }
             )
         }
         .listRowBackground(Color.kadoBackgroundSecondary)
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            if canSwipeUndo(record, state: state) {
+            if canSwipeUndo(item, state: state) {
                 Button(role: .destructive) {
-                    toggle(record)
+                    toggle(item.id)
                 } label: {
                     Label("Undo", systemImage: "arrow.uturn.backward")
                 }
@@ -196,32 +213,28 @@ struct TodayView: View {
         }
     }
 
-    private var habitsDueToday: [HabitRecord] {
-        activeHabits.filter { record in
-            isDueTodayOrCompletedToday(record, on: today)
-        }
-    }
-
-    private var habitsNotDueToday: [HabitRecord] {
-        activeHabits.filter { record in
-            !isDueTodayOrCompletedToday(record, on: today)
-        }
-    }
-
-    /// "Show this habit in the Today section" — the schedule asks for
-    /// it today, or the user already logged progress today anyway (so
-    /// the row stays visible with its tick even once the daysPerWeek
-    /// rolling quota saturates).
+    /// The two Today sections, snapshotted from the live records.
     ///
-    /// The rule itself lives on `FrequencyEvaluating` so this view and
-    /// the widget snapshot can't drift apart.
-    private func isDueTodayOrCompletedToday(_ record: HabitRecord, on now: Date) -> Bool {
-        frequencyEvaluator.isDueOrLogged(
-            habit: record.snapshot,
-            on: now,
-            completions: (record.completions ?? []).compactMap(\.snapshot),
+    /// The split rule — "the schedule asks for it today, or the user
+    /// already logged progress today anyway", which keeps a row
+    /// visible with its tick once a daysPerWeek rolling quota
+    /// saturates — lives on `FrequencyEvaluating` so this view and the
+    /// widget snapshot can't drift apart.
+    private var sections: (due: [TodayRow], other: [TodayRow]) {
+        TodayRow.sections(
+            from: activeHabits,
+            on: today,
+            evaluator: frequencyEvaluator,
             calendar: calendar
         )
+    }
+
+    /// Resolves a row back to the live managed object it was
+    /// snapshotted from, against whichever store is mounted now.
+    /// Returns `nil` when the habit isn't there any more — archived
+    /// from another surface, or left behind by a dev-mode store swap.
+    private func record(for habitID: UUID) -> HabitRecord? {
+        activeHabits.first { $0.id == habitID }
     }
 
     private var archiveDialogBinding: Binding<Bool> {
@@ -233,20 +246,20 @@ struct TodayView: View {
 
     // MARK: - Type predicates
 
-    private func canToggle(_ record: HabitRecord) -> Bool {
-        switch record.type {
+    private func canToggle(_ item: TodayRow) -> Bool {
+        switch item.habit.type {
         case .binary, .negative: true
         case .counter, .timer: false
         }
     }
 
-    private func isCounter(_ record: HabitRecord) -> Bool {
-        if case .counter = record.type { return true }
+    private func isCounter(_ item: TodayRow) -> Bool {
+        if case .counter = item.habit.type { return true }
         return false
     }
 
-    private func isTimer(_ record: HabitRecord) -> Bool {
-        if case .timer = record.type { return true }
+    private func isTimer(_ item: TodayRow) -> Bool {
+        if case .timer = item.habit.type { return true }
         return false
     }
 
@@ -254,18 +267,18 @@ struct TodayView: View {
     /// day is already marked. Counter / timer get their undo from the
     /// row's own `−` button (counter) or the "Log specific value…"
     /// menu item, so a swipe action would be redundant.
-    private func canSwipeUndo(_ record: HabitRecord, state: HabitRowState) -> Bool {
+    private func canSwipeUndo(_ item: TodayRow, state: HabitRowState) -> Bool {
         guard state.status == .complete else { return false }
-        switch record.type {
+        switch item.habit.type {
         case .binary, .negative: return true
         case .counter, .timer: return false
         }
     }
 
-    private func logSheetCallback(for record: HabitRecord) -> (() -> Void)? {
-        switch record.type {
-        case .counter: return { sheet = .logCounter(record) }
-        case .timer: return { sheet = .logTimer(record) }
+    private func logSheetCallback(for item: TodayRow) -> (() -> Void)? {
+        switch item.habit.type {
+        case .counter: return { sheet = .logCounter(item.id) }
+        case .timer: return { sheet = .logTimer(item.id) }
         case .binary, .negative: return nil
         }
     }
@@ -279,29 +292,35 @@ struct TodayView: View {
         dayBoundary.loggingInstant(for: .now, on: today)
     }
 
-    private func moveHabits(_ section: [HabitRecord], from source: IndexSet, to destination: Int) {
+    private func moveHabits(_ section: [TodayRow], from source: IndexSet, to destination: Int) {
         var reordered = section
         reordered.move(fromOffsets: source, toOffset: destination)
 
-        let due = habitsDueToday
-        let other = habitsNotDueToday
-        let isDueSection = section.first.map({ due.contains($0) }) == true
+        let (due, other) = sections
+        let isDueSection = section.first.map { first in
+            due.contains { $0.id == first.id }
+        } == true
 
-        let finalOrder: [HabitRecord]
+        let finalOrder: [TodayRow]
         if isDueSection {
             finalOrder = reordered + other
         } else {
             finalOrder = due + reordered
         }
 
-        for (index, record) in finalOrder.enumerated() {
-            record.sortOrder = index
+        let recordsByID = Dictionary(
+            activeHabits.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for (index, item) in finalOrder.enumerated() {
+            recordsByID[item.id]?.sortOrder = index
         }
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
-    private func toggle(_ record: HabitRecord) {
+    private func toggle(_ habitID: UUID) {
+        guard let record = record(for: habitID) else { return }
         CompletionToggler(calendar: calendar)
             .toggleToday(for: record, on: loggingInstant, in: modelContext)
         try? modelContext.save()
@@ -309,7 +328,8 @@ struct TodayView: View {
         checkMilestones(for: record)
     }
 
-    private func incrementCounter(_ record: HabitRecord) {
+    private func incrementCounter(_ habitID: UUID) {
+        guard let record = record(for: habitID) else { return }
         CompletionLogger(calendar: calendar)
             .incrementCounter(for: record, on: loggingInstant, in: modelContext)
         try? modelContext.save()
@@ -317,14 +337,16 @@ struct TodayView: View {
         checkMilestones(for: record)
     }
 
-    private func decrementCounter(_ record: HabitRecord) {
+    private func decrementCounter(_ habitID: UUID) {
+        guard let record = record(for: habitID) else { return }
         CompletionLogger(calendar: calendar)
             .decrementCounter(for: record, on: loggingInstant, in: modelContext)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
-    private func addFiveMinutes(_ record: HabitRecord) {
+    private func addFiveMinutes(_ habitID: UUID) {
+        guard let record = record(for: habitID) else { return }
         CompletionLogger(calendar: calendar)
             .incrementCounter(for: record, on: loggingInstant, by: 300, in: modelContext)
         try? modelContext.save()
@@ -340,17 +362,23 @@ struct TodayView: View {
             reviewPromptService.recordMilestone(.streak(days: streak))
         }
 
-        let allComplete = habitsDueToday.allSatisfy { habit in
-            let s = habit.snapshot
-            let c = (habit.completions ?? []).compactMap(\.snapshot)
-            return HabitRowState.resolve(habit: s, completions: c, calendar: calendar, asOf: today).status == .complete
+        // Re-snapshotted after the save, so this sees the mutation that
+        // just landed rather than the pre-tap rows.
+        let allComplete = sections.due.allSatisfy { item in
+            HabitRowState.resolve(
+                habit: item.habit,
+                completions: item.completions,
+                calendar: calendar,
+                asOf: today
+            ).status == .complete
         }
         if allComplete {
             reviewPromptService.recordMilestone(.allHabitsComplete)
         }
     }
 
-    private func archive(_ record: HabitRecord) {
+    private func archive(_ habitID: UUID) {
+        guard let record = record(for: habitID) else { return }
         record.archivedAt = loggingInstant
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)

--- a/KadoTests/TodayRowTests.swift
+++ b/KadoTests/TodayRowTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Kado
+import KadoCore
+
+/// Regression coverage for issue #63: the Today list must hold value
+/// types, not managed objects. A dev-mode `ModelContainer` swap
+/// invalidates every `HabitRecord` the previous store vended, and
+/// `ForEach` re-reads its retained data during the next list diff —
+/// so anything the list keeps has to stay readable once the records
+/// behind it are gone.
+@Suite("TodayRow")
+@MainActor
+struct TodayRowTests {
+    private func makeContainer() throws -> ModelContainer {
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
+        return try ModelContainer(
+            for: schema,
+            migrationPlan: KadoMigrationPlan.self,
+            configurations: ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        )
+    }
+
+    private let calendar = TestCalendar.utc
+    private let evaluator = DefaultFrequencyEvaluator()
+
+    /// 2026-03-11, a Wednesday.
+    private var now: Date {
+        calendar.date(from: DateComponents(year: 2026, month: 3, day: 11, hour: 12))!
+    }
+
+    @Test("Rows stay readable after their records are deleted")
+    func rowsSurviveRecordDeletion() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+
+        let habit = HabitRecord(
+            name: "Meditate",
+            frequency: .daily,
+            type: .binary,
+            createdAt: calendar.date(byAdding: .day, value: -10, to: now)!,
+            sortOrder: 0
+        )
+        ctx.insert(habit)
+        ctx.insert(CompletionRecord(date: now, value: 1, habit: habit))
+        try ctx.save()
+
+        let (due, _) = TodayRow.sections(
+            from: try ctx.fetch(FetchDescriptor<HabitRecord>()),
+            on: now,
+            evaluator: evaluator,
+            calendar: calendar
+        )
+        let id = try #require(due.first).id
+
+        // Stand-in for the container swap: the records the rows came
+        // from are gone, but the rows themselves must still answer.
+        for record in try ctx.fetch(FetchDescriptor<HabitRecord>()) {
+            ctx.delete(record)
+        }
+        try ctx.save()
+
+        let row = try #require(due.first)
+        #expect(row.id == id)
+        #expect(row.habit.name == "Meditate")
+        #expect(row.completions.count == 1)
+    }
+
+    @Test("Row id is the habit id, which is what ForEach diffs on")
+    func rowIDIsHabitID() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+
+        let habit = HabitRecord(name: "Read", frequency: .daily, type: .binary, createdAt: now)
+        ctx.insert(habit)
+        try ctx.save()
+
+        let row = TodayRow(habit)
+        #expect(row.id == habit.id)
+    }
+
+    @Test("Sections split habits the schedule asks for today from the rest")
+    func sectionsSplitByDueness() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+        let createdAt = calendar.date(byAdding: .day, value: -30, to: now)!
+
+        let daily = HabitRecord(
+            name: "Daily", frequency: .daily, type: .binary, createdAt: createdAt, sortOrder: 0
+        )
+        // Wednesday is 2026-03-11; scheduling Monday only keeps this
+        // one out of the due section.
+        let mondayOnly = HabitRecord(
+            name: "Mondays",
+            frequency: .specificDays([.monday]),
+            type: .binary,
+            createdAt: createdAt,
+            sortOrder: 1
+        )
+        ctx.insert(daily)
+        ctx.insert(mondayOnly)
+        try ctx.save()
+
+        let (due, other) = TodayRow.sections(
+            from: try ctx.fetch(
+                FetchDescriptor<HabitRecord>(sortBy: [SortDescriptor(\.sortOrder)])
+            ),
+            on: now,
+            evaluator: evaluator,
+            calendar: calendar
+        )
+
+        #expect(due.map(\.habit.name) == ["Daily"])
+        #expect(other.map(\.habit.name) == ["Mondays"])
+    }
+
+    @Test("A habit logged today stays in the due section even when off schedule")
+    func loggedOffScheduleHabitStaysDue() throws {
+        let container = try makeContainer()
+        let ctx = container.mainContext
+
+        let mondayOnly = HabitRecord(
+            name: "Mondays",
+            frequency: .specificDays([.monday]),
+            type: .binary,
+            createdAt: calendar.date(byAdding: .day, value: -30, to: now)!
+        )
+        ctx.insert(mondayOnly)
+        ctx.insert(CompletionRecord(date: now, value: 1, habit: mondayOnly))
+        try ctx.save()
+
+        let (due, other) = TodayRow.sections(
+            from: try ctx.fetch(FetchDescriptor<HabitRecord>()),
+            on: now,
+            evaluator: evaluator,
+            calendar: calendar
+        )
+
+        #expect(due.map(\.habit.name) == ["Mondays"])
+        #expect(other.isEmpty)
+    }
+}


### PR DESCRIPTION
## Why?

- Toggling **Dev Mode** in Settings while habits were on screen crashed the app with `EXC_BREAKPOINT` — a SwiftData assertion, not a catchable exception ([#63](https://github.com/scastiel/kado/issues/63)).
- `DevModeController` swaps the `ModelContainer` at runtime, which invalidates every `HabitRecord` the previous store vended. SwiftUI re-reads state it retained across that swap — during a list diff, or when re-evaluating a retained view's body — and reading any persisted property on an invalidated managed object traps.
- `DevModeSection` ships in App Store builds (it's a deliberate user-facing feature with its own confirmation alert), so this is reachable by a real user, not just a debug nuisance.

## What?

Two distinct crashes, both fixed:

1. **The Today list.** Toggle Dev Mode with habits on screen. `ForEach` retains the collection it was handed and re-reads `Identifiable.id` during the diff that runs after the swap.
2. **A pushed detail screen.** Today → tap a habit → Settings → toggle → back to Today. Reachable because tabs stay alive, so the `NavigationPath` outlives the swap. This one wasn't in #63 at all.

Also: a habit that isn't in the store now mounted shows a neutral "Habit unavailable" placeholder (EN + FR) instead of an empty screen. No other behaviour change — same rows, same sections, same reorder / swipe / long-press actions.

## How?

The rule, now recorded in `CLAUDE.md`: **views address habits by `UUID` and render from value-type snapshots; an id becomes a record again only inside a mutation, against the current `@Query` or `ModelContext`.**

**First commit — the list half** (`60aabb7`):

- **`TodayRow`** snapshots a record to `Habit` + `[Completion]` and owns the due / not-due split, so the list diff reads plain structs.
- **`HabitRoute`** carries the id through `NavigationPath` in place of the record.
- **`HabitDetailLoader`** re-resolves that id against whichever store is mounted now, falling back to `HabitUnavailableView`.

**Second commit — the detail half** (`fc219d8`). The first commit did **not** fix this, which only became visible once [#66](https://github.com/scastiel/kado/pull/66)'s UI suite ran the repro for real:

```
_assertionFailure <- SwiftData <- KadoSchemaV4.HabitRecord.name.getter
  <- closure #1 in HabitDetailView.header.getter <- ViewBodyAccessor.updateBody
```

Re-resolving the id in the loader is necessary but **not sufficient**: `HabitDetailView` took `@Bindable var habit: HabitRecord` and retained it, and SwiftUI re-evaluates that retained struct's body against the previous store's record *before* the loader's re-resolution reaches it. Only `@Query` is safe to read a record from, because SwiftUI refreshes it ahead of the body that reads it. So the snapshot boundary moved up into the loader:

- **`HabitDetailView`** takes `Habit` + `[Completion]`. There were no `$habit` binding uses, so nothing needed a two-way path; its ~10 mutation sites resolve the record by id first.
- **`CompletionHistoryList`** takes `HabitType` + `[Completion]` — its `ForEach` was holding `CompletionRecord`s, the same exposure one level down, and would have been the next crash.
- **`ModelContext.habitRecord(id:)` / `.completionRecord(id:)`** are where an id becomes a record again.

Ruled out along the way, so nobody re-derives it: **keying the loader's child on `record.persistentModelID` does not work** — the retained body still runs first.

Other notes:

- `.id(devModeFlag)` was deliberately not used. It stops both crashes by resetting exactly the navigation and scroll state `CLAUDE.md`'s swap note exists to preserve.
- `OverviewView` was named in #63 as having the same exposure. It doesn't — `ForEach(rows, id: \.habit.id)` already iterates value-type `MatrixRow`s.

## Verification

**The repro was executed, not reasoned about.** #66 adds a `KadoUITests` target that drives #63's exact steps; both repros fail against `main` with the app dead, and all three pass here:

```
testTogglingDevModeOffWithHabitsOnScreenDoesNotCrash     passed
testTogglingDevModeOffWithBothStoresPopulated            passed
testTogglingDevModeWithADetailScreenPushedDoesNotCrash   passed
```

Confirmed independently from two worktrees. Plus: `build_sim` clean with no new warnings, `test_sim` 492/492 including 4 new `TodayRowTests`, and screenshots on iPhone 17 Pro (dev dataset, both sections, all four habit types) and iPad Air 11-inch (M4).

An earlier revision of this description asked for a manual verification pass before merge. That's no longer needed — and worth recording that the manual pass would not have caught the detail-screen crash, because the first commit looked correct by inspection and passed all 492 unit tests.

## Next steps

- Merge this **before** #66, which is stacked on it. #66 carries the tests; landing it first would put a red test on `main`.
- No schema change, so no CloudKit console deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XU4DXV9T2m4rPZaDDjFHqP
