### PR TITLE
fix(frequency): re-anchor the every-N-days cycle on each completion

### DIFF
--- a/Kado/Services/DevModeSeed.swift
+++ b/Kado/Services/DevModeSeed.swift
@@ -3,8 +3,8 @@ import SwiftData
 import KadoCore
 
 /// Seeds a `ModelContext` with a realistic demo dataset covering every
-/// `HabitType` variant and the `.daily`, `.specificDays` and
-/// `.daysPerWeek` frequencies, plus ~30 days of historical completions.
+/// `HabitType` variant and every `Frequency` variant, plus ~30 days of
+/// historical completions.
 /// Used by the in-app dev mode sandbox and by SwiftUI previews.
 @MainActor
 enum DevModeSeed {
@@ -24,6 +24,30 @@ enum DevModeSeed {
     static let daysPerWeekOffsets: [Int] = {
         let scheduled = (1...35).filter { $0 % 7 != 0 && $0 % 7 != 6 }
         return (scheduled + [6, 20]).sorted()
+    }()
+
+    /// Day offsets (in days ago) for the `.everyNDays(2)` habit: on
+    /// cadence for the most part, but done a day early four times.
+    ///
+    /// The early days are the whole point. The cycle re-anchors on each
+    /// completion, so doing the habit early moves the next due day
+    /// instead of leaving a phantom miss on the day a fixed grid from
+    /// `createdAt` would have insisted on. Seeded flat on cadence, the
+    /// habit would render identically either way and dev mode would
+    /// show nothing.
+    ///
+    /// Starts on the creation day so both readings begin aligned, and
+    /// ends two days ago so the habit is due — and outstanding — today.
+    static let everyNDaysOffsets: [Int] = {
+        var offsets: [Int] = []
+        var daysAgo = 30
+        // Gaps walking forward in time. A 1 is an early completion.
+        for gap in [2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2] {
+            offsets.append(daysAgo)
+            daysAgo -= gap
+        }
+        offsets.append(daysAgo)
+        return offsets
     }()
 
     static func seed(into context: ModelContext, calendar: Calendar = .current) {
@@ -85,6 +109,15 @@ enum DevModeSeed {
             icon: "figure.run"
         )
 
+        let plants = HabitRecord(
+            name: names.plants,
+            frequency: .everyNDays(2),
+            type: .binary,
+            createdAt: calendar.date(byAdding: .day, value: -30, to: today)!,
+            color: .teal,
+            icon: "leaf.fill"
+        )
+
         for habit in habits {
             context.insert(habit)
             // 15 completions per habit, every other day going back 29 days.
@@ -106,6 +139,12 @@ enum DevModeSeed {
             context.insert(CompletionRecord(date: date, value: 1, habit: run))
         }
 
+        context.insert(plants)
+        for daysAgo in everyNDaysOffsets {
+            let date = calendar.date(byAdding: .day, value: -daysAgo, to: today)!
+            context.insert(CompletionRecord(date: date, value: 1, habit: plants))
+        }
+
         try? context.save()
     }
 
@@ -116,6 +155,7 @@ enum DevModeSeed {
         let read: String
         let noSocialMedia: String
         let run: String
+        let plants: String
 
         static func forCurrentLocale() -> SeedNames {
             switch Locale.current.language.languageCode?.identifier {
@@ -126,7 +166,8 @@ enum DevModeSeed {
                     water: "Boire de l'eau",
                     read: "Lecture",
                     noSocialMedia: "Pas de réseaux sociaux",
-                    run: "Course à pied"
+                    run: "Course à pied",
+                    plants: "Arroser les plantes"
                 )
             default:
                 SeedNames(
@@ -135,7 +176,8 @@ enum DevModeSeed {
                     water: "Drink water",
                     read: "Read",
                     noSocialMedia: "No social media",
-                    run: "Running"
+                    run: "Running",
+                    plants: "Water the plants"
                 )
             }
         }

--- a/Kado/Services/DevModeSeed.swift
+++ b/Kado/Services/DevModeSeed.swift
@@ -36,19 +36,15 @@ enum DevModeSeed {
     /// habit would render identically either way and dev mode would
     /// show nothing.
     ///
-    /// Starts on the creation day so both readings begin aligned, and
-    /// ends two days ago so the habit is due — and outstanding — today.
-    static let everyNDaysOffsets: [Int] = {
-        var offsets: [Int] = []
-        var daysAgo = 30
-        // Gaps walking forward in time. A 1 is an early completion.
-        for gap in [2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2] {
-            offsets.append(daysAgo)
-            daysAgo -= gap
-        }
-        offsets.append(daysAgo)
-        return offsets
-    }()
+    /// Starts on the creation day (30) so the habit is due on the day
+    /// it was created, and ends two days ago (2) so it is due — and
+    /// outstanding — today. Both ends are load-bearing, so the values
+    /// are written out rather than derived from a gap array whose sum
+    /// would have to stay exactly 28 for the last one to land on 2.
+    /// `PreviewContainerTests` pins both.
+    static let everyNDaysOffsets: [Int] = [
+        30, 28, 26, 25, 23, 21, 19, 18, 16, 14, 12, 11, 9, 7, 5, 4, 2,
+    ]
 
     static func seed(into context: ModelContext, calendar: Calendar = .current) {
         // Through the boundary so seeded history lines up with what

--- a/KadoTests/DefaultNotificationSchedulerTests.swift
+++ b/KadoTests/DefaultNotificationSchedulerTests.swift
@@ -73,7 +73,7 @@ struct DefaultNotificationSchedulerTests {
         #expect(center.pending.count == 3)
     }
 
-    @Test("everyNDays(3) anchored to createdAt produces correct offsets")
+    @Test("everyNDays(3) with no completions falls back to the createdAt grid")
     func everyNDaysWindow() async {
         let (scheduler, center) = makeScheduler()
         // createdAt at day(-6). In the 7-day window 0..6, due when
@@ -81,6 +81,20 @@ struct DefaultNotificationSchedulerTests {
         let habit = makeHabit(frequency: .everyNDays(3), createdOffset: -6)
         await scheduler.rescheduleAll(habits: [habit], completions: [])
         #expect(center.pending.count == 3)
+    }
+
+    @Test("everyNDays reminders follow the last completion, not the createdAt grid")
+    func everyNDaysWindowFollowsLastCompletion() async {
+        let (scheduler, center) = makeScheduler()
+        // Same habit, but done yesterday — a day off the createdAt
+        // grid. The cycle re-anchors there, so the window 0...6 is due
+        // on days 2 and 5, not 0, 3 and 6. Without a completion in the
+        // fixture this path is never exercised: the anchor falls back
+        // to createdAt and the test passes against the old rule.
+        let habit = makeHabit(frequency: .everyNDays(3), createdOffset: -6)
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(-1))]
+        await scheduler.rescheduleAll(habits: [habit], completions: completions)
+        #expect(center.pending.count == 2)
     }
 
     @Test("daysPerWeek(3) stays silent while the sliding window holds three completions")

--- a/KadoTests/FrequencyEvaluatorTests.swift
+++ b/KadoTests/FrequencyEvaluatorTests.swift
@@ -290,12 +290,24 @@ struct FrequencyEvaluatorTests {
             let habit = makeHabit(frequency, createdOffset: 0)
             for offset in 0...13 {
                 let day = TestCalendar.day(offset)
-                let completions = [Completion(habitID: habit.id, date: day)]
-                #expect(
-                    evaluator.isDue(habit: habit, on: day, completions: completions)
-                        == evaluator.isOutstanding(habit: habit, on: day, completions: completions),
-                    "\(frequency) at offset \(offset)"
-                )
+                // Both a completion on the day itself and one on a
+                // prior day. The own-day record alone cannot detect an
+                // `.everyNDays` divergence: the anchor lookup skips
+                // records that are not strictly earlier, so both
+                // questions fall through to the createdAt fallback and
+                // agree trivially. A prior-day record is what actually
+                // exercises the re-anchored cycle here.
+                let ownDay = [Completion(habitID: habit.id, date: day)]
+                let withPrior = ownDay + [
+                    Completion(habitID: habit.id, date: TestCalendar.day(offset - 1))
+                ]
+                for completions in [ownDay, withPrior] {
+                    #expect(
+                        evaluator.isDue(habit: habit, on: day, completions: completions)
+                            == evaluator.isOutstanding(habit: habit, on: day, completions: completions),
+                        "\(frequency) at offset \(offset)"
+                    )
+                }
             }
         }
     }

--- a/KadoTests/FrequencyEvaluatorTests.swift
+++ b/KadoTests/FrequencyEvaluatorTests.swift
@@ -90,6 +90,109 @@ struct FrequencyEvaluatorTests {
         }
     }
 
+    // MARK: .everyNDays — the cycle re-anchors on completion
+
+    @Test("Completing early restarts the every-2-days cycle")
+    func everyNDaysReanchorsOnEarlyCompletion() {
+        // Created Monday (offset 0), done Mon, Tue, Thu. Tuesday's
+        // completion moves the next due day from Wednesday to
+        // Thursday, so Wednesday is never asked for and none of the
+        // three days reads as a miss.
+        let habit = makeHabit(.everyNDays(2), createdOffset: 0)
+        let completions = [0, 1, 3].map {
+            Completion(habitID: habit.id, date: TestCalendar.day($0))
+        }
+        let expected: [Int: Bool] = [0: true, 1: false, 2: false, 3: true, 4: false, 5: true]
+        for offset in 0...5 {
+            #expect(
+                evaluator.isDue(habit: habit, on: TestCalendar.day(offset), completions: completions)
+                    == expected[offset]!,
+                "offset \(offset) expected due=\(expected[offset]!)"
+            )
+        }
+    }
+
+    @Test("A missed due day does not reschedule the every-N-days cycle")
+    func everyNDaysMissKeepsTheCycle() {
+        // Done on day 0 only. Day 3 is due and goes unmet — the cycle
+        // stays anchored to day 0, so day 6 is due. Skipping must not
+        // buy the user a fresh interval; only doing the work does.
+        let habit = makeHabit(.everyNDays(3), createdOffset: 0)
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(0))]
+        #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(3), completions: completions))
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(4), completions: completions))
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(5), completions: completions))
+        #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(6), completions: completions))
+    }
+
+    @Test("everyNDays ignores completions belonging to another habit")
+    func everyNDaysIgnoresOtherHabits() {
+        let habit = makeHabit(.everyNDays(2), createdOffset: 0)
+        let completions = [Completion(habitID: UUID(), date: TestCalendar.day(1))]
+        #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(2), completions: completions))
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(3), completions: completions))
+    }
+
+    @Test("A note-only day does not restart the every-N-days cycle")
+    func everyNDaysZeroValueDoesNotReanchor() {
+        // `CompletionToggler` leaves a value-0 record behind when an
+        // unchecked day carries a note. Nothing was done that day, so
+        // nothing re-anchors.
+        let habit = makeHabit(.everyNDays(2), createdOffset: 0)
+        let completions = [
+            Completion(habitID: habit.id, date: TestCalendar.day(1), value: 0, note: "note")
+        ]
+        #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(2), completions: completions))
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(3), completions: completions))
+    }
+
+    @Test("A negative habit's slip does not restart the every-N-days cycle")
+    func everyNDaysNegativeSlipDoesNotReanchor() {
+        // On a `.negative` habit a record means the user *broke* it.
+        // Slipping must not push the next check-in day out.
+        let habit = Habit(
+            name: "No soda",
+            frequency: .everyNDays(2),
+            type: .negative,
+            createdAt: TestCalendar.day(0)
+        )
+        let completions = [Completion(habitID: habit.id, date: TestCalendar.day(1))]
+        #expect(evaluator.isDue(habit: habit, on: TestCalendar.day(2), completions: completions))
+        #expect(!evaluator.isDue(habit: habit, on: TestCalendar.day(3), completions: completions))
+    }
+
+    @Test("The re-anchored cycle holds across DST transitions of every shape")
+    func everyNDaysReanchorSurvivesDST() {
+        // The invariant, not an example: after an early completion the
+        // next due day is two calendar days later, whatever the day's
+        // length. Paris shifts at 02:00/03:00; Havana shifts at
+        // midnight, so its day starts at 01:00 and any arithmetic that
+        // assumes midnight exists drifts by an hour.
+        let fixtures: [(String, Calendar, Date)] = [
+            ("Paris spring-forward", TestCalendar.paris, TestCalendar.instant(TestCalendar.paris, 2026, 3, 27, 12)),
+            ("Paris fall-back", TestCalendar.paris, TestCalendar.instant(TestCalendar.paris, 2026, 10, 23, 12)),
+            ("Havana midnight shift", TestCalendar.havana, TestCalendar.instant(TestCalendar.havana, 2026, 3, 6, 12)),
+        ]
+        for (label, calendar, start) in fixtures {
+            let evaluator = DefaultFrequencyEvaluator(calendar: calendar)
+            let habit = Habit(
+                name: "Run",
+                frequency: .everyNDays(2),
+                type: .binary,
+                createdAt: start
+            )
+            func day(_ offset: Int) -> Date {
+                calendar.date(byAdding: .day, value: offset, to: start)!
+            }
+            // Done on the created day and again the next day: the
+            // early completion moves the next due day from +2 to +3.
+            let completions = [0, 1].map { Completion(habitID: habit.id, date: day($0)) }
+            #expect(evaluator.isDue(habit: habit, on: day(0), completions: completions), "\(label) day 0")
+            #expect(!evaluator.isDue(habit: habit, on: day(2), completions: completions), "\(label) day 2")
+            #expect(evaluator.isDue(habit: habit, on: day(3), completions: completions), "\(label) day 3")
+        }
+    }
+
     // MARK: .daysPerWeek (trailing 7-day rolling window)
 
     @Test("3-per-week habit is due when trailing 7-day window has zero completions")

--- a/KadoTests/HabitScoreCalculatorTests.swift
+++ b/KadoTests/HabitScoreCalculatorTests.swift
@@ -248,20 +248,21 @@ struct HabitScoreCalculatorTests {
     @Test("Completing an every-2-days habit early still scores a perfect run")
     func everyNDaysEarlyCompletionMatchesPerfectRun() {
         let daily = makeHabit(createdOffset: 0)
-        let dailyCompletions = (0..<5).map {
+        let dailyCompletions = (0..<6).map {
             Completion(habitID: daily.id, date: TestCalendar.day($0))
         }
         let dailyScore = calculator.currentScore(
             for: daily,
             completions: dailyCompletions,
-            asOf: TestCalendar.day(4)
+            asOf: TestCalendar.day(5)
         )
 
         // Every 2 days, done a day early on offset 1. The cycle
-        // re-anchors there, so the due days are 0, 3, 5, 7, 9 — five
-        // of them, all met, which is the same perfect run as above.
-        // On a fixed createdAt grid the due days would be 0, 2, 4, 6,
-        // 8 and four of the five would read as missed.
+        // re-anchors there, so the due days are 0, 3, 5, 7, 9 — all
+        // met — and offset 1 counts as a day it was done. Six measured
+        // days at full value, the same perfect run as above. On a fixed
+        // createdAt grid the due days would be 0, 2, 4, 6, 8 and four
+        // of the five would read as missed.
         let flexible = Habit(
             name: "Long run",
             frequency: .everyNDays(2),
@@ -278,6 +279,43 @@ struct HabitScoreCalculatorTests {
         )
 
         #expect(abs(dailyScore - flexibleScore) < 1e-9, "daily=\(dailyScore) every2=\(flexibleScore)")
+    }
+
+    @Test("An every-2-days habit done daily scores the same as a daily habit done daily")
+    func everyNDaysDailyOverDeliveryScoresPerfect() {
+        // Working ahead re-anchors the cycle, so this habit is never
+        // due after its first day. Measured on due days alone its
+        // score would freeze at alpha (5%) after 30 days of flawless
+        // adherence — far worse than doing half the work. Counting the
+        // days actually done is what keeps "more work never scores
+        // worse" true.
+        let daily = makeHabit(createdOffset: 0)
+        let dailyCompletions = (0..<30).map {
+            Completion(habitID: daily.id, date: TestCalendar.day($0))
+        }
+        let dailyScore = calculator.currentScore(
+            for: daily,
+            completions: dailyCompletions,
+            asOf: TestCalendar.day(29)
+        )
+
+        let everyTwo = Habit(
+            name: "Water plants",
+            frequency: .everyNDays(2),
+            type: .binary,
+            createdAt: TestCalendar.day(0)
+        )
+        let everyTwoCompletions = (0..<30).map {
+            Completion(habitID: everyTwo.id, date: TestCalendar.day($0))
+        }
+        let everyTwoScore = calculator.currentScore(
+            for: everyTwo,
+            completions: everyTwoCompletions,
+            asOf: TestCalendar.day(29)
+        )
+
+        #expect(abs(dailyScore - everyTwoScore) < 1e-9, "daily=\(dailyScore) every2=\(everyTwoScore)")
+        #expect(everyTwoScore > 0.75, "every2=\(everyTwoScore) — over-delivery must not stall the score")
     }
 
     @Test("Off-schedule completions on non-due days do not contribute to the score")

--- a/KadoTests/HabitScoreCalculatorTests.swift
+++ b/KadoTests/HabitScoreCalculatorTests.swift
@@ -245,6 +245,41 @@ struct HabitScoreCalculatorTests {
         #expect(abs(dailyScore - everyThreeScore) < 1e-9, "daily=\(dailyScore) every3=\(everyThreeScore)")
     }
 
+    @Test("Completing an every-2-days habit early still scores a perfect run")
+    func everyNDaysEarlyCompletionMatchesPerfectRun() {
+        let daily = makeHabit(createdOffset: 0)
+        let dailyCompletions = (0..<5).map {
+            Completion(habitID: daily.id, date: TestCalendar.day($0))
+        }
+        let dailyScore = calculator.currentScore(
+            for: daily,
+            completions: dailyCompletions,
+            asOf: TestCalendar.day(4)
+        )
+
+        // Every 2 days, done a day early on offset 1. The cycle
+        // re-anchors there, so the due days are 0, 3, 5, 7, 9 — five
+        // of them, all met, which is the same perfect run as above.
+        // On a fixed createdAt grid the due days would be 0, 2, 4, 6,
+        // 8 and four of the five would read as missed.
+        let flexible = Habit(
+            name: "Long run",
+            frequency: .everyNDays(2),
+            type: .binary,
+            createdAt: TestCalendar.day(0)
+        )
+        let flexibleCompletions = [0, 1, 3, 5, 7, 9].map {
+            Completion(habitID: flexible.id, date: TestCalendar.day($0))
+        }
+        let flexibleScore = calculator.currentScore(
+            for: flexible,
+            completions: flexibleCompletions,
+            asOf: TestCalendar.day(9)
+        )
+
+        #expect(abs(dailyScore - flexibleScore) < 1e-9, "daily=\(dailyScore) every2=\(flexibleScore)")
+    }
+
     @Test("Off-schedule completions on non-due days do not contribute to the score")
     func offScheduleCompletionsIgnored() {
         let mondayOnly = Habit(

--- a/KadoTests/PreviewContainerTests.swift
+++ b/KadoTests/PreviewContainerTests.swift
@@ -7,7 +7,7 @@ import KadoCore
 @Suite("DevModeSeed seeding")
 @MainActor
 struct PreviewContainerTests {
-    @Test("Seeds six habits covering each type and the main frequencies")
+    @Test("Seeds seven habits covering each type and every frequency")
     func seededShape() throws {
         let container = try ModelContainer(
             for: HabitRecord.self, CompletionRecord.self,
@@ -16,7 +16,7 @@ struct PreviewContainerTests {
         DevModeSeed.seed(into: container.mainContext)
 
         let habits = try container.mainContext.fetch(FetchDescriptor<HabitRecord>())
-        #expect(habits.count == 6)
+        #expect(habits.count == 7)
 
         let frequencies = Set(habits.map(\.frequency))
         #expect(frequencies.contains(.daily))
@@ -25,6 +25,9 @@ struct PreviewContainerTests {
         })
         #expect(frequencies.contains { freq in
             if case .daysPerWeek = freq { return true } else { return false }
+        })
+        #expect(frequencies.contains { freq in
+            if case .everyNDays = freq { return true } else { return false }
         })
 
         let types = Set(habits.map(\.type))
@@ -40,7 +43,9 @@ struct PreviewContainerTests {
         let completions = try container.mainContext.fetch(FetchDescriptor<CompletionRecord>())
         #expect(
             completions.count
-                == 5 * DevModeSeed.completionsPerHabit + DevModeSeed.daysPerWeekOffsets.count
+                == 5 * DevModeSeed.completionsPerHabit
+                    + DevModeSeed.daysPerWeekOffsets.count
+                    + DevModeSeed.everyNDaysOffsets.count
         )
     }
 }

--- a/KadoTests/PreviewContainerTests.swift
+++ b/KadoTests/PreviewContainerTests.swift
@@ -40,6 +40,13 @@ struct PreviewContainerTests {
             if case .timer = type { return true } else { return false }
         })
 
+        // The every-N-days habit only demonstrates the re-anchoring
+        // cycle if it starts on its creation day and is still due
+        // today. Both are silent properties of the offset list, and a
+        // count assertion alone would not notice either drifting.
+        #expect(DevModeSeed.everyNDaysOffsets.first == 30)
+        #expect(DevModeSeed.everyNDaysOffsets.last == 2)
+
         let completions = try container.mainContext.fetch(FetchDescriptor<CompletionRecord>())
         #expect(
             completions.count

--- a/KadoTests/StreakCalculatorTests.swift
+++ b/KadoTests/StreakCalculatorTests.swift
@@ -140,14 +140,48 @@ struct StreakCalculatorTests {
     func everyNDaysEarlyCompletionKeepsStreak() {
         // N=2 from day -6. Done -6, then -5 a day early, then -3 and
         // -1. Each completion restarts the cycle, so the due days are
-        // -6, -3, -1 and every one is met. Under a fixed createdAt
-        // grid the due days would be -6, -4, -2 and the user would
-        // read as having missed two of them.
+        // -6, -3, -1 — all met — and -5 counts as a day it was done.
+        // Under a fixed createdAt grid the due days would be -6, -4,
+        // -2 and the user would read as having missed two of them.
         let h = habit(frequency: .everyNDays(2), createdAtOffset: -6)
         let completions = [-6, -5, -3, -1].map { completion(for: h, dayOffset: $0) }
         let calc = calculator()
-        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 3)
-        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 3)
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 4)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 4)
+    }
+
+    @Test(".everyNDays done every single day counts every day")
+    func everyNDaysDailyOverDeliveryCountsEveryDay() {
+        // Working ahead re-anchors the cycle, so an every-2-days habit
+        // done daily is never due after its first day. Counting due
+        // days alone would report a streak of 1 for flawless
+        // adherence — strictly worse than doing half the work.
+        let h = habit(frequency: .everyNDays(2), createdAtOffset: -29)
+        let completions = (-29...0).map { completion(for: h, dayOffset: $0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 30)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 30)
+    }
+
+    @Test(".everyNDays doing more never scores a shorter streak than doing less")
+    func everyNDaysMoreWorkNeverShortensStreak() {
+        // The invariant the over-delivery case exists to protect:
+        // adding completions to a perfect on-cadence history must
+        // never shorten the streak.
+        let h = habit(frequency: .everyNDays(3), createdAtOffset: -30)
+        let onCadence = stride(from: -30, through: 0, by: 3).map {
+            completion(for: h, dayOffset: $0)
+        }
+        let calc = calculator()
+        let baseline = calc.current(for: h, completions: onCadence, asOf: asOf)
+
+        for extraDay in [-29, -25, -14, -2] {
+            let richer = onCadence + [completion(for: h, dayOffset: extraDay)]
+            #expect(
+                calc.current(for: h, completions: richer, asOf: asOf) >= baseline,
+                "adding day \(extraDay) shortened the streak"
+            )
+        }
     }
 
     // MARK: - .daysPerWeek

--- a/KadoTests/StreakCalculatorTests.swift
+++ b/KadoTests/StreakCalculatorTests.swift
@@ -136,6 +136,20 @@ struct StreakCalculatorTests {
         #expect(calc.best(for: h, completions: completions, asOf: asOf) == 3)
     }
 
+    @Test(".everyNDays counts an early completion instead of breaking on it")
+    func everyNDaysEarlyCompletionKeepsStreak() {
+        // N=2 from day -6. Done -6, then -5 a day early, then -3 and
+        // -1. Each completion restarts the cycle, so the due days are
+        // -6, -3, -1 and every one is met. Under a fixed createdAt
+        // grid the due days would be -6, -4, -2 and the user would
+        // read as having missed two of them.
+        let h = habit(frequency: .everyNDays(2), createdAtOffset: -6)
+        let completions = [-6, -5, -3, -1].map { completion(for: h, dayOffset: $0) }
+        let calc = calculator()
+        #expect(calc.current(for: h, completions: completions, asOf: asOf) == 3)
+        #expect(calc.best(for: h, completions: completions, asOf: asOf) == 3)
+    }
+
     // MARK: - .daysPerWeek
 
     @Test(".daysPerWeek(3) counts qualifying weeks, current week is grace")

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultFrequencyEvaluator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultFrequencyEvaluator.swift
@@ -49,6 +49,15 @@ public struct DefaultFrequencyEvaluator: FrequencyEvaluating {
             // the clock. Only completions strictly before `day` are
             // read, so this stays monotonic and `isDue` /
             // `isOutstanding` still agree. See `EveryNDaysCycle`.
+            //
+            // Guarded here rather than left to `EveryNDaysCycle.isDue`:
+            // the anchor is an argument expression, so it would be
+            // computed — an O(completions) scan, per day, per habit —
+            // before the interval was ever checked. A corrupt or
+            // hand-edited backup can decode `.everyNDays(0)`; neither
+            // `Frequency.init(from:)` nor `CSVBackupCoder` range-checks
+            // it.
+            guard n > 0 else { return false }
             return EveryNDaysCycle.isDue(
                 interval: n,
                 on: day,

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultFrequencyEvaluator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultFrequencyEvaluator.swift
@@ -44,10 +44,22 @@ public struct DefaultFrequencyEvaluator: FrequencyEvaluating {
             return weekdays.contains(weekday)
 
         case .everyNDays(let n):
-            guard n > 0 else { return false }
-            let createdDay = calendar.startOfDay(for: habit.createdAt)
-            let delta = calendar.dateComponents([.day], from: createdDay, to: day).day ?? 0
-            return ((delta % n) + n) % n == 0
+            // Anchored to the last day the habit was done, not to a
+            // fixed grid from `createdAt` — doing it early restarts
+            // the clock. Only completions strictly before `day` are
+            // read, so this stays monotonic and `isDue` /
+            // `isOutstanding` still agree. See `EveryNDaysCycle`.
+            return EveryNDaysCycle.isDue(
+                interval: n,
+                on: day,
+                anchoredAt: EveryNDaysCycle.anchorDay(
+                    for: habit,
+                    before: day,
+                    completions: completions,
+                    calendar: calendar
+                ),
+                calendar: calendar
+            )
 
         case .daysPerWeek(let target):
             guard target > 0 else { return false }

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultHabitScoreCalculator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultHabitScoreCalculator.swift
@@ -44,13 +44,31 @@ public struct DefaultHabitScoreCalculator: HabitScoreCalculating {
         let lastDay = calendar.startOfDay(for: endDate)
         guard firstDay <= lastDay else { return [] }
 
-        let completionsByDay = completionsForHabitGrouped(by: habit, completions: completions)
+        // Filtered once, then handed to the evaluator on every day of
+        // the walk. Every frequency it evaluates already discards other
+        // habits' records, so this changes no answer — but the
+        // `.everyNDays` anchor lookup and the `.daysPerWeek` window are
+        // both linear scans, run per day, and `WidgetSnapshotBuilder`
+        // rebuilds every habit's score on MainActor after every
+        // mutation. Handing them the whole store's completions made
+        // that quadratic in the store, not in the habit.
+        let habitCompletions = completions.filter { $0.habitID == habit.id }
+        let completionsByDay = completionsForHabitGrouped(by: habit, completions: habitCompletions)
 
         var score = 0.0
         var result: [DailyScore] = []
         var day = firstDay
         while day <= lastDay {
-            if frequencyEvaluator.isDue(habit: habit, on: day, completions: completions) {
+            // `isCounted`, not `isDue`: an `.everyNDays` cycle
+            // re-anchors on completion, so working ahead removes due
+            // days and a due-days-only measure would score perfect
+            // daily adherence at nearly zero.
+            if frequencyEvaluator.isCounted(
+                habit: habit,
+                on: day,
+                completions: habitCompletions,
+                calendar: calendar
+            ) {
                 let value = DailyValue.compute(
                     for: habit,
                     completionsOnDay: completionsByDay[day] ?? []

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
@@ -48,14 +48,18 @@ public struct DefaultStreakCalculator: StreakCalculating {
         startDay: Date
     ) -> Int {
         let completedDays = completedDaySet(habit: habit, completions: completions)
-        let cycleAnchors = cycleAnchors(habit: habit, completions: completions)
+        let cycleAnchors = EveryNDaysCycle.anchorCandidates(for: habit, completedDays: completedDays)
+        let createdDay = calendar.startOfDay(for: habit.createdAt)
+        let countsLogged = countsLoggedDays(habit: habit)
         var streak = 0
         var day = end
         var isEndDay = true
 
         while day >= startDay {
-            let due = isDueByDay(habit: habit, on: day, cycleAnchors: cycleAnchors)
-            if !due {
+            let due = isDueByDay(
+                habit: habit, on: day, cycleAnchors: cycleAnchors, createdDay: createdDay
+            )
+            if !due && !(countsLogged && completedDays.contains(day)) {
                 day = previousDay(day)
                 isEndDay = false
                 continue
@@ -82,14 +86,18 @@ public struct DefaultStreakCalculator: StreakCalculating {
         startDay: Date
     ) -> Int {
         let completedDays = completedDaySet(habit: habit, completions: completions)
-        let cycleAnchors = cycleAnchors(habit: habit, completions: completions)
+        let cycleAnchors = EveryNDaysCycle.anchorCandidates(for: habit, completedDays: completedDays)
+        let createdDay = calendar.startOfDay(for: habit.createdAt)
+        let countsLogged = countsLoggedDays(habit: habit)
         var best = 0
         var run = 0
         var day = startDay
 
         while day <= end {
-            let due = isDueByDay(habit: habit, on: day, cycleAnchors: cycleAnchors)
-            if !due {
+            let due = isDueByDay(
+                habit: habit, on: day, cycleAnchors: cycleAnchors, createdDay: createdDay
+            )
+            if !due && !(countsLogged && completedDays.contains(day)) {
                 day = nextDay(day)
                 continue
             }
@@ -210,7 +218,12 @@ public struct DefaultStreakCalculator: StreakCalculating {
     ///
     /// The lifecycle guards the evaluator applies (`effectiveStart`,
     /// `archivedAt`) are already enforced by the callers' loop bounds.
-    private func isDueByDay(habit: Habit, on day: Date, cycleAnchors: [Date]) -> Bool {
+    private func isDueByDay(
+        habit: Habit,
+        on day: Date,
+        cycleAnchors: [Date],
+        createdDay: Date
+    ) -> Bool {
         switch habit.frequency {
         case .daily:
             return true
@@ -224,13 +237,14 @@ public struct DefaultStreakCalculator: StreakCalculating {
             // instead of leaving a phantom miss behind. `cycleAnchors`
             // is hoisted out of the caller's day-by-day walk to keep
             // this a binary search rather than a scan per day.
+            guard n > 0 else { return false }
             return EveryNDaysCycle.isDue(
                 interval: n,
                 on: day,
                 anchoredAt: EveryNDaysCycle.anchorDay(
                     before: day,
                     in: cycleAnchors,
-                    fallback: calendar.startOfDay(for: habit.createdAt)
+                    fallback: createdDay
                 ),
                 calendar: calendar
             )
@@ -239,16 +253,20 @@ public struct DefaultStreakCalculator: StreakCalculating {
         }
     }
 
-    /// Days that may re-anchor an `.everyNDays` cycle, ascending.
-    /// Empty for every other frequency — nothing else reads it, and
-    /// the walkers above call this once per streak, not once per day.
-    private func cycleAnchors(habit: Habit, completions: [Completion]) -> [Date] {
-        guard case .everyNDays = habit.frequency else { return [] }
-        return EveryNDaysCycle.anchorCandidates(
-            for: habit,
-            completions: completions,
-            calendar: calendar
-        )
+    /// Whether a day the user logged counts toward the streak even when
+    /// the schedule didn't ask for it.
+    ///
+    /// Only `.everyNDays`, and only because its cycle re-anchors on
+    /// completion: working ahead removes due days, so a habit done
+    /// every day on an every-2-days cadence would otherwise report a
+    /// streak of 1. Mirrors `FrequencyEvaluating.isCounted`, which the
+    /// score uses for the same reason.
+    ///
+    /// Never for `.negative`, where `completedDaySet` holds the days
+    /// the user *slipped* — counting those would credit the slip.
+    private func countsLoggedDays(habit: Habit) -> Bool {
+        guard case .everyNDays = habit.frequency else { return false }
+        return EveryNDaysCycle.canReanchor(habit)
     }
 
     private func completedDaySet(habit: Habit, completions: [Completion]) -> Set<Date> {

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
@@ -48,12 +48,13 @@ public struct DefaultStreakCalculator: StreakCalculating {
         startDay: Date
     ) -> Int {
         let completedDays = completedDaySet(habit: habit, completions: completions)
+        let cycleAnchors = cycleAnchors(habit: habit, completions: completions)
         var streak = 0
         var day = end
         var isEndDay = true
 
         while day >= startDay {
-            let due = isDueByDay(habit: habit, on: day)
+            let due = isDueByDay(habit: habit, on: day, cycleAnchors: cycleAnchors)
             if !due {
                 day = previousDay(day)
                 isEndDay = false
@@ -81,12 +82,13 @@ public struct DefaultStreakCalculator: StreakCalculating {
         startDay: Date
     ) -> Int {
         let completedDays = completedDaySet(habit: habit, completions: completions)
+        let cycleAnchors = cycleAnchors(habit: habit, completions: completions)
         var best = 0
         var run = 0
         var day = startDay
 
         while day <= end {
-            let due = isDueByDay(habit: habit, on: day)
+            let due = isDueByDay(habit: habit, on: day, cycleAnchors: cycleAnchors)
             if !due {
                 day = nextDay(day)
                 continue
@@ -196,7 +198,10 @@ public struct DefaultStreakCalculator: StreakCalculating {
     /// day at a time across the habit's whole lifetime. That turns an
     /// O(1) check into O(completions) per day, on the main thread, for
     /// a value `HabitDetailView` reads from a computed property and
-    /// `WidgetSnapshotBuilder` recomputes on every mutation.
+    /// `WidgetSnapshotBuilder` recomputes on every mutation. The
+    /// `.everyNDays` anchor has the same shape — the evaluator rescans
+    /// every completion per day, where the walkers below hoist the
+    /// sorted anchors once and binary-search them.
     /// Correctness: the explicit `.daysPerWeek` case keeps the
     /// "week-bucket path handles this frequency" invariant enforced
     /// where it is used, rather than relying on both callers switching
@@ -205,7 +210,7 @@ public struct DefaultStreakCalculator: StreakCalculating {
     ///
     /// The lifecycle guards the evaluator applies (`effectiveStart`,
     /// `archivedAt`) are already enforced by the callers' loop bounds.
-    private func isDueByDay(habit: Habit, on day: Date) -> Bool {
+    private func isDueByDay(habit: Habit, on day: Date, cycleAnchors: [Date]) -> Bool {
         switch habit.frequency {
         case .daily:
             return true
@@ -214,13 +219,36 @@ public struct DefaultStreakCalculator: StreakCalculating {
             guard let weekday = Weekday(rawValue: weekdayInt) else { return false }
             return weekdays.contains(weekday)
         case .everyNDays(let n):
-            guard n > 0 else { return false }
-            let createdDay = calendar.startOfDay(for: habit.createdAt)
-            let delta = calendar.dateComponents([.day], from: createdDay, to: day).day ?? 0
-            return ((delta % n) + n) % n == 0
+            // The cycle restarts from the last day the habit was
+            // done, so an early completion moves the next due day
+            // instead of leaving a phantom miss behind. `cycleAnchors`
+            // is hoisted out of the caller's day-by-day walk to keep
+            // this a binary search rather than a scan per day.
+            return EveryNDaysCycle.isDue(
+                interval: n,
+                on: day,
+                anchoredAt: EveryNDaysCycle.anchorDay(
+                    before: day,
+                    in: cycleAnchors,
+                    fallback: calendar.startOfDay(for: habit.createdAt)
+                ),
+                calendar: calendar
+            )
         case .daysPerWeek:
             return false
         }
+    }
+
+    /// Days that may re-anchor an `.everyNDays` cycle, ascending.
+    /// Empty for every other frequency — nothing else reads it, and
+    /// the walkers above call this once per streak, not once per day.
+    private func cycleAnchors(habit: Habit, completions: [Completion]) -> [Date] {
+        guard case .everyNDays = habit.frequency else { return [] }
+        return EveryNDaysCycle.anchorCandidates(
+            for: habit,
+            completions: completions,
+            calendar: calendar
+        )
     }
 
     private func completedDaySet(habit: Habit, completions: [Completion]) -> Set<Date> {

--- a/Packages/KadoCore/Sources/KadoCore/Services/EveryNDaysCycle.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/EveryNDaysCycle.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// Cycle math for `.everyNDays(n)`.
+///
+/// The interval is measured from the last day the habit was **actually
+/// done**, not from a fixed grid pinned to `createdAt`. Doing the habit
+/// early restarts the clock, so an every-2-days habit completed Monday
+/// and again Tuesday is next due Thursday — Wednesday was never asked
+/// for and is not a miss.
+///
+/// The fixed-grid reading punished the user for being early: it kept
+/// insisting on Wednesday, scored it as missed, and broke the streak of
+/// someone who had just done the habit the day before.
+///
+/// Two properties this keeps:
+///
+/// - **Monotonic.** Only completions *strictly before* the day under
+///   test can move the anchor, so logging a day never rewrites whether
+///   that same day was due. `FrequencyEvaluating.isDue` depends on this.
+/// - **A miss doesn't reschedule.** Only a completion re-anchors, so
+///   skipping a due day leaves the cycle where it was and the day stays
+///   a miss (offsets `anchor + n`, `anchor + 2n`, … as before).
+///
+/// Before the first completion the cycle is anchored to `createdAt`,
+/// which is what makes a brand-new habit due on the day it was created.
+public enum EveryNDaysCycle {
+
+    /// Does the `interval`-day cycle running from `anchorDay` land on
+    /// `day`? Days before the anchor are answered on the same modular
+    /// grid, which is what lets a backdated completion sit on-cycle.
+    public static func isDue(
+        interval: Int,
+        on day: Date,
+        anchoredAt anchorDay: Date,
+        calendar: Calendar
+    ) -> Bool {
+        guard interval > 0 else { return false }
+        let delta = calendar.dateComponents([.day], from: anchorDay, to: day).day ?? 0
+        return ((delta % interval) + interval) % interval == 0
+    }
+
+    /// The day the cycle restarts from when evaluating `day`: the most
+    /// recent completed day strictly before it, or the habit's creation
+    /// day when the habit has never been done before then.
+    ///
+    /// Scans `completions` once. Callers that walk a habit's whole
+    /// lifetime a day at a time should hoist `anchorCandidates(for:…)`
+    /// out of the loop and use the sorted overload instead.
+    public static func anchorDay(
+        for habit: Habit,
+        before day: Date,
+        completions: [Completion],
+        calendar: Calendar
+    ) -> Date {
+        let createdDay = calendar.startOfDay(for: habit.createdAt)
+        guard canReanchor(habit) else { return createdDay }
+
+        var latest: Date?
+        for completion in completions {
+            guard completion.habitID == habit.id, completion.value > 0 else { continue }
+            let completionDay = calendar.startOfDay(for: completion.date)
+            guard completionDay < day else { continue }
+            if latest == nil || completionDay > latest! { latest = completionDay }
+        }
+        return latest ?? createdDay
+    }
+
+    /// Same answer as `anchorDay(for:before:completions:calendar:)`,
+    /// against a pre-built ascending list of completed days. `O(log n)`
+    /// per day rather than `O(completions)`.
+    public static func anchorDay(
+        before day: Date,
+        in sortedCompletedDays: [Date],
+        fallback createdDay: Date
+    ) -> Date {
+        // Last element strictly less than `day`.
+        var low = 0
+        var high = sortedCompletedDays.count
+        while low < high {
+            let mid = low + (high - low) / 2
+            if sortedCompletedDays[mid] < day {
+                low = mid + 1
+            } else {
+                high = mid
+            }
+        }
+        return low > 0 ? sortedCompletedDays[low - 1] : createdDay
+    }
+
+    /// The days that may re-anchor `habit`'s cycle, ascending and
+    /// de-duplicated, ready for the sorted `anchorDay` overload.
+    ///
+    /// Empty for a `.negative` habit: there a record means the user
+    /// *broke* the habit, and a slip must not reschedule anything.
+    /// `Habit.effectiveStart` draws the same line.
+    public static func anchorCandidates(
+        for habit: Habit,
+        completions: [Completion],
+        calendar: Calendar
+    ) -> [Date] {
+        guard canReanchor(habit) else { return [] }
+        let days = Set(
+            completions
+                .lazy
+                .filter { $0.habitID == habit.id && $0.value > 0 }
+                .map { calendar.startOfDay(for: $0.date) }
+        )
+        return days.sorted()
+    }
+
+    private static func canReanchor(_ habit: Habit) -> Bool {
+        if case .negative = habit.type { return false }
+        return true
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Services/EveryNDaysCycle.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/EveryNDaysCycle.swift
@@ -14,15 +14,22 @@ import Foundation
 ///
 /// Two properties this keeps:
 ///
-/// - **Monotonic.** Only completions *strictly before* the day under
-///   test can move the anchor, so logging a day never rewrites whether
-///   that same day was due. `FrequencyEvaluating.isDue` depends on this.
+/// - **Monotonic in the day itself.** Only completions *strictly
+///   before* the day under test can move the anchor, so logging a day
+///   never rewrites whether that same day was due. See the caveat on
+///   `FrequencyEvaluating.isDue` about days *after* it.
 /// - **A miss doesn't reschedule.** Only a completion re-anchors, so
 ///   skipping a due day leaves the cycle where it was and the day stays
 ///   a miss (offsets `anchor + n`, `anchor + 2n`, … as before).
 ///
 /// Before the first completion the cycle is anchored to `createdAt`,
 /// which is what makes a brand-new habit due on the day it was created.
+///
+/// **Working ahead removes due days**, which is why the score and the
+/// streak measure a day that is due *or* done rather than due alone —
+/// see `FrequencyEvaluating.isCounted`. Measured on due days only, a
+/// habit done every single day on an every-2-days cadence is never due
+/// after its first day and scores near zero for perfect adherence.
 public enum EveryNDaysCycle {
 
     /// Does the `interval`-day cycle running from `anchorDay` land on
@@ -37,6 +44,18 @@ public enum EveryNDaysCycle {
         guard interval > 0 else { return false }
         let delta = calendar.dateComponents([.day], from: anchorDay, to: day).day ?? 0
         return ((delta % interval) + interval) % interval == 0
+    }
+
+    /// Is `completion` work that re-anchors `habit`'s cycle?
+    ///
+    /// The single definition both anchor lookups below filter on. Two
+    /// copies of a schedule rule drifting apart is what issue #57 was,
+    /// and the linear and sorted paths here feed different callers —
+    /// the streak walker versus the score, grid and calendar — so a
+    /// divergence would render two different due-day sets for one
+    /// habit.
+    public static func isAnchor(_ completion: Completion, for habit: Habit) -> Bool {
+        completion.habitID == habit.id && completion.value > 0 && canReanchor(habit)
     }
 
     /// The day the cycle restarts from when evaluating `day`: the most
@@ -56,8 +75,7 @@ public enum EveryNDaysCycle {
         guard canReanchor(habit) else { return createdDay }
 
         var latest: Date?
-        for completion in completions {
-            guard completion.habitID == habit.id, completion.value > 0 else { continue }
+        for completion in completions where isAnchor(completion, for: habit) {
             let completionDay = calendar.startOfDay(for: completion.date)
             guard completionDay < day else { continue }
             if latest == nil || completionDay > latest! { latest = completionDay }
@@ -89,10 +107,6 @@ public enum EveryNDaysCycle {
 
     /// The days that may re-anchor `habit`'s cycle, ascending and
     /// de-duplicated, ready for the sorted `anchorDay` overload.
-    ///
-    /// Empty for a `.negative` habit: there a record means the user
-    /// *broke* the habit, and a slip must not reschedule anything.
-    /// `Habit.effectiveStart` draws the same line.
     public static func anchorCandidates(
         for habit: Habit,
         completions: [Completion],
@@ -102,13 +116,30 @@ public enum EveryNDaysCycle {
         let days = Set(
             completions
                 .lazy
-                .filter { $0.habitID == habit.id && $0.value > 0 }
+                .filter { isAnchor($0, for: habit) }
                 .map { calendar.startOfDay(for: $0.date) }
         )
         return days.sorted()
     }
 
-    private static func canReanchor(_ habit: Habit) -> Bool {
+    /// Same, for a caller that has already reduced the habit's
+    /// completions to a set of day-start `Date`s — which is exactly
+    /// what the streak walkers build for their completed-day lookup.
+    /// Rebuilding it from `[Completion]` would repeat that whole
+    /// filter + map + `startOfDay` pass.
+    public static func anchorCandidates(
+        for habit: Habit,
+        completedDays: Set<Date>
+    ) -> [Date] {
+        guard canReanchor(habit) else { return [] }
+        return completedDays.sorted()
+    }
+
+    /// Whether a record on this habit represents work that moves the
+    /// cycle. False for `.negative`, where a record means the user
+    /// *broke* the habit — a slip must not push the next check-in out.
+    /// `Habit.effectiveStart` draws the same line.
+    public static func canReanchor(_ habit: Habit) -> Bool {
         if case .negative = habit.type { return false }
         return true
     }

--- a/Packages/KadoCore/Sources/KadoCore/Services/FrequencyEvaluating.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/FrequencyEvaluating.swift
@@ -5,9 +5,11 @@ import Foundation
 /// (`createdAt` / `archivedAt`) and, for flexible schedules like
 /// `.daysPerWeek`, its recent completion history.
 ///
-/// The two differ **only** for `.daysPerWeek`. Fixed schedules
-/// (`.daily`, `.specificDays`, `.everyNDays`) ignore completions
-/// entirely, so they answer both identically.
+/// The two differ **only** for `.daysPerWeek`. `.daily` and
+/// `.specificDays` ignore completions outright; `.everyNDays` reads
+/// only the ones *strictly before* the day it is asked about, because
+/// its cycle restarts from the last day the habit was done (see
+/// `EveryNDaysCycle`). So all three answer both questions identically.
 ///
 /// Keeping them apart matters: collapsing them into a single `isDue`
 /// is what let a completed day render as "not scheduled" in the
@@ -24,6 +26,11 @@ public protocol FrequencyEvaluating: Sendable {
     ///
     /// For `.daysPerWeek(n)`, counts completions over the six days
     /// *before* `date` and reports whether the quota still had room.
+    ///
+    /// For `.everyNDays(n)`, measures the interval from the last day
+    /// the habit was done before `date`, falling back to its creation
+    /// day. Only a completion re-anchors the cycle, so a skipped due
+    /// day stays a miss.
     ///
     /// This is the right question for anything retrospective:
     /// rendering a grid or calendar, scoring, sectioning a list.

--- a/Packages/KadoCore/Sources/KadoCore/Services/FrequencyEvaluating.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/FrequencyEvaluating.swift
@@ -18,11 +18,20 @@ import Foundation
 public protocol FrequencyEvaluating: Sendable {
     /// Did the schedule ask for this habit on `date`?
     ///
-    /// **Monotonic**: what is logged *on* `date` never changes the
-    /// answer. Performing a habit must not retroactively decide the
-    /// day was never required — otherwise back-filling a day makes it
-    /// disappear from the grid, and hitting a weekly target stops the
-    /// score from advancing.
+    /// **Monotonic in `date` itself**: what is logged *on* `date` never
+    /// changes the answer. Performing a habit must not retroactively
+    /// decide that same day was never required — otherwise back-filling
+    /// a day makes it disappear from the grid, and hitting a weekly
+    /// target stops the score from advancing.
+    ///
+    /// It is **not** monotonic in days that follow, and deliberately so
+    /// for the two completion-driven schedules. Back-filling day 1 of
+    /// an `.everyNDays(2)` habit re-anchors its cycle and turns day 2
+    /// from due into not-due, clearing the miss that day 2 had been
+    /// carrying; `.daysPerWeek` shifts its rolling window the same way.
+    /// That is the point of both — a schedule that answers "was this
+    /// asked for?" from history has to be allowed to change its mind
+    /// when the history changes.
     ///
     /// For `.daysPerWeek(n)`, counts completions over the six days
     /// *before* `date` and reports whether the quota still had room.
@@ -64,6 +73,40 @@ extension FrequencyEvaluating {
     /// day the schedule never covered is not a reason to surface the
     /// row — and `HabitRowState` would resolve that row to
     /// `.complete`, crediting the user for the day they slipped.
+    /// Should `date`'s outcome feed the habit's score and streak?
+    ///
+    /// `isDue` for every schedule except `.everyNDays`, which also
+    /// counts a day the user did the habit on anyway.
+    ///
+    /// That exception is load-bearing rather than generous. An
+    /// `.everyNDays` cycle re-anchors on each completion, so working
+    /// ahead *removes* due days: a habit on an every-2-days cadence
+    /// done every single day is never due after its first day. Measured
+    /// on due days alone its score would sit near zero and its streak
+    /// at 1 for flawless adherence — strictly worse than doing less
+    /// work. Counting the days actually done restores the monotonicity
+    /// that matters to a user: more work never scores worse.
+    ///
+    /// A fixed schedule keeps the opposite rule. Running on a Tuesday
+    /// is not part of a Monday-only habit, and `.daysPerWeek` already
+    /// expresses "extra is fine" through its rolling quota.
+    public func isCounted(
+        habit: Habit,
+        on date: Date,
+        completions: [Completion],
+        calendar: Calendar
+    ) -> Bool {
+        guard case .everyNDays = habit.frequency else {
+            return isDue(habit: habit, on: date, completions: completions)
+        }
+        return isDueOrLogged(
+            habit: habit,
+            on: date,
+            completions: completions,
+            calendar: calendar
+        )
+    }
+
     public func isDueOrLogged(
         habit: Habit,
         on date: Date,

--- a/docs/streak.md
+++ b/docs/streak.md
@@ -34,7 +34,9 @@ scheduled:
 
 - `.daily` → every day from `createdAt` to today.
 - `.specificDays(Set<Weekday>)` → only the listed weekdays.
-- `.everyNDays(N)` → every Nth day starting from `createdAt`.
+- `.everyNDays(N)` → every Nth day counted from the last day the
+  habit was done, falling back to `createdAt` before the first
+  completion. Doing it early restarts the clock.
 - `.daysPerWeek(N)` → **every day is potentially due**; the unit
   of streak counting is the *week*, not the day (see below).
 
@@ -115,8 +117,26 @@ against the streak. A Mon/Wed/Fri habit completed every Mon, Wed,
 Fri for three weeks has a current streak of 9.
 
 ### `.everyNDays(N)`
-Due days are `createdAt`, `createdAt + N`, `createdAt + 2N`, …
-Non-due days are skipped. A miss on a due day breaks the streak.
+The cycle is anchored to the **last day the habit was done**, not to
+a fixed grid from `createdAt`. Due days are `anchor + N`,
+`anchor + 2N`, … where the anchor is the most recent completed day
+strictly before the day being judged, or `createdAt` if there is
+none. A miss on a due day breaks the streak.
+
+Only a completion re-anchors, so skipping a due day leaves the cycle
+where it was and the day stays a miss — a skip must not buy a fresh
+interval.
+
+Days that are **not** due but **were** done still count toward the
+streak. Working ahead re-anchors the cycle and therefore removes due
+days, so counting due days alone would give a habit performed every
+single day on an every-2-days cadence a streak of 1. More work must
+never score worse than less. Days that are neither due nor done are
+skipped as before.
+
+An every-2-days habit done Mon, Tue, Thu has a current streak of 3:
+Tuesday moves the next due day to Thursday, so Wednesday is never
+asked for, and Tuesday counts as a day it was done.
 
 ### `.daysPerWeek(N)`
 Counted in **weeks**, not days. A week "counts" if ≥ N


### PR DESCRIPTION
## Why?

An "every 2 days" habit completed **Mon, Tue, Thu** counted Wednesday as a missed due day.

The cycle was pinned to a fixed grid running from `createdAt`, so doing the habit a day early neither satisfied the schedule nor moved the next due day. Being *ahead* of schedule was punished three ways at once — the habit score dipped, the streak broke, and the Overview grid drew a miss on a day the user had every reason to think was covered.

## What?

**The interval is measured from the last day the habit was actually done**, falling back to `createdAt` before the first completion. Tuesday's completion moves the next due day from Wednesday to Thursday, so Wednesday is never asked for.

**Days that are done but not due still count** toward the score and the streak, for `.everyNDays` only. This is the other half of the original request — "Mon, Tue, Thu … should count as completed" — and it is load-bearing rather than generous: because the cycle re-anchors on every completion, working ahead *removes* due days, so a habit on an every-2-days cadence done every single day is never due after its first day. Measured on due days alone its score froze at 5% and its streak at 1 after thirty days of flawless adherence, which is worse than doing half the work and worse than the behaviour this PR set out to fix. Counting the days actually done restores the property that matters: more work never scores worse.

Fixed schedules keep the opposite rule — running on a Tuesday is not part of a Monday-only habit, and `.daysPerWeek` already expresses "extra is fine" through its rolling quota.

Two further properties kept deliberately:

- **Only a completion re-anchors.** Skipping a due day leaves the cycle where it was, so a miss stays a miss — a skip must not buy the user a fresh interval.
- **A `.negative` habit's slip never re-anchors and never counts.** There a record means the user *broke* the habit. Same line `Habit.effectiveStart` already draws.

## How?

- New `EveryNDaysCycle` (`KadoCore/Services/`) holds the cycle rule, which was duplicated in `DefaultFrequencyEvaluator` and `DefaultStreakCalculator.isDueByDay`. A single `isAnchor` predicate backs both anchor lookups — two copies of a schedule rule drifting apart is exactly what issue #57 was.
- New `FrequencyEvaluating.isCounted` is the due-or-done rule the score measures on; `DefaultStreakCalculator.countsLoggedDays` mirrors it for the streak walk.
- Only completions **strictly before** the evaluated day are read, so `isDue` stays monotonic in the day itself and still agrees with `isOutstanding`. The protocol's doc previously claimed a broader monotonicity it never had for either completion-driven schedule; that claim is now correctly scoped.
- Perf: the score walked every day against the **unfiltered** completions array, making a per-day linear scan quadratic in the whole store rather than in the habit — `WidgetSnapshotBuilder` runs this for every habit on MainActor after every mutation. The streak walkers rebuilt the completed-day set twice and recomputed `startOfDay(for: createdAt)` once per day of the habit's lifetime. All hoisted.
- The `n > 0` guard is back at the head of both branches: as an argument expression the anchor was computed before the interval was checked, and a corrupt `.everyNDays(0)` (neither `Frequency.init(from:)` nor `CSVBackupCoder` range-checks it) paid a full scan per day to return false.
- `docs/streak.md` updated — it still specified the fixed grid this PR replaces, so spec and code contradicted each other.

**Tests** — 12 across the evaluator, streak, score, scheduler and seed suites: the Mon/Tue/Thu case, the daily-over-delivery case in both score and streak, a "more work never shortens the streak" invariant, a guard that a *missed* day does not reschedule, note-only (`value: 0`) records, foreign-habit completions, negative-habit slips, and a DST invariant swept over Paris (02:00/03:00) and Havana (midnight, so the day starts at 01:00).

Each was checked to actually discriminate by reverting each copy of the rule in turn. Two pre-existing blind spots closed: the scheduler suite only ever passed `completions: []`, exercising the `createdAt` fallback exclusively, and `fixedSchedulesAgree` only placed a completion on the day under test — the one day the anchor lookup ignores.

**Dev seed** — the demo dataset covered `.daily`, `.specificDays` and `.daysPerWeek` but not `.everyNDays`, so launching the app to check this fix showed nothing at all. Added "Water the plants": every 2 days, 30 days of history, mostly on cadence with four completions a day early. The early days are the point — seeded flat on cadence the habit renders identically whether the cycle re-anchors or not. Verified in the simulator: it reads **17 · 55%**, where the same history on the old fixed grid breaks at day -6 for a streak of 2.

## Next steps

- No schema change, so no CloudKit deploy needed.
- **Needs a what's-new entry before shipping.** The change is retroactive: every existing `.everyNDays` habit's score, streak and Overview row shift on update, and best streak — the number users treat as a permanent record — moves too. The direction is always favourable, but it is unexplained without a release note. The repo already has the mechanism (see 4080fdc).
- Only the Today screen was reachable for visual verification (`idb` not installed, XcodeBuildMCP tap primitives not enabled), so the Overview grid has not been checked live.
- Not taken from review: making a partial counter log (1 rep of 20) stop re-anchoring. `value > 0` is the existing convention for "did something" in `effectiveStart`, the `.daysPerWeek` quota and `completedDaySet`; singling out `.everyNDays` would be the inconsistency. Worth revisiting as a cross-cutting decision.
- Consider whether the New Habit form's "Every N days" label should hint at the flexible reading. Left alone here; it is a copy decision, not a logic one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjLtYt8oJ69MV7agVSscQb
