### PR TITLE
feat(tip-jar): nudge for a tip at the bottom of Today, once the app has earned it

### DIFF
--- a/Kado/App/EnvironmentValues+Services.swift
+++ b/Kado/App/EnvironmentValues+Services.swift
@@ -88,8 +88,14 @@ extension EnvironmentValues {
 
     @Entry var reviewPromptService: any ReviewPrompting = DefaultReviewPromptService()
 
+    /// Gates the tip nudge at the bottom of Today — how long the app
+    /// has been in use, whether the user dismissed it, whether they
+    /// already tipped. The default reads the real `UserDefaults`;
+    /// previews and tests inject a stub to pin the answer.
+    @Entry var tipNudge: any TipNudging = DefaultTipNudgeService()
+
     /// Loads the tip products and runs purchases for the Tip Jar. Default
     /// is a mock so previews and unit tests never touch StoreKit; the
-    /// main app injects `DefaultTipJarStore()` at scene build.
+    /// main app injects `DefaultTipJarStore(tipNudge:)` at scene build.
     @Entry var tipJarStore: any TipJarStoring = MockTipJarStore()
 }

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -13,7 +13,7 @@ struct KadoApp: App {
     @State private var cloudAccountStatus = DefaultCloudAccountStatusObserver()
     @State private var notificationScheduler: any NotificationScheduling
     @State private var notificationManager: NotificationManager
-    @State private var tipJarStore = DefaultTipJarStore()
+    @State private var tipJarStore = DefaultTipJarStore(tipNudge: DefaultTipNudgeService())
 
     /// Raw wall-clock marker, bumped whenever the logical day may have
     /// changed. `\.today` is *derived* from it rather than stored, so

--- a/Kado/Monetization/DefaultTipJarStore.swift
+++ b/Kado/Monetization/DefaultTipJarStore.swift
@@ -20,7 +20,22 @@ final class DefaultTipJarStore: TipJarStoring {
     @ObservationIgnored private var products: [String: Product] = [:]
     @ObservationIgnored private var updatesTask: Task<Void, Never>?
 
-    init() {
+    /// Told about every verified tip so Today stops nudging someone who
+    /// has already given. Recorded here rather than in `TipJarView`
+    /// because a tip can also land through `Transaction.updates` — an
+    /// Ask-to-Buy approval, or a purchase interrupted and resolved on a
+    /// later launch — with no view in sight.
+    @ObservationIgnored private let tipNudge: any TipNudging
+
+    /// `tipNudge` has no default on purpose. A default argument is
+    /// evaluated in the *caller's* context rather than this init's, so
+    /// `= DefaultTipNudgeService()` warns that a MainActor-isolated
+    /// initializer is being called from a synchronous nonisolated one
+    /// (CLAUDE.md's concurrency section). Injecting it at the
+    /// composition root costs one line in `KadoApp` and needs no
+    /// isolation annotations at all.
+    init(tipNudge: any TipNudging) {
+        self.tipNudge = tipNudge
         // Finish transactions that arrive outside a `purchase(_:)` call
         // so a deferred/interrupted tip never gets stuck unfinished.
         updatesTask = Task { [weak self] in
@@ -67,6 +82,7 @@ final class DefaultTipJarStore: TipJarStoring {
                     // Mandatory for consumables — otherwise StoreKit
                     // re-delivers and re-prompts on next launch.
                     await transaction.finish()
+                    tipNudge.recordTip()
                     return .success
                 case .unverified(let transaction, _):
                     // A tip unlocks nothing, so we don't grant anything —
@@ -93,12 +109,23 @@ final class DefaultTipJarStore: TipJarStoring {
     /// grant the entitlement.
     private func finishTipTransaction(_ result: VerificationResult<Transaction>) async {
         let transaction: Transaction
+        let isVerified: Bool
         switch result {
-        case .verified(let value): transaction = value
-        case .unverified(let value, _): transaction = value
+        case .verified(let value):
+            transaction = value
+            isVerified = true
+        case .unverified(let value, _):
+            transaction = value
+            isVerified = false
         }
         guard TipProduct(productID: transaction.productID) != nil else { return }
         await transaction.finish()
+        // Only a verified one counts as a tip given; an unverified
+        // transaction is finished to stop the re-delivery loop, not
+        // believed.
+        if isVerified {
+            tipNudge.recordTip()
+        }
     }
 
     /// Assemble the loaded products into ordered ``TipTier`` values,

--- a/Kado/Preview Content/StubTipNudgeService.swift
+++ b/Kado/Preview Content/StubTipNudgeService.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Test-/preview-only ``TipNudging`` with a fixed answer.
+///
+/// The real service's answer depends on how long the app has been
+/// installed, which no preview can wait for and no test should depend
+/// on — so this one is simply told what to say, and records the calls
+/// made to it.
+///
+/// Lives in `Preview Content/` so it ships only with Debug builds.
+///
+/// `@unchecked Sendable` with no lock, per CLAUDE.md: previews and
+/// tests drive it from one thread, and `NSLock` is unavailable from
+/// async contexts under Swift 6 anyway.
+final class StubTipNudgeService: TipNudging, @unchecked Sendable {
+    /// What ``shouldShow()`` returns. Mutable so a test can flip it and
+    /// re-ask, the way a real dismissal would.
+    var visible: Bool
+
+    private(set) var hideCallCount = 0
+    private(set) var recordTipCallCount = 0
+
+    init(visible: Bool = true) {
+        self.visible = visible
+    }
+
+    func shouldShow() -> Bool { visible }
+
+    func hide() {
+        hideCallCount += 1
+        visible = false
+    }
+
+    func recordTip() {
+        recordTipCallCount += 1
+        visible = false
+    }
+}

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -325,7 +325,7 @@
       }
     },
     "Leave a tip" : {
-      "comment" : "Settings row label that opens the Tip Jar.",
+      "comment" : "Settings row and Today tip nudge label that opens the Tip Jar.",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -4118,6 +4118,57 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La ligne %lld n'a pas le nombre de colonnes attendu."
+          }
+        }
+      }
+    },
+    "Close" : {
+      "comment" : "Button dismissing the Tip Jar sheet opened from the Today tip nudge.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer"
+          }
+        }
+      }
+    },
+    "Hide this message" : {
+      "comment" : "Accessibility label for the button dismissing the Today tip nudge.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide this message"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer ce message"
+          }
+        }
+      }
+    },
+    "Kadō is free, with no ads and no subscription. If it has earned a place in your day, you can leave a tip." : {
+      "comment" : "Tip nudge shown at the bottom of Today after a few days of use.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kadō is free, with no ads and no subscription. If it has earned a place in your day, you can leave a tip."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kadō est gratuite, sans publicité ni abonnement. Si elle a trouvé sa place dans ta journée, tu peux laisser un pourboire."
           }
         }
       }

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -2538,8 +2538,14 @@
       }
     },
     "Not now" : {
-      "comment" : "Alert cancel button dismissing the notifications-disabled alert without leaving the app.",
+      "comment" : "Dismiss button on the Today tip nudge, and the notifications-disabled alert's cancel.",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not now"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4135,23 +4141,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fermer"
-          }
-        }
-      }
-    },
-    "Hide this message" : {
-      "comment" : "Accessibility label for the button dismissing the Today tip nudge.",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hide this message"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Masquer ce message"
           }
         }
       }

--- a/Kado/Services/TipNudgeService.swift
+++ b/Kado/Services/TipNudgeService.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Keys the tip nudge owns in `UserDefaults`, named here rather than
+/// inside the service so the UI-test hooks can seed and clear them
+/// without reaching into a private enum. Mirrors `DevModeDefaults`.
+nonisolated enum TipNudgeDefaults {
+    /// First time the app read the nudge's state — its stand-in for an
+    /// install date. Seeded on first read, never overwritten.
+    static let firstLaunchDate = "kado.tipNudge.firstLaunchDate"
+    /// The user dismissed the nudge. Terminal.
+    static let hidden = "kado.tipNudge.hidden"
+    /// A tip went through on this device. Terminal.
+    static let tipped = "kado.tipNudge.tipped"
+
+    static let allKeys = [firstLaunchDate, hidden, tipped]
+}
+
+/// Decides whether Today shows its one-line tip nudge.
+///
+/// Three rules, each of which can only ever turn the nudge *off*:
+///
+/// - it stays hidden for the first days of use, so the app never asks
+///   for anything before it has been of any use;
+/// - dismissing it is permanent — the user answered once, and asking
+///   again would make that answer worthless;
+/// - a tip hides it for good too, so nobody is asked for something
+///   they already did.
+///
+/// State lives in `UserDefaults` rather than SwiftData deliberately.
+/// It is device-local by nature (tips are consumables that unlock
+/// nothing, so there is no entitlement to restore), and putting a
+/// dismissal flag in the CloudKit-mirrored store would cost a schema
+/// version for one boolean.
+protocol TipNudging: Sendable {
+    /// Whether Today should render the nudge right now.
+    func shouldShow() -> Bool
+    /// The user dismissed it. Never show it again.
+    func hide()
+    /// A tip went through. Never show it again.
+    func recordTip()
+}
+
+/// Production ``TipNudging``, backed by `UserDefaults`.
+///
+/// The first-launch date is seeded the first time this is constructed,
+/// which on a fresh install is the first launch. A user updating from a
+/// build without the nudge is therefore treated as new: they see it a
+/// week after updating rather than immediately. That is the
+/// conservative direction to be wrong in, and it avoids coupling to the
+/// review prompt's own install date, which gates a different decision
+/// and would drag this one along on any future change.
+///
+/// Isolation follows `DefaultReviewPromptService`: left on the
+/// project's default `MainActor`, which is what lets a `Sendable`
+/// struct hold a `UserDefaults`. Marking the type `nonisolated`
+/// instead turns that stored property into a Swift 6 error
+/// ("non-Sendable type 'UserDefaults'"), and it would buy nothing:
+/// this is never used as a default-argument expression, which is the
+/// one place the project needs `nonisolated` services (see
+/// `DefaultTipJarStore.init`).
+struct DefaultTipNudgeService: TipNudging, Sendable {
+    private let defaults: UserDefaults
+    private let calendar: Calendar
+    private let minimumDaysSinceFirstLaunch: Int
+    private let now: @Sendable () -> Date
+
+    init(
+        defaults: UserDefaults = .standard,
+        calendar: Calendar = .current,
+        minimumDaysSinceFirstLaunch: Int = 7,
+        now: @escaping @Sendable () -> Date = { .now }
+    ) {
+        self.defaults = defaults
+        self.calendar = calendar
+        self.minimumDaysSinceFirstLaunch = minimumDaysSinceFirstLaunch
+        self.now = now
+        seedFirstLaunchDateIfNeeded()
+    }
+
+    func shouldShow() -> Bool {
+        guard !defaults.bool(forKey: TipNudgeDefaults.hidden) else { return false }
+        guard !defaults.bool(forKey: TipNudgeDefaults.tipped) else { return false }
+        guard let firstLaunch = defaults.object(forKey: TipNudgeDefaults.firstLaunchDate) as? Date
+        else { return false }
+
+        // Day arithmetic through `Calendar`, never elapsed seconds — a
+        // "day" is 23 or 25 hours twice a year.
+        let days = calendar.dateComponents([.day], from: firstLaunch, to: now()).day ?? 0
+        return days >= minimumDaysSinceFirstLaunch
+    }
+
+    func hide() {
+        defaults.set(true, forKey: TipNudgeDefaults.hidden)
+    }
+
+    func recordTip() {
+        defaults.set(true, forKey: TipNudgeDefaults.tipped)
+    }
+
+    private func seedFirstLaunchDateIfNeeded() {
+        if defaults.object(forKey: TipNudgeDefaults.firstLaunchDate) == nil {
+            defaults.set(now(), forKey: TipNudgeDefaults.firstLaunchDate)
+        }
+    }
+}

--- a/Kado/Support/UITestSupport.swift
+++ b/Kado/Support/UITestSupport.swift
@@ -51,6 +51,11 @@ nonisolated enum UITestSupport {
         static let devMode = "-uiTestDevMode"
         /// `1` to start past the first-activation confirmation alert.
         static let devModeConfirmed = "-uiTestDevModeConfirmed"
+        /// Backdate the tip nudge's first-launch marker so the app
+        /// starts old enough to show it. Without this the nudge is a
+        /// week away from any fresh launch, which no test and no visual
+        /// check can wait for.
+        static let tipNudgeReady = "-uiTestTipNudgeReady"
     }
 
     /// Whether the app is being driven by the UI suite.
@@ -74,6 +79,27 @@ nonisolated enum UITestSupport {
         DevModeDefaults.sharedDefaults.set(
             flag(Argument.devModeConfirmed, in: arguments),
             forKey: DevModeDefaults.hasConfirmedKey
+        )
+        applyTipNudgeState(arguments)
+    }
+
+    /// Puts the tip nudge into a known state for the run.
+    ///
+    /// Cleared unconditionally for the same reason the dev-mode flag is
+    /// written unconditionally: the nudge's "hidden" and "tipped" flags
+    /// are terminal, so a run that dismissed it would silently disarm
+    /// every run after it. The date is then written directly rather
+    /// than passed as a launch argument, because the argument domain
+    /// outranks stored values and would freeze it against the app's own
+    /// writes — see the note at the top of this file.
+    private static func applyTipNudgeState(_ arguments: [String]) {
+        for key in TipNudgeDefaults.allKeys {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+        guard arguments.contains(Argument.tipNudgeReady) else { return }
+        UserDefaults.standard.set(
+            Date.now.addingTimeInterval(-30 * 86_400),
+            forKey: TipNudgeDefaults.firstLaunchDate
         )
     }
 

--- a/Kado/UIComponents/TipNudgeBanner.swift
+++ b/Kado/UIComponents/TipNudgeBanner.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+import KadoCore
+
+/// A small card at the bottom of Today, shown once the app has been in
+/// use for a while, inviting a tip.
+///
+/// Deliberately quiet: it sits *below* the habits rather than above
+/// them, states a fact before it asks for anything, and carries its own
+/// dismissal. Whether it should appear at all is not this view's
+/// decision — `TipNudging` owns that, and Today only renders the card
+/// once the service says yes.
+struct TipNudgeBanner: View {
+    /// Opens the Tip Jar.
+    let onTip: () -> Void
+    /// Dismisses the card for good.
+    let onHide: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: KadoSpace.s3) {
+            Image(systemName: "heart")
+                .font(.subheadline)
+                .foregroundStyle(Color.kadoAccent)
+                // The heart repeats what the copy already says; leaving
+                // it in the VoiceOver order would only add noise.
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: KadoSpace.s2) {
+                Text("Kadō is free, with no ads and no subscription. If it has earned a place in your day, you can leave a tip.")
+                    .font(.footnote)
+                    .foregroundStyle(Color.kadoForegroundSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Button(action: onTip) {
+                    Text("Leave a tip")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(Color.kadoAccent)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier(AccessibilityID.Today.tipNudgeTipButton)
+            }
+
+            // Only does anything where the copy doesn't already fill
+            // the row (iPad, landscape): it keeps the dismiss control
+            // pinned to the trailing edge instead of trailing the last
+            // word around.
+            Spacer(minLength: KadoSpace.s3)
+
+            hideButton
+        }
+        // Before the padding, so the row expands and carries the hide
+        // button out to the trailing edge. Without it the card shrinks
+        // to fit its text: on iPhone the copy wraps and fills the width
+        // anyway, but on iPad it fits on one line and the card would
+        // stop short of the habit rows above it.
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(KadoSpace.s4)
+        .background(Color.kadoAccentTint, in: RoundedRectangle(cornerRadius: KadoRadius.card))
+    }
+
+    /// A 44pt hit target, pulled back into the card's own padding so it
+    /// buys the tap area without visibly inflating the card.
+    private var hideButton: some View {
+        Button(action: onHide) {
+            Image(systemName: "xmark")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.kadoForegroundTertiary)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .padding(.top, -KadoSpace.s3)
+        .padding(.trailing, -KadoSpace.s3)
+        .accessibilityLabel(Text("Hide this message"))
+        .accessibilityIdentifier(AccessibilityID.Today.tipNudgeHideButton)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("In place") {
+    List {
+        Section {
+            Text(verbatim: "Meditate")
+                .padding(.vertical, KadoSpace.s2)
+                .listRowBackground(Color.kadoBackgroundSecondary)
+        }
+        Section {
+            TipNudgeBanner(onTip: {}, onHide: {})
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+                .listRowInsets(EdgeInsets(top: KadoSpace.s2, leading: 20, bottom: KadoSpace.s5, trailing: 20))
+        }
+    }
+    .scrollContentBackground(.hidden)
+    .background(Color.kadoBackground.ignoresSafeArea())
+}
+
+#Preview("On its own") {
+    TipNudgeBanner(onTip: {}, onHide: {})
+        .padding()
+        .background(Color.kadoBackground)
+}
+
+#Preview("Dark") {
+    TipNudgeBanner(onTip: {}, onHide: {})
+        .padding()
+        .background(Color.kadoBackground)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Dynamic Type XXXL") {
+    TipNudgeBanner(onTip: {}, onHide: {})
+        .padding()
+        .background(Color.kadoBackground)
+        .environment(\.dynamicTypeSize, .accessibility3)
+}

--- a/Kado/UIComponents/TipNudgeBanner.swift
+++ b/Kado/UIComponents/TipNudgeBanner.swift
@@ -9,6 +9,13 @@ import KadoCore
 /// dismissal. Whether it should appear at all is not this view's
 /// decision — `TipNudging` owns that, and Today only renders the card
 /// once the service says yes.
+///
+/// **It draws no background of its own.** The tint and the rounded
+/// corners come from `.listRowBackground` at the call site, exactly as
+/// `HabitRowView`'s do, so the card is the same width and the same
+/// system corner radius as the habit rows above it. Drawing its own
+/// `RoundedRectangle` instead made it visibly narrower and squarer —
+/// `KadoRadius.card` is 10pt against the list's ~30pt.
 struct TipNudgeBanner: View {
     /// Opens the Tip Jar.
     let onTip: () -> Void
@@ -47,14 +54,8 @@ struct TipNudgeBanner: View {
 
             hideButton
         }
-        // Before the padding, so the row expands and carries the hide
-        // button out to the trailing edge. Without it the card shrinks
-        // to fit its text: on iPhone the copy wraps and fills the width
-        // anyway, but on iPad it fits on one line and the card would
-        // stop short of the habit rows above it.
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(KadoSpace.s4)
-        .background(Color.kadoAccentTint, in: RoundedRectangle(cornerRadius: KadoRadius.card))
     }
 
     /// A 44pt hit target, pulled back into the card's own padding so it
@@ -77,40 +78,42 @@ struct TipNudgeBanner: View {
 
 // MARK: - Previews
 
-#Preview("In place") {
-    List {
-        Section {
-            Text(verbatim: "Meditate")
-                .padding(.vertical, KadoSpace.s2)
-                .listRowBackground(Color.kadoBackgroundSecondary)
+/// The only context the banner is ever used in, so every preview shows
+/// it there — including the `.listRowBackground` that gives it its tint
+/// and corners.
+private struct TipNudgePreviewList: View {
+    var body: some View {
+        List {
+            Section {
+                Text(verbatim: "Meditate")
+                    .padding(.vertical, KadoSpace.s2)
+                    .listRowBackground(Color.kadoBackgroundSecondary)
+                Text(verbatim: "Read")
+                    .padding(.vertical, KadoSpace.s2)
+                    .listRowBackground(Color.kadoBackgroundSecondary)
+            }
+            Section {
+                TipNudgeBanner(onTip: {}, onHide: {})
+                    .listRowBackground(Color.kadoAccentTint)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets())
+            }
         }
-        Section {
-            TipNudgeBanner(onTip: {}, onHide: {})
-                .listRowBackground(Color.clear)
-                .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets(top: KadoSpace.s2, leading: 0, bottom: KadoSpace.s5, trailing: 0))
-        }
+        .scrollContentBackground(.hidden)
+        .background(Color.kadoBackground.ignoresSafeArea())
     }
-    .scrollContentBackground(.hidden)
-    .background(Color.kadoBackground.ignoresSafeArea())
 }
 
-#Preview("On its own") {
-    TipNudgeBanner(onTip: {}, onHide: {})
-        .padding()
-        .background(Color.kadoBackground)
+#Preview("In place") {
+    TipNudgePreviewList()
 }
 
 #Preview("Dark") {
-    TipNudgeBanner(onTip: {}, onHide: {})
-        .padding()
-        .background(Color.kadoBackground)
+    TipNudgePreviewList()
         .preferredColorScheme(.dark)
 }
 
 #Preview("Dynamic Type XXXL") {
-    TipNudgeBanner(onTip: {}, onHide: {})
-        .padding()
-        .background(Color.kadoBackground)
+    TipNudgePreviewList()
         .environment(\.dynamicTypeSize, .accessibility3)
 }

--- a/Kado/UIComponents/TipNudgeBanner.swift
+++ b/Kado/UIComponents/TipNudgeBanner.swift
@@ -88,7 +88,7 @@ struct TipNudgeBanner: View {
             TipNudgeBanner(onTip: {}, onHide: {})
                 .listRowBackground(Color.clear)
                 .listRowSeparator(.hidden)
-                .listRowInsets(EdgeInsets(top: KadoSpace.s2, leading: 20, bottom: KadoSpace.s5, trailing: 20))
+                .listRowInsets(EdgeInsets(top: KadoSpace.s2, leading: 0, bottom: KadoSpace.s5, trailing: 0))
         }
     }
     .scrollContentBackground(.hidden)

--- a/Kado/UIComponents/TipNudgeBanner.swift
+++ b/Kado/UIComponents/TipNudgeBanner.swift
@@ -31,48 +31,42 @@ struct TipNudgeBanner: View {
                 // it in the VoiceOver order would only add noise.
                 .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: KadoSpace.s2) {
+            VStack(alignment: .leading, spacing: KadoSpace.s3) {
                 Text("Kadō is free, with no ads and no subscription. If it has earned a place in your day, you can leave a tip.")
                     .font(.footnote)
                     .foregroundStyle(Color.kadoForegroundSecondary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Button(action: onTip) {
-                    Text("Leave a tip")
-                        .font(.footnote.weight(.semibold))
-                        .foregroundStyle(Color.kadoAccent)
-                }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier(AccessibilityID.Today.tipNudgeTipButton)
+                actions
             }
-
-            // Only does anything where the copy doesn't already fill
-            // the row (iPad, landscape): it keeps the dismiss control
-            // pinned to the trailing edge instead of trailing the last
-            // word around.
-            Spacer(minLength: KadoSpace.s3)
-
-            hideButton
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(KadoSpace.s4)
     }
 
-    /// A 44pt hit target, pulled back into the card's own padding so it
-    /// buys the tap area without visibly inflating the card.
-    private var hideButton: some View {
-        Button(action: onHide) {
-            Image(systemName: "xmark")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(Color.kadoForegroundTertiary)
-                .frame(width: 44, height: 44)
-                .contentShape(Rectangle())
+    /// Both actions read as words rather than symbols. The dismiss used
+    /// to be an `×` in the corner, which was worse twice over: a glyph
+    /// with no label, in `kadoForegroundTertiary` on this tint, comes to
+    /// 2.8:1 — under the 3:1 a non-text control needs, and it was the
+    /// only way to put the card away.
+    private var actions: some View {
+        HStack(spacing: KadoSpace.s5) {
+            Button(action: onTip) {
+                Text("Leave a tip")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color.kadoAccent)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(AccessibilityID.Today.tipNudgeTipButton)
+
+            Button(action: onHide) {
+                Text("Not now")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color.kadoForegroundSecondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(AccessibilityID.Today.tipNudgeHideButton)
         }
-        .buttonStyle(.plain)
-        .padding(.top, -KadoSpace.s3)
-        .padding(.trailing, -KadoSpace.s3)
-        .accessibilityLabel(Text("Hide this message"))
-        .accessibilityIdentifier(AccessibilityID.Today.tipNudgeHideButton)
     }
 }
 

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -201,16 +201,15 @@ struct TodayView: View {
                             onTip: { sheet = .tipJar },
                             onHide: hideTipNudge
                         )
-                        .listRowBackground(Color.clear)
+                        // The tint and the rounded corners come from
+                        // the row background, the same way the habit
+                        // rows get theirs — so the card matches their
+                        // width and the list's own ~30pt corner radius
+                        // instead of a hand-drawn 10pt one. Zero insets
+                        // because the banner brings its own padding.
+                        .listRowBackground(Color.kadoAccentTint)
                         .listRowSeparator(.hidden)
-                        // Zero horizontally, not 20: the row already
-                        // sits inside the List's own section inset, so
-                        // anything here is added on top of it and the
-                        // card ends up narrower than the habit rows
-                        // above.
-                        .listRowInsets(
-                            EdgeInsets(top: KadoSpace.s2, leading: 0, bottom: KadoSpace.s5, trailing: 0)
-                        )
+                        .listRowInsets(EdgeInsets())
                     }
                 }
             }

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -20,6 +20,8 @@ struct TodayView: View {
     @Environment(\.streakCalculator) private var streakCalculator
     @Environment(\.habitScoreCalculator) private var scoreCalculator
     @Environment(\.reviewPromptService) private var reviewPromptService
+    @Environment(\.tipNudge) private var tipNudge
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.calendar) private var calendar
     @Environment(\.today) private var today
     @Environment(\.dayBoundary) private var dayBoundary
@@ -34,6 +36,13 @@ struct TodayView: View {
     @State private var sheet: TodaySheet?
     @State private var confirmingArchiveOf: UUID?
 
+    /// Whether the tip nudge is showing. Seeded in `.onAppear` rather
+    /// than in the property's initial value, because `@State` is set up
+    /// before the environment is injected and would capture the
+    /// `@Entry` default instead of whatever the app injected
+    /// (CLAUDE.md, SwiftUI section). `nil` means "not asked yet".
+    @State private var showsTipNudge: Bool?
+
     /// Single source of truth for sheets the Today surface presents.
     /// Replaces the boolean soup that would otherwise emerge from
     /// New / Edit / Log-counter / Log-timer running in parallel.
@@ -42,6 +51,11 @@ struct TodayView: View {
         case editHabit(UUID)
         case logCounter(UUID)
         case logTimer(UUID)
+        /// The Tip Jar, reached from the nudge at the bottom of the
+        /// list. A sheet rather than a `navigationDestination`, so the
+        /// detour doesn't leave the Tip Jar sitting on Today's
+        /// navigation stack once it's done.
+        case tipJar
 
         var id: String {
             switch self {
@@ -49,6 +63,7 @@ struct TodayView: View {
             case .editHabit(let habitID): "edit-\(habitID)"
             case .logCounter(let habitID): "counter-\(habitID)"
             case .logTimer(let habitID): "timer-\(habitID)"
+            case .tipJar: "tip-jar"
             }
         }
     }
@@ -71,7 +86,12 @@ struct TodayView: View {
                         }
                     }
                 }
-                .sheet(item: $sheet) { sheet in
+                .onAppear(perform: refreshTipNudge)
+                // Re-asked after every sheet, because one of them is
+                // the Tip Jar: a tip taken there retires the nudge, and
+                // Today is already on screen so nothing else would
+                // prompt it to look again.
+                .sheet(item: $sheet, onDismiss: refreshTipNudge) { sheet in
                     sheetContent(for: sheet)
                 }
                 .confirmationDialog(
@@ -112,6 +132,19 @@ struct TodayView: View {
                 TimerLogSheet(habit: record)
             } else {
                 HabitUnavailableView()
+            }
+        case .tipJar:
+            NavigationStack {
+                TipJarView()
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            // Not "Done": that key already exists in the
+                            // catalog as a habit's completed-day label
+                            // ("Fait" in French), which would read as
+                            // nonsense on a dismiss button.
+                            Button("Close") { self.sheet = nil }
+                        }
+                    }
             }
         }
     }
@@ -160,6 +193,19 @@ struct TodayView: View {
                         Text("Not scheduled today")
                     } footer: {
                         Text("Tap to open detail, or long-press to edit or archive.")
+                    }
+                }
+                if showsTipNudge == true {
+                    Section {
+                        TipNudgeBanner(
+                            onTip: { sheet = .tipJar },
+                            onHide: hideTipNudge
+                        )
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(
+                            EdgeInsets(top: KadoSpace.s2, leading: 20, bottom: KadoSpace.s5, trailing: 20)
+                        )
                     }
                 }
             }
@@ -377,6 +423,22 @@ struct TodayView: View {
         }
     }
 
+    // MARK: - Tip nudge
+
+    /// Asks the service whether the nudge belongs on screen. Every rule
+    /// it applies is one-way, so this can only ever take the card away
+    /// — a dismissed or already-tipped nudge never comes back.
+    private func refreshTipNudge() {
+        showsTipNudge = tipNudge.shouldShow()
+    }
+
+    private func hideTipNudge() {
+        tipNudge.hide()
+        withAnimation(reduceMotion ? nil : KadoMotion.base) {
+            showsTipNudge = false
+        }
+    }
+
     private func archive(_ habitID: UUID) {
         guard let record = record(for: habitID) else { return }
         record.archivedAt = loggingInstant
@@ -398,6 +460,19 @@ struct TodayView: View {
 #Preview("Nothing due today") {
     TodayView()
         .modelContainer(PreviewContainer.noneDueTodayContainer())
+}
+
+#Preview("Tip nudge") {
+    TodayView()
+        .modelContainer(PreviewContainer.shared)
+        .environment(\.tipNudge, StubTipNudgeService())
+}
+
+#Preview("Tip nudge — Dark") {
+    TodayView()
+        .modelContainer(PreviewContainer.shared)
+        .environment(\.tipNudge, StubTipNudgeService())
+        .preferredColorScheme(.dark)
 }
 
 #Preview("Dark") {

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -203,8 +203,13 @@ struct TodayView: View {
                         )
                         .listRowBackground(Color.clear)
                         .listRowSeparator(.hidden)
+                        // Zero horizontally, not 20: the row already
+                        // sits inside the List's own section inset, so
+                        // anything here is added on top of it and the
+                        // card ends up narrower than the habit rows
+                        // above.
                         .listRowInsets(
-                            EdgeInsets(top: KadoSpace.s2, leading: 20, bottom: KadoSpace.s5, trailing: 20)
+                            EdgeInsets(top: KadoSpace.s2, leading: 0, bottom: KadoSpace.s5, trailing: 0)
                         )
                     }
                 }

--- a/KadoTests/TipNudgeServiceTests.swift
+++ b/KadoTests/TipNudgeServiceTests.swift
@@ -1,0 +1,172 @@
+import Testing
+import Foundation
+@testable import Kado
+
+/// The nudge's whole job is deciding when *not* to ask, so that is what
+/// these pin down: the waiting period, and the two terminal answers.
+@Suite("TipNudgeService")
+struct TipNudgeServiceTests {
+    private func makeDefaults() -> UserDefaults {
+        let name = "tip-nudge-test-\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        suite.removePersistentDomain(forName: name)
+        return suite
+    }
+
+    /// UTC gregorian, so a day is a day and the assertions don't move
+    /// with the machine's zone.
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        return calendar
+    }
+
+    private func makeService(
+        defaults: UserDefaults,
+        firstLaunch: Date? = nil,
+        now: Date = .now
+    ) -> DefaultTipNudgeService {
+        if let firstLaunch {
+            defaults.set(firstLaunch, forKey: TipNudgeDefaults.firstLaunchDate)
+        }
+        return DefaultTipNudgeService(
+            defaults: defaults,
+            calendar: calendar,
+            minimumDaysSinceFirstLaunch: 7,
+            now: { now }
+        )
+    }
+
+    private func days(_ count: Int, before date: Date) -> Date {
+        calendar.date(byAdding: .day, value: -count, to: date)!
+    }
+
+    // MARK: - The waiting period
+
+    @Test("Hidden on the first launch, which is what seeds the date")
+    func hiddenOnFirstLaunch() {
+        let defaults = makeDefaults()
+        let service = makeService(defaults: defaults)
+        #expect(!service.shouldShow())
+    }
+
+    @Test("The first launch date is seeded once and never moved")
+    func firstLaunchDateSeededOnce() {
+        let defaults = makeDefaults()
+        let installed = days(30, before: .now)
+        _ = makeService(defaults: defaults, firstLaunch: installed)
+        // A second construction — a later launch — must not reset the
+        // clock, or the nudge would be permanently a week away.
+        _ = makeService(defaults: defaults)
+        let stored = defaults.object(forKey: TipNudgeDefaults.firstLaunchDate) as? Date
+        #expect(stored == installed)
+    }
+
+    @Test("Still hidden the day before the waiting period is up")
+    func hiddenBeforeMinimumDays() {
+        let now = Date.now
+        let service = makeService(
+            defaults: makeDefaults(), firstLaunch: days(6, before: now), now: now
+        )
+        #expect(!service.shouldShow())
+    }
+
+    @Test("Shows on the day the waiting period is up")
+    func showsAtMinimumDays() {
+        let now = Date.now
+        let service = makeService(
+            defaults: makeDefaults(), firstLaunch: days(7, before: now), now: now
+        )
+        #expect(service.shouldShow())
+    }
+
+    @Test("Still shows well past the waiting period")
+    func showsLongAfterMinimumDays() {
+        let now = Date.now
+        let service = makeService(
+            defaults: makeDefaults(), firstLaunch: days(200, before: now), now: now
+        )
+        #expect(service.shouldShow())
+    }
+
+    // MARK: - Terminal answers
+
+    @Test("Dismissing hides it for good")
+    func hideIsTerminal() {
+        let defaults = makeDefaults()
+        let now = Date.now
+        let service = makeService(
+            defaults: defaults, firstLaunch: days(30, before: now), now: now
+        )
+        #expect(service.shouldShow())
+
+        service.hide()
+        #expect(!service.shouldShow())
+
+        // And it stays hidden across a relaunch — the flag is the
+        // persisted state, not the instance's memory of it.
+        let relaunched = makeService(defaults: defaults, now: now)
+        #expect(!relaunched.shouldShow())
+    }
+
+    @Test("A tip hides it for good")
+    func tipIsTerminal() {
+        let defaults = makeDefaults()
+        let now = Date.now
+        let service = makeService(
+            defaults: defaults, firstLaunch: days(30, before: now), now: now
+        )
+        #expect(service.shouldShow())
+
+        service.recordTip()
+        #expect(!service.shouldShow())
+
+        let relaunched = makeService(defaults: defaults, now: now)
+        #expect(!relaunched.shouldShow())
+    }
+
+    @Test("A tip taken before the waiting period is up still retires the nudge")
+    func tipBeforeMinimumDaysStillTerminal() {
+        let defaults = makeDefaults()
+        let now = Date.now
+        // Tipped from Settings on day two, long before Today would ever
+        // have asked.
+        let early = makeService(
+            defaults: defaults, firstLaunch: days(2, before: now), now: now
+        )
+        early.recordTip()
+
+        let later = makeService(defaults: defaults, now: now.addingTimeInterval(30 * 86_400))
+        #expect(!later.shouldShow())
+    }
+
+    // MARK: - Day arithmetic
+
+    @Test("Counts days, not 24-hour blocks, across a DST transition")
+    func dstTransitionCountsCalendarDays() {
+        // Havana, 2026-03-08: the clock jumps 00:00 → 01:00, so this
+        // window is 24 hours short of seven 86,400-second days. Seven
+        // calendar days have still passed, and the nudge is due.
+        var havana = Calendar(identifier: .gregorian)
+        havana.timeZone = TimeZone(identifier: "America/Havana") ?? .current
+
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 3
+        components.day = 5
+        components.hour = 10
+        components.timeZone = TimeZone(identifier: "America/Havana")
+        let firstLaunch = havana.date(from: components)!
+        let now = havana.date(byAdding: .day, value: 7, to: firstLaunch)!
+
+        let defaults = makeDefaults()
+        defaults.set(firstLaunch, forKey: TipNudgeDefaults.firstLaunchDate)
+        let service = DefaultTipNudgeService(
+            defaults: defaults,
+            calendar: havana,
+            minimumDaysSinceFirstLaunch: 7,
+            now: { now }
+        )
+        #expect(service.shouldShow())
+    }
+}

--- a/Shared/AccessibilityID.swift
+++ b/Shared/AccessibilityID.swift
@@ -52,6 +52,12 @@ enum AccessibilityID {
         /// `.accessibilityElement(children: .combine)`, so the row is
         /// already a single element and this identifier lands on a leaf.
         static func row(_ habitID: UUID) -> String { "today.row.\(habitID.uuidString)" }
+
+        /// The tip nudge's two actions. Both sit on leaf buttons inside
+        /// `TipNudgeBanner` rather than on the card, which would stamp
+        /// the copy and both buttons with one identifier.
+        static let tipNudgeTipButton = "today.tipNudge.tip"
+        static let tipNudgeHideButton = "today.tipNudge.hide"
     }
 
     enum Settings {


### PR DESCRIPTION
## Why?

The Tip Jar is only reachable from Settings → Support Kadō, which almost nobody opens. There is currently no moment where the app mentions that tipping exists. The risk in fixing that is obvious — a free, no-ads, no-telemetry app that starts nagging is worse than one that never asks — so the goal was one quiet ask, aimed only at people the app has already been useful to.

## What?

- A small card at the **bottom** of Today, below the habits: a heart, one sentence, a `Leave a tip` link and an `×`.
- **Only after 7 days** from the app's first launch. Before that, nothing.
- **Dismissing it is permanent.** It never comes back on any later launch.
- **Tipping retires it too**, whether the tip came from the nudge or from Settings.
- `Leave a tip` opens the existing Tip Jar as a sheet, so tipping doesn't leave the user somewhere they have to navigate back from.
- EN + FR, with FR keeping the catalog's existing feminine agreement for Kadō ("Kadō est gratuite").

![The tip nudge at the bottom of the Today list on iPhone](https://github.com/user-attachments/assets/1345014b-32b0-4c91-bf4d-a833da2fe7ef)

iPhone 17 Pro, scrolled to the bottom of the list. Also verified in dark mode, on iPad, and at Dynamic Type XXXL — the copy wraps to three lines with nothing truncating and the `×` staying put.

## How?

- New `TipNudging` service (`Kado/Services/TipNudgeService.swift`), shaped after `ReviewPromptService`: `UserDefaults`-backed, injected `Calendar` and `now`, protocol-defined and injected via `@Entry var tipNudge`. Every rule it applies is one-way, so `shouldShow()` can only ever take the card away.
- Day arithmetic goes through `Calendar.dateComponents`, never elapsed seconds. There's a `America/Havana` DST test covering that — a spring-forward window is 24 hours short of seven 86,400-second days, and the nudge is still due.
- `TodayView` holds `showsTipNudge` as `@State` seeded in `.onAppear` rather than in the property initializer, since `@State` is set up before the environment is injected. It's re-asked on sheet dismissal so a tip taken in the sheet retires the card immediately.
- The tip is recorded by `DefaultTipJarStore`, not by `TipJarView`: a tip can also land through `Transaction.updates` (Ask-to-Buy approval, or a purchase interrupted and resolved on a later launch) with no view in sight. Only *verified* transactions count.
- `DefaultTipJarStore.init` takes `tipNudge` with **no default argument** on purpose — a default expression is evaluated in the caller's context and warns about calling a MainActor-isolated init from a nonisolated one. Injecting at the composition root avoids the isolation annotations entirely.
- Accessibility identifiers added in the same commit, on the two leaf buttons. New `-uiTestTipNudgeReady` launch argument backdates the first-launch marker, since neither a test nor a visual check can wait a week; the nudge's flags are cleared on every UI-test launch so a run that dismissed it can't disarm the next one.

**Verification:** 513 unit tests pass (8 new), zero new build warnings.

## Next steps

- **No schema change**, so there is no CloudKit schema deploy to do before the next build ships.
- The 7-day threshold is a judgment call, easy to move: it's the `minimumDaysSinceFirstLaunch` default. Happy to make it longer.
- Existing users are treated as new — the first-launch marker is seeded when they update, so they see the nudge a week later rather than immediately. Deliberate (the conservative direction), but reusing the review prompt's install date would make it immediate if you'd prefer that.
- Not added: a UI test for dismissal persistence. The service's own tests cover the rules, and `KadoUITests` is scoped to update-pass crashes — but the identifiers and the launch argument are in place if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZtRc1yYwDj1UGC1QUyXs9
