### PR TITLE
test(ui): add a KadoUITests target so update-pass crashes are catchable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -818,6 +818,62 @@ where you still open Xcode:
 
 ---
 
+## UI tests (XCUITest)
+
+`KadoUITests` exists for the one class of bug unit tests structurally
+cannot see: a crash *inside* a SwiftUI update pass, where there is no
+seam to assert on. `make e2e` runs it; `make test` keeps the unit
+suite at its usual couple of seconds. Each worktree drives a simulator
+of its own (`SIM_NAME ?= Kado $(notdir $(CURDIR))`) because parallel
+`.claude/worktrees/` runs would otherwise install over each other, and
+XCUITest's parallel clones are named after the device they came from,
+so even the clones collide.
+
+Everything the app exposes to the suite lives in
+`Kado/Support/UITestSupport.swift`, entirely inside `#if DEBUG`.
+
+Four findings, each of which cost a cycle:
+
+- **Never build the UI suite with `CODE_SIGNING_ALLOWED=NO`.** Kadō's
+  app target carries the iCloud and App Group entitlements, and an
+  unsigned build has neither, so `CKContainer(identifier:)` traps on
+  the first line of `KadoApp.init()`. Every test then "fails" at launch
+  with `EXC_BREAKPOINT` for a reason unrelated to what it tested.
+  Simulator builds sign to run locally at no cost.
+- **A launch argument sets a `UserDefaults` value but also freezes
+  it.** `-kado.devMode 1` does start the app in dev mode — and then the
+  argument domain, which outranks every stored value, serves that `1`
+  straight back to `@AppStorage` after the user's toggle writes `false`.
+  The toggle springs on again and nothing swaps. Starting state that a
+  test intends to *change* must be written into the real suite from
+  inside the app (`UITestSupport.applyLaunchArguments()`), not passed
+  as an argument.
+- **SwiftUI's `Tab` gives no seam for an accessibility identifier.**
+  One on the tab's content stamps every element in the screen beneath
+  it; one on its label compiles, looks right, and never reaches the tab
+  bar button — dumped live, all three come through with their labels
+  and an empty identifier. It half-works by accident (the selected
+  tab's label matches something in the content), which is worse than
+  not working. Address tabs by position: `AccessibilityID.Tab`.
+- **`waitForExistence` cannot wait for a row below the fold.** An
+  unrealized `Form` row is not in the hierarchy at all, so the wait
+  watches for something that cannot appear until something scrolls.
+  Scroll first (`KadoUITestCase.scrollTo`). The Dev mode toggle, last
+  section in Settings, looked missing for a full 30s timeout this way.
+
+**Apply accessibility identifiers in the same commit as the view.**
+Retrofitting them across a grown app is what makes UI suites get
+abandoned. They go on **leaves, never containers** —
+`.accessibilityIdentifier` applies to every descendant, so an outer one
+silently erases every identifier set inside it. A row that has already
+collapsed its subtree with `.accessibilityElement(children: .combine)`
+is a leaf, and is the right place (`HabitRowView`). Identifiers also
+matter more here than in an English-only app: Kadō ships French, and a
+suite matching `app.staticTexts["Dev mode"]` passes on one simulator
+and fails on the other.
+
+---
+
 ## Git and commits
 
 ### Branches

--- a/Kado.xcodeproj/project.pbxproj
+++ b/Kado.xcodeproj/project.pbxproj
@@ -30,6 +30,13 @@
 			remoteGlobalIDString = BE58C75C2F940AAF0020146E;
 			remoteInfo = KadoWidgetsExtension;
 		};
+		BEC0DE0130000001000000AB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BE4188722F91B4F0006126D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BE4188792F91B4F0006126D6;
+			remoteInfo = Kado;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -55,6 +62,7 @@
 		BE58C7752F940AC60020146E /* KadoWidgetsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KadoWidgetsExtension.entitlements; sourceTree = "<group>"; };
 		BE7563AF2FF9D739001CB541 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		BE7563B12FF9D7F7001CB541 /* Tips.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Tips.storekit; sourceTree = "<group>"; };
+		BEC0DE0130000001000000A2 /* KadoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KadoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -91,6 +99,11 @@
 			path = KadoWidgets;
 			sourceTree = "<group>";
 		};
+		BEC0DE0130000001000000A3 /* KadoUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = KadoUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +133,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BEC0DE0130000001000000A5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -131,6 +151,7 @@
 				BE58C7752F940AC60020146E /* KadoWidgetsExtension.entitlements */,
 				BE41887C2F91B4F0006126D6 /* Kado */,
 				BE41888A2F91B4F2006126D6 /* KadoTests */,
+				BEC0DE0130000001000000A3 /* KadoUITests */,
 				BE58C7632F940AAF0020146E /* KadoWidgets */,
 				BE58C75E2F940AAF0020146E /* Frameworks */,
 				BE41887B2F91B4F0006126D6 /* Products */,
@@ -142,6 +163,7 @@
 			children = (
 				BE41887A2F91B4F0006126D6 /* Kado.app */,
 				BE4188872F91B4F2006126D6 /* KadoTests.xctest */,
+				BEC0DE0130000001000000A2 /* KadoUITests.xctest */,
 				BE58C75D2F940AAF0020146E /* KadoWidgetsExtension.appex */,
 			);
 			name = Products;
@@ -233,6 +255,30 @@
 			productReference = BE58C75D2F940AAF0020146E /* KadoWidgetsExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		BEC0DE0130000001000000A1 /* KadoUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BEC0DE0130000001000000A7 /* Build configuration list for PBXNativeTarget "KadoUITests" */;
+			buildPhases = (
+				BEC0DE0130000001000000A4 /* Sources */,
+				BEC0DE0130000001000000A5 /* Frameworks */,
+				BEC0DE0130000001000000A6 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BEC0DE0130000001000000AA /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				BE0A51582F94102000E09C34 /* Shared */,
+				BEC0DE0130000001000000A3 /* KadoUITests */,
+			);
+			name = KadoUITests;
+			packageProductDependencies = (
+			);
+			productName = KadoUITests;
+			productReference = BEC0DE0130000001000000A2 /* KadoUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -252,6 +298,9 @@
 					};
 					BE58C75C2F940AAF0020146E = {
 						CreatedOnToolsVersion = 26.4.1;
+					};
+					BEC0DE0130000001000000A1 = {
+						TestTargetID = BE4188792F91B4F0006126D6;
 					};
 				};
 			};
@@ -274,6 +323,7 @@
 			targets = (
 				BE4188792F91B4F0006126D6 /* Kado */,
 				BE4188862F91B4F2006126D6 /* KadoTests */,
+				BEC0DE0130000001000000A1 /* KadoUITests */,
 				BE58C75C2F940AAF0020146E /* KadoWidgetsExtension */,
 			);
 		};
@@ -295,6 +345,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		BE58C75B2F940AAF0020146E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BEC0DE0130000001000000A6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -325,6 +382,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BEC0DE0130000001000000A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -337,6 +401,11 @@
 			isa = PBXTargetDependency;
 			target = BE58C75C2F940AAF0020146E /* KadoWidgetsExtension */;
 			targetProxy = BE58C76D2F940AB10020146E /* PBXContainerItemProxy */;
+		};
+		BEC0DE0130000001000000AA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = BE4188792F91B4F0006126D6 /* Kado */;
+			targetProxy = BEC0DE0130000001000000AB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -642,6 +711,48 @@
 			};
 			name = Release;
 		};
+		BEC0DE0130000001000000A8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 11;
+				DEVELOPMENT_TEAM = VKY5EKKU47;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.6;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.scastiel.kado.KadoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Kado;
+			};
+			name = Debug;
+		};
+		BEC0DE0130000001000000A9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 11;
+				DEVELOPMENT_TEAM = VKY5EKKU47;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.6;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.scastiel.kado.KadoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Kado;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -677,6 +788,15 @@
 			buildConfigurations = (
 				BE58C7712F940AB10020146E /* Debug */,
 				BE58C7722F940AB10020146E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BEC0DE0130000001000000A7 /* Build configuration list for PBXNativeTarget "KadoUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BEC0DE0130000001000000A8 /* Debug */,
+				BEC0DE0130000001000000A9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Kado.xcodeproj/xcshareddata/xcschemes/Kado.xcscheme
+++ b/Kado.xcodeproj/xcshareddata/xcschemes/Kado.xcscheme
@@ -40,6 +40,16 @@
                ReferencedContainer = "container:Kado.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BEC0DE0130000001000000A1"
+               BuildableName = "KadoUITests.xctest"
+               BlueprintName = "KadoUITests"
+               ReferencedContainer = "container:Kado.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Kado/App/DevModeController.swift
+++ b/Kado/App/DevModeController.swift
@@ -124,13 +124,33 @@ final class DevModeController {
         )
     }
 
-    nonisolated static var defaultDevStoreURL: URL { SharedStore.devStoreURL() }
+    nonisolated static var defaultDevStoreURL: URL {
+        #if DEBUG
+        if UITestSupport.isRunningUITests { return UITestSupport.devStoreURL() }
+        #endif
+        return SharedStore.devStoreURL()
+    }
 
     nonisolated static func defaultProductionContainer() -> ModelContainer {
+        #if DEBUG
+        // A UI test gets a local-only stand-in, so a run can never write
+        // demo habits into a real iCloud account. See `UITestSupport`.
+        if let override = UITestSupport.productionContainerOverride() { return override }
+        #endif
         do {
             return try SharedStore.productionContainer()
         } catch {
             fatalError("Failed to construct production ModelContainer: \(error)")
         }
     }
+
+    #if DEBUG
+    /// The production container, built now if it hasn't been yet.
+    ///
+    /// The UI-test seeding hook needs to fill the production store while
+    /// the *dev* store is the one mounted, and it must not open a
+    /// container of its own to do it — going through the same cache the
+    /// app mounts from is what keeps it to one instance per store.
+    func productionContainerForUITests() -> ModelContainer { productionContainer() }
+    #endif
 }

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -28,6 +28,11 @@ struct KadoApp: App {
     }
 
     init() {
+        #if DEBUG
+        // Before anything opens a `ModelContainer`: a run that asked for
+        // a clean slate needs the store files gone first.
+        UITestSupport.applyLaunchArguments()
+        #endif
         DevModeDefaults.migrateFromStandardIfNeeded()
         KadoFont.register()
         let scheduler = DefaultNotificationScheduler(center: LiveUserNotificationCenter())
@@ -64,6 +69,17 @@ struct KadoApp: App {
                 .task(id: RolloverTick(mark: clockMark, hour: boundary.startHour)) {
                     await advanceAtNextDayEdge(boundary)
                 }
+                #if DEBUG
+                // Asked of the controller rather than of `container`:
+                // the dev-mode swap tests start in dev mode, so the
+                // mounted container is the *dev* one and the store that
+                // needs rows is the one they will swap to.
+                .task {
+                    UITestSupport.seedProductionIfRequested(
+                        using: devModeController.productionContainerForUITests()
+                    )
+                }
+                #endif
         }
         .modelContainer(container)
         .environment(\.cloudAccountStatus, cloudAccountStatus)

--- a/Kado/Support/UITestSupport.swift
+++ b/Kado/Support/UITestSupport.swift
@@ -1,0 +1,163 @@
+#if DEBUG
+import Foundation
+import SwiftData
+import KadoCore
+
+/// Test-only hooks, compiled out of release builds.
+///
+/// UI tests need to control what the app starts from: which store is
+/// mounted, and whether it has anything in it. Everything is driven by
+/// launch arguments, so the app itself has no idea it is under test.
+///
+/// **The dev-mode flag cannot be set with `-kado.devMode 1`**, tempting
+/// as that is — it does land in `UserDefaults`' argument domain and the
+/// app does start in dev mode, but the argument domain also *outranks*
+/// every stored value, so the write `@AppStorage` makes when the user
+/// flips the toggle is read straight back as the launch value. The
+/// toggle springs on again, and the container swap these tests exist to
+/// exercise never happens. So the starting state is written into the
+/// App Group suite here instead, from inside the app, where the toggle
+/// can still move it afterwards.
+///
+/// What also needs hooks is the data underneath. The production store
+/// is CloudKit-mirrored, so a suite that seeded it on a simulator signed
+/// into a real iCloud account would push demo habits to the developer's
+/// own devices. Under `-uiTestRun` both stores are therefore redirected
+/// to throwaway files and the production one drops CloudKit: the suite
+/// never opens, seeds or deletes anything the developer owns, and never
+/// reaches the network. The crash these tests exist to catch is a
+/// SwiftUI/SwiftData container-swap problem with nothing to do with
+/// sync, so nothing under test is lost by cutting it out.
+nonisolated enum UITestSupport {
+
+    enum Argument {
+        /// Present on every launch a UI test makes. It is what redirects
+        /// both stores away from the developer's real ones, so it must
+        /// be passed even by a test that seeds nothing.
+        static let uiTestRun = "-uiTestRun"
+        /// Delete both throwaway stores, so runs don't inherit each
+        /// other.
+        static let resetState = "-uiTestResetState"
+        /// Seed the (redirected) production store with the demo dataset.
+        ///
+        /// Needed for the dev-mode swap tests: they start in dev mode
+        /// and toggle *off*, and an empty production store would land
+        /// the Today list on its empty state, replacing the list rather
+        /// than diffing it — and the diff is where the crash lives.
+        static let seedProduction = "-uiTestSeedProduction"
+        /// `1` to start in dev mode, `0` to start on the real store.
+        /// Followed by its value. See the note at the top of this file
+        /// for why this is not just `-kado.devMode`.
+        static let devMode = "-uiTestDevMode"
+        /// `1` to start past the first-activation confirmation alert.
+        static let devModeConfirmed = "-uiTestDevModeConfirmed"
+    }
+
+    /// Whether the app is being driven by the UI suite.
+    static var isRunningUITests: Bool {
+        ProcessInfo.processInfo.arguments.contains(Argument.uiTestRun)
+    }
+
+    /// Call before anything opens a `ModelContainer` or reads the
+    /// dev-mode flag.
+    static func applyLaunchArguments() {
+        guard isRunningUITests else { return }
+        let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains(Argument.resetState) {
+            resetState()
+        }
+        // Written unconditionally, so a run never inherits the flag the
+        // last one left in the shared suite.
+        DevModeDefaults.sharedDefaults.set(
+            flag(Argument.devMode, in: arguments), forKey: DevModeDefaults.key
+        )
+        DevModeDefaults.sharedDefaults.set(
+            flag(Argument.devModeConfirmed, in: arguments),
+            forKey: DevModeDefaults.hasConfirmedKey
+        )
+    }
+
+    private static func flag(_ argument: String, in arguments: [String]) -> Bool {
+        guard let index = arguments.firstIndex(of: argument),
+              arguments.indices.contains(index + 1)
+        else { return false }
+        return arguments[index + 1] == "1"
+    }
+
+    // MARK: - Redirected stores
+
+    /// Where the suite's stand-in for the production store lives.
+    /// Deliberately *not* `SharedStore.productionStoreURL()` — the real
+    /// file is never opened or deleted by a test run.
+    static func productionStoreURL() -> URL {
+        base().appendingPathComponent("KadoUITest.sqlite")
+    }
+
+    /// Where the suite's stand-in for the dev sandbox lives, so a run
+    /// can't wipe the sandbox the developer was using.
+    static func devStoreURL() -> URL {
+        base().appendingPathComponent("KadoUITestDev.sqlite")
+    }
+
+    private static func base() -> URL {
+        let root = SharedStore.appGroupContainerURL()
+            .map { $0.appendingPathComponent("Library/Application Support", isDirectory: true) }
+            ?? URL.applicationSupportDirectory
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    /// The container `DevModeController` should mount in place of the
+    /// production one, or nil on a normal launch.
+    ///
+    /// Local-only: see the note at the top of this file. Same schema and
+    /// same migration plan as the real thing, so everything the app does
+    /// with it is unchanged.
+    static func productionContainerOverride() -> ModelContainer? {
+        guard isRunningUITests else { return nil }
+        let schema = Schema(versionedSchema: KadoSchemaV4.self)
+        let configuration = ModelConfiguration(
+            schema: schema,
+            url: productionStoreURL(),
+            cloudKitDatabase: .none
+        )
+        do {
+            return try ModelContainer(
+                for: schema,
+                migrationPlan: KadoMigrationPlan.self,
+                configurations: configuration
+            )
+        } catch {
+            fatalError("Failed to construct the UI-test production ModelContainer: \(error)")
+        }
+    }
+
+    /// Fills the (redirected) production store with the demo dataset if
+    /// this run asked for it and it is still empty.
+    ///
+    /// Goes through the container the app already built rather than
+    /// opening one of its own — two containers over one store is the
+    /// shape that traps with `NSCocoaErrorDomain 134422`.
+    @MainActor
+    static func seedProductionIfRequested(using container: ModelContainer) {
+        guard isRunningUITests,
+              ProcessInfo.processInfo.arguments.contains(Argument.seedProduction)
+        else { return }
+        let context = container.mainContext
+        let count = (try? context.fetchCount(FetchDescriptor<HabitRecord>())) ?? 0
+        guard count == 0 else { return }
+        DevModeSeed.seed(into: context)
+    }
+
+    private static func resetState() {
+        for url in [productionStoreURL(), devStoreURL()] {
+            // SwiftData writes `<name>.sqlite` plus `-shm` / `-wal` siblings.
+            for suffix in ["", "-shm", "-wal"] {
+                try? FileManager.default.removeItem(
+                    at: URL(fileURLWithPath: url.path + suffix)
+                )
+            }
+        }
+    }
+}
+#endif

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -56,6 +56,11 @@ struct HabitRowView: View {
         .contentShape(Rectangle())
         .contextMenu { contextMenuContent }
         .accessibilityElement(children: .combine)
+        // Safe here precisely because `.combine` has already collapsed
+        // the subtree: the row is one element, so this lands on a leaf
+        // rather than stamping over anything. Keyed by id because the
+        // name is both localized and user-editable.
+        .accessibilityIdentifier(AccessibilityID.Today.row(habit.id))
         .accessibilityLabel(accessibilityLabelText)
         .accessibilityValue(accessibilityValueText)
         .accessibilityActions { rowAccessibilityActions }

--- a/Kado/Views/ContentView.swift
+++ b/Kado/Views/ContentView.swift
@@ -9,6 +9,11 @@ import KadoCore
 /// lands in v0.1 (Today list) and v1.0 (Settings screens).
 struct ContentView: View {
     var body: some View {
+        // Deliberately no `.accessibilityIdentifier` on these tabs: one
+        // on a tab's content would stamp every element in the screen
+        // beneath it, and one on its label never reaches the tab bar
+        // button. The UI suite addresses tabs by position instead — see
+        // `AccessibilityID.Tab`, and keep the order here in step with it.
         TabView {
             Tab("Today", systemImage: "list.bullet.clipboard") {
                 TodayView()

--- a/Kado/Views/Settings/DevModeSection.swift
+++ b/Kado/Views/Settings/DevModeSection.swift
@@ -28,6 +28,7 @@ struct DevModeSection: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
+            .accessibilityIdentifier(AccessibilityID.Settings.devModeToggle)
             .onChange(of: isDevMode) { oldValue, newValue in
                 // Intercept the first on-flip: revert, prompt, re-flip on confirm.
                 if newValue && !oldValue && !hasConfirmed {
@@ -47,6 +48,7 @@ struct DevModeSection: View {
                 hasConfirmed = true
                 isDevMode = true
             }
+            .accessibilityIdentifier(AccessibilityID.Settings.devModeConfirmButton)
         } message: {
             Text("Your habits will be replaced by a demo dataset while dev mode is on. Your real habits are safe and will return as soon as you turn it off.")
         }

--- a/KadoUITests/DevModeSwapTests.swift
+++ b/KadoUITests/DevModeSwapTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+
+/// The regression suite for issue #63: toggling Dev mode swaps the
+/// `ModelContainer` underneath a live SwiftUI tree, and anything that
+/// retained a `HabitRecord` from the old store traps inside SwiftData
+/// the moment the update pass re-reads it.
+///
+/// A crash during a SwiftUI update pass is structurally invisible to a
+/// unit test — the trap happens inside
+/// `UICollectionViewListCoordinatorBase.updateListContents`, with no
+/// seam to assert on. `XCTAssertEqual(app.state, .runningForeground)`
+/// is the real assertion in both tests below: the bug is a crash, so
+/// "still alive afterwards" is the whole check. What is rendered after
+/// the swap is a bonus.
+final class DevModeSwapTests: KadoUITestCase {
+
+    /// The `ForEach` half, on #63's own repro: a fresh install, where
+    /// the real store is empty and turning dev mode off leaves the list
+    /// diffing six rows away to nothing. That removal is what re-reads
+    /// `Identifiable.id` on records the swap has already invalidated —
+    /// `ForEach.IDGenerator.makeID` is the frame directly above
+    /// `HabitRecord.id.getter` in the original crash.
+    ///
+    /// Deliberately *not* seeded: with rows on both sides the list takes
+    /// a different path through the update and survives, so a seeded
+    /// version of this test passes on the unfixed code and proves
+    /// nothing. `testTogglingDevModeOffWithBothStoresPopulated` covers
+    /// that shape separately.
+    @MainActor
+    func testTogglingDevModeOffWithHabitsOnScreenDoesNotCrash() {
+        let app = launchApp(devMode: true, seedProduction: false)
+
+        tapTab(.today, in: app)
+        waitForTodayRows(in: app)
+
+        toggleDevModeOff(in: app)
+
+        tapTab(.today, in: app)
+        capture(app, "today-after-swap")
+        XCTAssertEqual(app.state, .runningForeground)
+    }
+
+    /// The same swap with the real store populated — what a returning
+    /// user actually has. Six rows are replaced by six different ones
+    /// rather than removed, which is a different path through the list
+    /// update and worth holding separately.
+    @MainActor
+    func testTogglingDevModeOffWithBothStoresPopulated() {
+        let app = launchApp(devMode: true, seedProduction: true)
+
+        tapTab(.today, in: app)
+        waitForTodayRows(in: app)
+
+        toggleDevModeOff(in: app)
+
+        tapTab(.today, in: app)
+        waitForTodayRows(in: app)
+        capture(app, "today-after-swap-populated")
+        XCTAssertEqual(app.state, .runningForeground)
+    }
+
+    /// The half that wasn't in #63: a `NavigationPath` outlives the
+    /// swap still holding the record that was pushed onto it. Reachable
+    /// because tabs stay alive — Today, into a habit, over to Settings,
+    /// toggle, back to Today, and the detail screen is still on the
+    /// stack with a dead object in it.
+    @MainActor
+    func testTogglingDevModeWithADetailScreenPushedDoesNotCrash() {
+        let app = launchApp(devMode: true, seedProduction: true)
+
+        tapTab(.today, in: app)
+        waitForTodayRows(in: app)
+        todayRows(in: app).firstMatch.tap()
+
+        toggleDevModeOff(in: app)
+
+        tapTab(.today, in: app)
+        capture(app, "detail-after-swap")
+        XCTAssertEqual(app.state, .runningForeground)
+    }
+
+    /// Flips the toggle and waits for it to actually read as off.
+    ///
+    /// Launching with `hasConfirmedDevMode: true` means no confirmation
+    /// alert stands in the way; the wait afterwards is for the swap
+    /// itself, which rebuilds a container and can take a moment.
+    @MainActor
+    private func toggleDevModeOff(in app: XCUIApplication) {
+        tapTab(.settings, in: app)
+
+        // Developer is the last section in Settings, so it starts below
+        // the fold and is not in the hierarchy at all until scrolled to.
+        let toggle = app.switches[AccessibilityID.Settings.devModeToggle]
+        scrollTo(toggle, in: app)
+        expect(toggle, toRead: "1", "Dev mode should have started on.")
+
+        // The identified element spans the whole row — label included —
+        // so its centre is over the text, not over the control. The
+        // inner switch is the part that answers a tap.
+        let control = toggle.switches.firstMatch
+        (control.exists ? control : toggle).tap()
+
+        // The swap happens here, and so does the crash when it happens.
+        // Checking the app is still alive *before* blaming the toggle
+        // matters: a dead app can't move a switch either, and "the
+        // toggle never turned off" would send the next reader looking in
+        // entirely the wrong place.
+        if !waited(for: toggle, toRead: "0") {
+            XCTAssertEqual(
+                app.state, .runningForeground,
+                "The app crashed during the dev-mode container swap — this is issue #63."
+            )
+            XCTFail("The Dev mode toggle never turned off.")
+        }
+    }
+
+    /// Asserts a switch reads a given value, waiting for it.
+    @MainActor
+    private func expect(
+        _ toggle: XCUIElement,
+        toRead value: String,
+        _ message: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(waited(for: toggle, toRead: value), message, file: file, line: line)
+    }
+
+    /// Whether a switch came to read a given value within the timeout.
+    ///
+    /// `value` comes back as a string for a switch, but reading it once
+    /// straight after a tap races the animation — hence a predicate that
+    /// re-reads rather than a single comparison.
+    @MainActor
+    private func waited(
+        for toggle: XCUIElement, toRead value: String, timeout: TimeInterval = 30
+    ) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value == %@", value),
+            object: toggle
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+    }
+}

--- a/KadoUITests/DevModeSwapTests.swift
+++ b/KadoUITests/DevModeSwapTests.swift
@@ -65,22 +65,22 @@ final class DevModeSwapTests: KadoUITestCase {
     /// toggle, back to Today, and the detail screen is still on the
     /// stack with a dead object in it.
     ///
-    /// **This test currently fails, and the failure is real.** PR #64
-    /// fixes the list half above but not this one: `HabitDetailLoader`
-    /// re-resolves the id on every render, yet `HabitDetailView` is
-    /// built on `@Bindable var habit: HabitRecord` and retains the
-    /// object it was handed, so SwiftUI re-evaluates that retained
-    /// struct's body against the previous store's record and traps in
-    /// `HabitRecord.name.getter`. Keying the loader's child on
-    /// `record.persistentModelID` was tried and does not help — the
-    /// retained body runs before the replacement reaches it.
+    /// Worth holding separately from the list tests, because it is a
+    /// different shape and took a second fix. Re-resolving the id in
+    /// `HabitDetailLoader` is not on its own enough: while
+    /// `HabitDetailView` took `@Bindable var habit: HabitRecord` it
+    /// retained the object it was handed, and SwiftUI re-evaluated that
+    /// retained struct's body against the previous store's record —
+    /// trapping in `HabitRecord.name.getter` — before the loader's
+    /// re-resolution reached it. This test caught that while the list
+    /// tests above were already passing.
     ///
-    /// The fix is for `HabitDetailView` to render from a value-type
-    /// snapshot and resolve the record only inside mutations, which is
-    /// the rule #64 itself added to `CLAUDE.md`. Left failing on
-    /// purpose rather than muted: a suite that reported green while the
-    /// app died would be the exact failure mode this target exists to
-    /// end.
+    /// Giving the loader's child a `.id(record.persistentModelID)`, so
+    /// the swap would discard the screen rather than update it, does
+    /// **not** fix it — the retained body still runs first. Don't spend
+    /// a cycle re-deriving that. What does fix it is rendering from a
+    /// value-type snapshot and resolving the record only inside
+    /// mutations, down through `CompletionHistoryList` too.
     @MainActor
     func testTogglingDevModeWithADetailScreenPushedDoesNotCrash() {
         let app = launchApp(devMode: true, seedProduction: true)

--- a/KadoUITests/DevModeSwapTests.swift
+++ b/KadoUITests/DevModeSwapTests.swift
@@ -64,6 +64,23 @@ final class DevModeSwapTests: KadoUITestCase {
     /// because tabs stay alive — Today, into a habit, over to Settings,
     /// toggle, back to Today, and the detail screen is still on the
     /// stack with a dead object in it.
+    ///
+    /// **This test currently fails, and the failure is real.** PR #64
+    /// fixes the list half above but not this one: `HabitDetailLoader`
+    /// re-resolves the id on every render, yet `HabitDetailView` is
+    /// built on `@Bindable var habit: HabitRecord` and retains the
+    /// object it was handed, so SwiftUI re-evaluates that retained
+    /// struct's body against the previous store's record and traps in
+    /// `HabitRecord.name.getter`. Keying the loader's child on
+    /// `record.persistentModelID` was tried and does not help — the
+    /// retained body runs before the replacement reaches it.
+    ///
+    /// The fix is for `HabitDetailView` to render from a value-type
+    /// snapshot and resolve the record only inside mutations, which is
+    /// the rule #64 itself added to `CLAUDE.md`. Left failing on
+    /// purpose rather than muted: a suite that reported green while the
+    /// app died would be the exact failure mode this target exists to
+    /// end.
     @MainActor
     func testTogglingDevModeWithADetailScreenPushedDoesNotCrash() {
         let app = launchApp(devMode: true, seedProduction: true)

--- a/KadoUITests/KadoUITestCase.swift
+++ b/KadoUITests/KadoUITestCase.swift
@@ -1,0 +1,156 @@
+import XCTest
+
+/// Shared setup for the UI suites.
+///
+/// Every test declares the state it starts from through `launchApp`,
+/// so none inherits what a previous one left behind. The app never
+/// reads the developer's real store: `-uiTestRun` redirects both the
+/// production and dev stores to throwaway files and drops CloudKit
+/// (see `UITestSupport`).
+class KadoUITestCase: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    /// - Parameters:
+    ///   - devMode: start with the demo sandbox mounted instead of the
+    ///     real store. Goes through `UITestSupport` rather than through
+    ///     a `-kado.devMode` launch argument: the argument domain
+    ///     outranks every stored value, which would pin the flag on and
+    ///     leave the toggle unable to move — see `UITestSupport`.
+    ///   - hasConfirmedDevMode: start past the first-activation
+    ///     confirmation alert. Pass `false` only when the alert itself
+    ///     is what's under test — otherwise `DevModeSection`'s
+    ///     `onChange` interception reverts the flip and the test taps a
+    ///     toggle that doesn't move.
+    ///   - seedProduction: fill the (redirected) production store with
+    ///     the demo dataset, so toggling dev mode *off* lands on a
+    ///     populated list rather than the empty state.
+    ///   - resetState: wipe both throwaway stores first.
+    ///   - language: which language to run the app in. Pinned rather
+    ///     than inherited so a run is the same on a French simulator as
+    ///     on an English one — and so the suite is worth something as
+    ///     evidence either way, since the assertions go through
+    ///     identifiers rather than labels.
+    @MainActor
+    func launchApp(
+        devMode: Bool = false,
+        hasConfirmedDevMode: Bool = true,
+        seedProduction: Bool = false,
+        resetState: Bool = true,
+        language: String = "en"
+    ) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["-uiTestRun"]
+
+        if resetState {
+            app.launchArguments.append("-uiTestResetState")
+        }
+        if seedProduction {
+            app.launchArguments.append("-uiTestSeedProduction")
+        }
+        app.launchArguments += [
+            "-uiTestDevMode", devMode ? "1" : "0",
+            "-uiTestDevModeConfirmed", hasConfirmedDevMode ? "1" : "0",
+            "-AppleLanguages", "(\(language))",
+            "-AppleLocale", language,
+        ]
+
+        app.launch()
+        return app
+    }
+
+    /// Switches tabs.
+    ///
+    /// By position, because SwiftUI's `Tab` gives no seam for an
+    /// accessibility identifier — see `AccessibilityID.Tab`. Going
+    /// through the tab bar rather than `app.buttons[…]` also keeps this
+    /// from matching a same-named button inside the tab's content.
+    @MainActor
+    func tapTab(
+        _ tab: AccessibilityID.Tab,
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let bar = app.tabBars.firstMatch
+        XCTAssertTrue(
+            bar.waitForExistence(timeout: 30), "The tab bar never appeared.",
+            file: file, line: line
+        )
+        bar.buttons.element(boundBy: tab.rawValue).tap()
+    }
+
+    /// Scrolls until `element` exists and can be tapped.
+    ///
+    /// `waitForExistence` alone is not enough for anything below the
+    /// fold of a `Form`: an unrealized row is not in the hierarchy at
+    /// all, so the wait watches for something that cannot appear until
+    /// something scrolls. This is the whole reason the Dev mode toggle —
+    /// the last section in Settings — looked missing for a full 30s
+    /// timeout on the first run of this suite.
+    ///
+    /// Slow swipes on purpose: a thrown scroll coasts, and XCUITest
+    /// answers `isHittable` only once the app looks idle, so every query
+    /// during the glide burns its whole quiescence budget and then
+    /// answers about a row that has already moved.
+    @MainActor
+    func scrollTo(
+        _ element: XCUIElement,
+        in app: XCUIApplication,
+        swipes: Int = 10,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for _ in 0..<swipes {
+            if element.exists && element.isHittable { return }
+            app.swipeUp(velocity: .slow)
+        }
+        XCTAssertTrue(
+            element.exists && element.isHittable,
+            "Never scrolled \(element) into view.",
+            file: file, line: line
+        )
+    }
+
+    /// The Today rows currently on screen, addressed by the identifier
+    /// prefix rather than by habit name.
+    ///
+    /// Names come from `DevModeSeed`, which translates them — so a test
+    /// that looked for "Morning meditation" would pass in English and
+    /// fail in French. The prefix says "a Today row, any of them",
+    /// which is what these tests actually mean.
+    @MainActor
+    func todayRows(in app: XCUIApplication) -> XCUIElementQuery {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "today.row."))
+    }
+
+    /// Waits for the Today list to have rows in it.
+    @MainActor
+    func waitForTodayRows(
+        in app: XCUIApplication,
+        timeout: TimeInterval = 30,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertTrue(
+            todayRows(in: app).firstMatch.waitForExistence(timeout: timeout),
+            "The Today list never showed a row.",
+            file: file,
+            line: line
+        )
+    }
+
+    /// Saves a screenshot into the result bundle, so a failing run can
+    /// be looked at without re-running it.
+    @MainActor
+    func capture(_ app: XCUIApplication, _ name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,119 @@
+# Building and testing Kadō from the command line.
+#
+#   make build   build the app for the simulator
+#   make test    the unit suite (KadoTests)
+#   make e2e     the UI suite (KadoUITests) — drives the app in a simulator
+#   make run     install and launch the app on this worktree's simulator
+#   make shot    screenshot that simulator
+#   make sim-clean  delete this worktree's simulator and any leftover clones
+#
+# XcodeBuildMCP remains the tool of choice from inside Claude Code (see
+# CLAUDE.md). This exists for the cases it can't cover: pinning an OS
+# version when `OS:latest` won't resolve, and giving each worktree a
+# simulator of its own.
+
+# The device *type* each worktree's simulator is created from.
+SIMULATOR ?= iPhone 17 Pro
+
+# One simulator per worktree, named after its directory. Two runs must
+# never share a device: they would install over each other's app
+# container, and XCUITest's parallel clones are named after the device
+# they came from, so even the clones would collide. This repo is worked
+# on from parallel `.claude/worktrees/` checkouts, so that is the normal
+# case rather than the exotic one.
+SIM_NAME  ?= Kado $(notdir $(CURDIR))
+
+# XCUITest parallelises by test *class*, cloning a simulator per worker.
+# Keep suites small and similar in size, or one long class becomes a pole
+# no worker count can shorten. More workers than cores makes things
+# slower, not faster — override with WORKERS=n, and lower it when several
+# worktrees are running at once, because each run boots WORKERS clones of
+# its own.
+WORKERS   ?= 3
+PARALLEL  := -parallel-testing-enabled YES -maximum-parallel-testing-workers $(WORKERS)
+
+SCHEME      := Kado
+PROJECT     := Kado.xcodeproj
+BUNDLE_ID   := dev.scastiel.kado
+DERIVED     := build
+DESTINATION := platform=iOS Simulator,name=$(SIM_NAME)
+
+# Deliberately *not* CODE_SIGNING_ALLOWED=NO, tempting as it is for a
+# simulator build. Kadō's app target carries entitlements — iCloud and
+# the App Group — and an unsigned build has none of them, so
+# `CKContainer(identifier:)` traps on the first line of `KadoApp.init()`
+# with EXC_BREAKPOINT and every UI test "fails" at launch for a reason
+# that has nothing to do with what it was testing. Simulator builds are
+# signed to run locally, which costs nothing and needs no device.
+
+.DEFAULT_GOAL := help
+.PHONY: help build test e2e run shot sim sim-clean clean
+
+help:
+	@grep -E '^[a-z0-9-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+# The device is only created, never booted, so this costs nothing on a
+# run that already has it. The four leading spaces in the pattern are
+# load-bearing: `simctl` indents device names by exactly that much, and a
+# leftover clone reads as "Clone 1 of $(SIM_NAME)" — without the indent,
+# one of those would pass for the device itself and the real one would
+# never be made.
+sim: ## Create this worktree's simulator if it doesn't exist yet
+	@xcrun simctl list devices | grep -qF '    $(SIM_NAME) (' \
+		|| xcrun simctl create '$(SIM_NAME)' '$(SIMULATOR)' >/dev/null
+
+sim-clean: ## Delete this worktree's simulator, and any clones a run left behind
+	@for udid in $$(xcrun simctl list devices | grep -F '$(SIM_NAME) (' \
+		| sed -E 's/.*\(([0-9A-F-]{36})\).*/\1/'); do \
+		xcrun simctl shutdown $$udid 2>/dev/null || true; \
+		xcrun simctl delete $$udid; \
+	done
+	@echo "Removed any simulator named $(SIM_NAME)."
+
+build: sim ## Build the app for the simulator
+	@xcodebuild build \
+		-project $(PROJECT) -scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-derivedDataPath $(DERIVED) \
+		-quiet
+
+# `-only-testing:` rather than `-skip-testing:`, because both bundles in
+# this scheme are real suites and each target runs one of them. Splitting
+# them keeps `make test` at the couple of seconds it has always been —
+# a UI run boots simulators and takes minutes.
+test: sim ## Run the unit suite (KadoTests)
+	@xcodebuild test \
+		-project $(PROJECT) -scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-derivedDataPath $(DERIVED) \
+		-only-testing:KadoTests \
+		-quiet
+
+e2e: sim ## Run the UI suite (KadoUITests) against the simulator
+	@xcodebuild test \
+		-project $(PROJECT) -scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-derivedDataPath $(DERIVED) \
+		$(PARALLEL) \
+		-only-testing:KadoUITests \
+		-test-timeouts-enabled YES \
+		-maximum-test-execution-time-allowance 180 \
+		-quiet
+
+# Named rather than `booted`, which is a coin toss the moment anything
+# else is running: a test run has clones of its own booted, and `booted`
+# would happily install into one of those.
+run: build ## Install and launch the app on this worktree's simulator
+	@xcrun simctl boot '$(SIM_NAME)' 2>/dev/null || true
+	@open -a Simulator
+	@xcrun simctl install '$(SIM_NAME)' \
+		"$$(find $(DERIVED)/Build/Products -name 'Kado.app' -maxdepth 3 | head -1)"
+	@xcrun simctl launch --console-pty '$(SIM_NAME)' $(BUNDLE_ID)
+
+shot: ## Screenshot this worktree's simulator to build/screenshot.png
+	@mkdir -p $(DERIVED)
+	@xcrun simctl io '$(SIM_NAME)' screenshot $(DERIVED)/screenshot.png
+	@echo "$(DERIVED)/screenshot.png"
+
+clean: ## Remove build output
+	@rm -rf $(DERIVED)

--- a/Shared/AccessibilityID.swift
+++ b/Shared/AccessibilityID.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Identifiers the UI tests look for.
+///
+/// Kept in one place, and applied in the same commit that adds the
+/// view. Retrofitting identifiers across a grown app is the thing that
+/// makes UI suites get abandoned.
+///
+/// **Put these on leaves, never on containers.** SwiftUI's
+/// `.accessibilityIdentifier` applies to every descendant of the view
+/// it modifies, and an outer one silently replaces the identifiers set
+/// inside it — so a screen-level identifier on a `NavigationStack`
+/// erases the identifiers of every button beneath it. That is why there
+/// is no `screen` entry here: to assert a screen is showing, look for
+/// something only that screen has.
+///
+/// **Kadō ships French**, which makes these load-bearing rather than
+/// merely convenient. A suite that matched on
+/// `app.staticTexts["Dev mode"]` would pass on an English simulator and
+/// fail on a French one. Identifiers are locale-independent; labels are
+/// not.
+enum AccessibilityID {
+
+    /// The tab bar's items, addressed by **position** rather than by
+    /// identifier.
+    ///
+    /// SwiftUI's `Tab` offers no seam for an accessibility identifier.
+    /// One applied to a tab's *content* would stamp every element in the
+    /// screen beneath it — the trap at the top of this file. One applied
+    /// to its *label* compiles and looks right but never reaches the tab
+    /// bar button: dumped live, all three buttons come through carrying
+    /// their labels and an empty identifier. (It half-works by accident
+    /// — the selected tab's label matches something in the content —
+    /// which is worse than not working, because a suite built on it
+    /// passes until the initial tab changes.)
+    ///
+    /// Position is the one property of a tab bar item that is neither
+    /// localized nor user-editable, so that is what the suite addresses.
+    /// Keep in step with `ContentView`.
+    enum Tab: Int {
+        case today = 0
+        case overview = 1
+        case settings = 2
+    }
+
+    enum Today {
+        /// One row, keyed by the habit's `UUID` so a test can address a
+        /// row without depending on its name — which is both localized
+        /// and user-editable.
+        ///
+        /// `HabitRowView` collapses its subtree with
+        /// `.accessibilityElement(children: .combine)`, so the row is
+        /// already a single element and this identifier lands on a leaf.
+        static func row(_ habitID: UUID) -> String { "today.row.\(habitID.uuidString)" }
+    }
+
+    enum Settings {
+        static let devModeToggle = "settings.devMode.toggle"
+        /// The destructive button in the first-activation confirmation
+        /// alert. A test that launches with the flag already confirmed
+        /// never sees it.
+        static let devModeConfirmButton = "settings.devMode.confirm"
+    }
+}


### PR DESCRIPTION
Closes #65. Stacked on #64 — base is `fix/dev-mode-container-swap-crash`, so the diff here is only the test target.

## Why?

- Kadō had 492 unit tests and no UI tests, and that gap is what let #63 ship.
- A crash *inside* a SwiftUI update pass is structurally invisible to a unit test: the trap happens in `UICollectionViewListCoordinatorBase.updateListContents`, with nothing to assert on.
- #64 fixes #63 and adds unit tests for the invariant, but **the actual repro was never executed** — it was left as a manual pass before merge. This runs it, and found a second crash doing so (see Results).
- That second crash is the argument for this target in one line: **the manual pass would not have caught it either.** #64's first commit looked correct by inspection and passed all 492 unit tests. Only driving the app caught it.

⚠️ **Merge #64 first.** This PR is based on its branch, so GitHub enforces the order, but don't retarget it at `main` — the tests would land ahead of the fix they check.

## What?

- **`KadoUITests`** target (`bundle.ui-testing`, `TEST_TARGET_NAME = Kado`), wired into the shared scheme alongside `KadoTests`. Filesystem-synchronized, so later test files need no project edit.
- **`Shared/AccessibilityID.swift`** — identifier constants, compiled into the app, the widget extension and the test bundle. Kadō ships French, so a suite matching on `app.staticTexts["Dev mode"]` would pass on one simulator and fail on the other.
- **`UITestSupport`** — the app-side hook, entirely `#if DEBUG`.
- **`Makefile`** — `make test` (unit, seconds), `make e2e` (UI), `make build`, `make run`, `make shot`, with a per-worktree simulator.
- **Three tests** around the dev-mode container swap.

## How?

- **Nothing real is ever touched.** Under `-uiTestRun` both stores are redirected to throwaway files and the production one drops CloudKit. Seeding a CloudKit-mirrored store on a simulator signed into a real iCloud account would push demo habits to the developer's own devices; now it can't, and the suite never reaches the network. The crash under test is a SwiftUI/SwiftData problem with nothing to do with sync.
- **Test 1 is #63's own repro** — a fresh install, so turning dev mode off leaves the list diffing six rows away to *nothing*. That removal is what re-reads `Identifiable.id` on invalidated records. Seeding the real store actually **prevents** the crash (a replacement takes a different path through the list update), so #65's suggestion to seed for this direction would have produced a test that passes on the unfixed code. Test 3 covers the seeded shape separately.
- Four things cost a cycle each and are now in `CLAUDE.md`:
  - **Never build this suite with `CODE_SIGNING_ALLOWED=NO`.** The app target carries the iCloud and App Group entitlements; unsigned it has neither, so `CKContainer(identifier:)` traps on the first line of `KadoApp.init()` and every test "fails" at launch for an unrelated reason.
  - **A launch argument sets a default and then freezes it.** `-kado.devMode 1` does start the app in dev mode — and the argument domain then serves that `1` back to `@AppStorage` after the toggle writes `false`, so the toggle springs on and nothing swaps. #65's "verified finding 1" is right that arguments drive the flag, but a value a test intends to *change* has to be written from inside the app instead.
  - **SwiftUI's `Tab` has no seam for an accessibility identifier.** One on the content stamps every element in the screen beneath it; one on the label compiles and never reaches the tab bar button. It half-works by accident (the selected tab's label matches something in the content), which is worse than not working — so tabs are addressed by position.
  - **`waitForExistence` can't wait for a row below the fold.** An unrealized `Form` row isn't in the hierarchy, so the wait watches for something that can't appear until something scrolls. The Dev mode toggle looked missing for a full 30s timeout this way.

## Results

Everything is green, against the current head of #64:

```
492 unit tests                                          passed
testTogglingDevModeOffWithHabitsOnScreenDoesNotCrash    passed
testTogglingDevModeOffWithBothStoresPopulated           passed
testTogglingDevModeWithADetailScreenPushedDoesNotCrash  passed
```

Clean build, zero warnings.

**The suite earned its keep before it merged.** Run against `main`, both #63 tests fail with the app dead — so it demonstrably detects the bug rather than merely passing:

```
main   testTogglingDevModeOffWithHabitsOnScreenDoesNotCrash    failed — app crashed
main   testTogglingDevModeWithADetailScreenPushedDoesNotCrash  failed — app crashed
```

And run against #64 as it originally stood, the pushed-detail test **still** failed, which turned out to be a real second bug: `HabitDetailLoader` re-resolved the id correctly, but `HabitDetailView` took `@Bindable var habit: HabitRecord` and retained the object it was handed, so SwiftUI re-evaluated that retained body against the previous store's record and trapped in `HabitRecord.name.getter`. `CompletionHistoryList` had the same problem one level down. Both are fixed in #64 by fc219d8; a `.id(record.persistentModelID)` containment was tried first and does **not** work, which the test's doc comment records so nobody re-derives it.

## Next steps

- Identifiers must be added in the same commit as any new view, or the suite decays — the ongoing cost this accepts deliberately.
- Not done, each worth its own issue if wanted: XcodeGen migration, screenshot automation, a French-locale run (`launchApp(language: "fr")` is already wired and the assertions are identifier-based, so it should just work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JR7Xp9VcRwXonVpJbPBbbT
