### PR TITLE
docs: refresh README, roadmap, and site for 1.7; descope Watch and HealthKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
   <p>
     <a href="https://github.com/scastiel/kado/blob/main/LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-blue.svg" /></a>
+    <a href="https://apps.apple.com/app/id6762570244"><img alt="App Store 1.7" src="https://img.shields.io/badge/App%20Store-1.7-black.svg" /></a>
     <a href="https://developer.apple.com/swift/"><img alt="Swift 5.10" src="https://img.shields.io/badge/Swift-5.10-orange.svg" /></a>
     <img alt="Platforms" src="https://img.shields.io/badge/platforms-iOS%2018%20%7C%20iPadOS%2018-lightgrey.svg" />
   </p>
@@ -34,7 +35,8 @@ Kadō is an iOS habit tracker with three commitments:
    fragile chain.
 2. **Your data stays yours.** No account, no analytics, no third-party
    SDKs. Storage is local (SwiftData), sync is optional through your
-   own iCloud (CloudKit private database). See [`PRIVACY.md`](./PRIVACY.md).
+   own iCloud (CloudKit private database). Export is lossless, in JSON
+   or CSV, whenever you want it. See [`PRIVACY.md`](./PRIVACY.md).
 3. **Native to Apple.** SwiftUI, `@Observable`, SwiftData, CloudKit,
    WidgetKit, App Intents — no cross-platform layer, no third-party
    dependencies.
@@ -43,9 +45,8 @@ Why another habit tracker? The market gap is spelled out in
 [`docs/PRODUCT.md`](./docs/PRODUCT.md): the reference open-source
 tracker (Loop) is Android-only; the reference iOS tracker (Streaks)
 is closed source and uses a binary streak; the most visible modern
-iOS open source attempt (Teymia) is freemium and ships without Apple
-Watch or HealthKit. Kadō takes Loop's algorithm to native iOS, MIT,
-with the full Apple ecosystem in scope.
+iOS open source attempt (Teymia) is freemium. Kadō takes Loop's
+algorithm to native iOS — MIT, free, no account, no subscription.
 
 ## Screenshots
 
@@ -60,37 +61,66 @@ with the full Apple ecosystem in scope.
 ## Features
 
 - **Today view** — habits due today, tap to complete, long-press for
-  partial / note / timer.
-- **Habit detail** — monthly calendar, current streak, best streak,
-  habit score with an info popover explaining the math.
+  partial / note / timer, drag to reorder (the order syncs via
+  iCloud).
+- **Habit detail** — monthly calendar with month-by-month navigation,
+  current streak, best streak, habit score with an info popover
+  explaining the math. Edit any past day straight from the calendar,
+  including days before the habit existed.
+- **Per-day notes** — a short note on any day's completion, carried
+  through export and import.
 - **Overview** — habits × days matrix with score-shaded cells, the
-  Loop / Way of Life pattern with Kadō's score DNA.
+  Loop / Way of Life pattern with Kadō's score DNA. Completions logged
+  off-schedule show up too, instead of hiding as rest days.
 - **Flexible schedules** — daily, N days per week, specific weekdays,
-  every N days. Binary, counter, or timer habit types.
+  every N days (the cycle re-anchors on each completion, so finishing
+  early never costs you a day). Binary, counter, or timer habit types.
+- **Day starts at** — push the day rollover as late as 6 AM, so
+  late-night logging still lands on the day you mean. Changing it
+  never re-buckets history.
 - **Widgets** — Home Screen (small / medium / large) and Lock Screen
   (rectangular / circular / inline). Quick-complete via `AppIntent`.
+- **Siri and Shortcuts** — complete a habit, log a value, or ask for a
+  score and streak, hands-free. Also available as Home Screen actions
+  and Shortcuts automations.
 - **Reminders** — per-habit local notifications with recurring
   schedules and check / skip quick actions.
 - **iCloud sync** — optional, opt-in, goes only through the user's
-  private CloudKit database.
-- **JSON export / import** — lossless backup of your data; round-trip
-  tested. CSV (export, generic import, Loop import) is a post-v0.2
-  follow-up.
+  private CloudKit database. Settings shows live sync state, including
+  when sync isn't working.
+- **JSON and CSV export / import** — lossless backup of your data, in
+  both formats, round-trip tested. Open a CSV backup in Numbers or
+  Excel, edit it, bring it back in.
+- **Tip Jar** — entirely optional, unlocks nothing. The whole app
+  stays free, with no ads, no subscription, and no tracking.
 - **Accessibility** — Dynamic Type up to XXXL, VoiceOver labels on
   every surface, full Dark Mode.
 - **Localization** — English and native French (not machine-translated).
 
 ## Status
 
-- **v0.1 MVP** — shipped.
-- **v0.2 "Visible iOS-native"** — shipped (widgets, overview,
-  notifications, JSON import/export, CloudKit polish).
-- **App Store** — first public build submitted, currently in review.
-  TestFlight external beta is live.
-- **Next** — v0.3: App Intents / Siri, HealthKit auto-completion,
-  Live Activities + Dynamic Island, native Apple Watch app.
+**Shipping on the App Store — [current version 1.7](https://apps.apple.com/app/id6762570244).**
 
-Full roadmap in [`docs/ROADMAP.md`](./docs/ROADMAP.md).
+| Version | Highlights |
+|---|---|
+| 1.0 | First public release — score, Today / Overview / Detail, widgets, iCloud sync, reminders, JSON export, EN + FR |
+| 1.1 | Siri and Shortcuts; edit past days from the calendar |
+| 1.2 | Per-day notes; backdated completions; month navigation |
+| 1.3 | Drag to reorder habits; a gentle, one-time review prompt |
+| 1.4 | iCloud sync reliability — iPad crash fix, honest sync status |
+| 1.5 | Tip Jar (StoreKit 2), optional and unlocking nothing |
+| 1.6 | "Day starts at" hour; days-per-week scoring fix; off-schedule completions in Overview |
+| 1.7 | CSV export / import round-trip; "every N days" re-anchors on completion |
+
+**Not planned.** A native Apple Watch app and HealthKit
+auto-completion were scoped for v0.3 and have been **descoped** — no
+user has asked for either since launch. Both stay listed in
+[`docs/ROADMAP.md`](./docs/ROADMAP.md) under "Descoped", and would be
+reconsidered on real demand.
+
+**Next** — Live Activities and Dynamic Island for timer habits, then
+the remaining v1.x polish (themes, biometrics, categories, backup
+files). Full roadmap in [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 
 ## Tech stack
 
@@ -102,9 +132,10 @@ Full roadmap in [`docs/ROADMAP.md`](./docs/ROADMAP.md).
 - **WidgetKit** + an App Group JSON snapshot for extension surfaces
   (the widget process never opens SwiftData — see `CLAUDE.md` for
   why).
-- **App Intents** for widget quick-complete today; Siri / Shortcuts
-  arrive in v0.3.
-- **Swift Testing** for unit tests, XCTest for UI tests.
+- **App Intents** for widget quick-complete, Siri, and Shortcuts.
+- **StoreKit 2** for the Tip Jar.
+- **Swift Testing** for unit tests, XCTest for UI tests and for the
+  App Store screenshot run.
 - **Zero third-party dependencies.**
 
 Target: iOS 18.0+, Xcode 16.0+, Swift 5.10+.
@@ -123,16 +154,24 @@ Packages/KadoCore/          # Shared Swift package — @Model types,
 KadoWidgets/                # Widget extension target (reads an
                             #   App Group JSON snapshot)
 KadoTests/                  # Unit tests (Swift Testing)
+KadoUITests/                # UI tests (XCTest) + the App Store
+                            #   screenshot run
+Scripts/                    # Screenshot capture, framing, and the
+                            #   dependency-free App Store Connect client
+site/                       # getkado.app — static marketing site
 branding/                   # SVG marks and wordmarks
 docs/
 ├── PRODUCT.md              # Product vision, competitive analysis
 ├── ROADMAP.md              # Versioned feature roadmap
 ├── habit-score.md          # Score algorithm spec
 ├── streak.md               # Streak algorithm spec
+├── app-store/              # Listing copy, captures, framed images,
+│                           #   and how they are pushed
 ├── app-store-connect.md    # Store metadata, copy, checklists
 ├── plans/                  # Per-feature research / plan / compound
 │                           #   artifacts from the conductor workflow
-└── screenshots/            # iPhone 6.7" and iPad 13" sets (EN + FR)
+└── screenshots/            # iPhone 6.7" set (EN + FR), also the
+                            #   source for the marketing site
 PRIVACY.md                  # Privacy policy (repo-hosted)
 ```
 
@@ -160,13 +199,17 @@ the project's practical default on Xcode 26 toolchains).
 
 From Xcode: `⌘U` on the `Kado` scheme.
 
-From the command line via `xcodebuild`:
+From the command line, the `Makefile` wraps the common loops:
 
 ```bash
-xcodebuild -project Kado.xcodeproj -scheme Kado \
-  -destination "platform=iOS Simulator,name=iPhone 17 Pro" \
-  test
+make test    # unit suite (Swift Testing) — a couple of seconds
+make e2e     # UI suite (XCUITest), minus the screenshot run
+make build   # compile the app for the simulator
 ```
+
+`make help` lists the rest, including the App Store targets
+(`make screenshots`, `make frames`, `make listing`) documented in
+[`docs/app-store/README.md`](./docs/app-store/README.md).
 
 If you use Claude Code with the
 [XcodeBuildMCP](https://github.com/getsentry/XcodeBuildMCP) server,
@@ -194,8 +237,9 @@ Issues and pull requests are welcome. A few notes:
 - One PR per feature or logical fix. Commit message format follows
   a lightweight Conventional Commits convention —
   `feat(scope): description`, `fix(scope): …`, etc.
-- No third-party dependencies in v0.x. If RevenueCat becomes
-  necessary for a Pro tier later it will be the only exception.
+- No third-party dependencies. The Tip Jar is built directly on
+  StoreKit 2, and the App Store Connect client in `Scripts/` signs
+  its own JWT with `openssl`, precisely so that stays true.
 
 ## Privacy
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,30 +3,108 @@
 Plan of incremental versions. Each version must be usable end-to-end
 by its author — that's the main scope definition criterion.
 
-Estimates are for a solo workflow with Claude Code as pair programmer,
-based on convergent Reddit accounts (2-4 weeks for an iOS MVP, 3
-weeks for a production app by an experienced dev, etc.).
+The pre-launch sections (v0.1 → v1.0) are kept as a record of what was
+scoped and what actually shipped. Everything after v1.0 is tracked as
+the App Store release it went out in.
 
 ---
 
-## Current status (2026-04-20)
+## Current status (2026-09-05)
 
-- **v0.1 MVP**: shipped — all scope items and exit criteria complete.
-- **v0.2 "Visible iOS-native"**: largely shipped — widgets,
-  multi-habit overview, notifications, CloudKit polish, and the
-  JSON half of import/export done. CSV export, generic CSV import,
-  and Loop-CSV import moved into a post-v0.2 follow-up.
-- **French localization** (originally scheduled for v1.0) shipped
-  early in the v0.2 stream — main app + widget extension, native
-  translations.
-- **App Store**: first public build submitted, currently in App
-  Store review. TestFlight external beta also live.
-- **v0.3 App Intents track**: shipped — three Siri-exposed
-  intents (Complete / Log Value / Get Stats) plus
-  `AppShortcutsProvider` registration and full FR localization.
-  See `docs/plans/2026-04/app-intents-siri/`.
-- **Next**: v0.3 remaining tracks — HealthKit, Live Activities,
-  native Apple Watch.
+- **Shipping on the App Store: version 1.7** (build 14). Seven
+  updates since the public launch, all free, no subscription.
+- **v0.1 MVP**, **v0.2 "Visible iOS-native"**, and **v1.0 public
+  launch**: shipped.
+- **v0.3 "iOS depth"**: partially shipped, partially descoped. App
+  Intents / Siri shipped in 1.1. Live Activities remain planned.
+  **Apple Watch and HealthKit are descoped** — see
+  [Descoped](#descoped) below.
+- **French localization** (originally v1.0) shipped early, in the
+  v0.2 stream.
+- **Next**: Live Activities + Dynamic Island for timer habits, then
+  the remaining v1.x polish items (themes, biometrics, categories,
+  backup files).
+
+---
+
+## Post-launch releases (shipped)
+
+| Version | Theme | Shipped |
+|---|---|---|
+| **1.0** | First public release | Score, Today / Overview / Detail, widgets, iCloud sync, reminders, JSON export, EN + FR |
+| **1.1** | Siri and editable history | Siri + Shortcuts (3 intents); edit past days from the detail calendar; Today refreshes correctly after midnight |
+| **1.2** | Notes, backdate, navigation | Per-day completion notes; completions before a habit's creation date; month navigation in the calendar |
+| **1.3** | Order and asking nicely | Drag-to-reorder habits on Today (order syncs via iCloud); a one-time, dismissable review prompt |
+| **1.4** | Sync reliability | Fixed an iPad crash shortly after enabling iCloud sync; Settings now reports sync failures honestly instead of always "active" |
+| **1.5** | Support Kadō | Tip Jar (StoreKit 2, no third-party SDK). Optional, unlocks nothing |
+| **1.6** | Late nights and fairer scores | "Day starts at" rollover hour (up to 6 AM); days-per-week scoring fix; off-schedule completions now visible in Overview |
+| **1.7** | Portable backups | CSV export and import with a lossless round-trip; "every N days" re-anchors on each completion instead of a fixed grid |
+
+Per-release copy (EN + FR) lives in `docs/app-store-connect.md`; the
+copy that actually ships is in `docs/app-store/metadata/`.
+
+---
+
+## Descoped
+
+Scope that was planned and has been **removed** from the roadmap. Not
+"later" — removed, and would only come back on evidence of real
+demand.
+
+### Native Apple Watch app — descoped 2026-09-05
+
+Originally the headline of v0.3 and listed as non-sacrificable (the
+"big differentiator vs Teymia and Loop"). **No user has asked for it
+since launch.** It was a competitive-analysis assumption, not a
+demand signal, and it carries a large ongoing cost: a second target,
+a second UI to keep localized and accessible, complications, and a
+sync story to debug on a device that is awkward to debug on.
+
+Was scoped as: watchOS app, Today list, circular + rectangular
+complications, CloudKit sync, haptics.
+
+### HealthKit auto-completion — descoped 2026-09-05
+
+Same reasoning, plus a philosophical one: auto-completion sits
+uneasily with a tracker whose whole premise is that *you* decide what
+counts. It also adds a permission prompt, a privacy surface to
+explain, and a class of "why did my score change on its own?"
+support questions — for a feature nobody has requested.
+
+Was scoped as: read-only granular permission, auto-completion from
+steps / exercise minutes / mindfulness / sleep / workouts,
+configurable thresholds, a manual-vs-auto indicator, and score
+neutrality under auto-completion.
+
+Reconsider either if: users file issues asking for it, reviews
+mention its absence, or a concrete workflow appears that the manual
+flow genuinely can't serve.
+
+---
+
+## Next
+
+### Live Activities (planned)
+- [ ] Live Activity for habits with a running timer
+- [ ] Dynamic Island compact + expanded
+- [ ] Timer background persistence (respecting iOS limitations)
+
+### Remaining v1.x polish
+- [ ] Core themes: light, dark, sepia, high contrast
+- [ ] Optional biometrics (Face ID / Touch ID) to open the app
+- [ ] Categories / tags for organization
+- [ ] Manual backup as `.kado` file (zipped JSON), and restore
+- [ ] Import from Loop Habit Tracker (CSV) — the generic CSV import
+      shipped in 1.7 is most of the machinery
+- [ ] Import from Streaks (format to reverse-engineer, or document if
+      there is no official export)
+
+### Quality
+- [ ] Unit test suite with >80% coverage on business logic
+- [x] UI tests on the critical flows — `KadoUITests` target added,
+      `make e2e` runs it
+- [ ] Pseudo-locale IDE smoke test pass
+- [ ] Manual smoke test on iPhone SE, iPhone 15, iPad
 
 ---
 
@@ -34,8 +112,6 @@ weeks for a production app by an experienced dev, etc.).
 
 **Objective**: usable daily by the author, with Kadō's philosophical
 DNA (habit score, offline, privacy) in place from the start.
-
-**Estimate**: 4-6 weeks.
 
 ### Data and domain
 - [x] SwiftData `Habit` model: id, name, icon, color, frequency,
@@ -80,12 +156,10 @@ DNA (habit score, offline, privacy) in place from the start.
 
 ---
 
-## v0.2 — Visible iOS-native ✅ shipped (CSV deferred)
+## v0.2 — Visible iOS-native ✅ shipped
 
 **Objective**: the iOS-native surfaces users see first — widgets, an
 at-a-glance overview, notifications, frictionless data portability.
-
-**Estimate**: 2-3 weeks.
 
 ### Widgets
 - [x] Small home screen widget: today's grid (5-6 habits max)
@@ -102,6 +176,8 @@ at-a-glance overview, notifications, frictionless data portability.
 - [x] Horizontal scroll back through history; sticky habit-name column
 - [x] Tap a cell to open the per-habit Detail for that date
 - [x] Dark mode, Dynamic Type, VoiceOver labels for every cell
+- [x] Off-schedule completions rendered instead of hidden as rest
+      days — shipped in 1.6
 
 ### Notifications
 - [x] Reminders per habit, at fixed time
@@ -113,11 +189,11 @@ at-a-glance overview, notifications, frictionless data portability.
 ### Import / Export
 - [x] JSON export: documented, stable format (versioned schema)
 - [x] Import from a Kadō JSON export (round-trip tested)
-- [ ] CSV export: one file per habit, or a consolidated one —
-      **deferred to a post-v0.2 follow-up**
-- [ ] Generic CSV import (with column mapping) — **deferred**
-- [ ] Import from Loop Habit Tracker — **deferred to v1.0** (see
-      v1.0 "Final features")
+- [x] CSV export — shipped in 1.7
+- [x] CSV import, round-trip tested against the export — shipped in
+      1.7
+- [ ] Import from Loop Habit Tracker — still open, see
+      [Next](#next)
 
 ### CloudKit sync polish
 - [x] Live sync indicator (subscribe to
@@ -125,25 +201,30 @@ at-a-glance overview, notifications, frictionless data portability.
       surface "Syncing…", "Up to date", or "Error" in Settings)
 - [x] Real "Sync now" affordance — replaces v0.1's cosmetic
       pull-to-refresh now that we have a real fetch hook
+- [x] Surface sync *failures* rather than always reporting active —
+      shipped in 1.4
 
 ### Exit criteria for v0.2
 - [x] Widgets work on iOS 18 and update correctly after completion
 - [x] An export followed by an import restores 100% of the data
-      (automated test) — JSON path covered
+      (automated test) — JSON and CSV paths both covered
 - [x] Notifications respect system settings (Focus, Do Not Disturb)
 - [x] Overview shows ≥30 days of history for all habits legibly on
       iPhone 17 Pro and iPad Air M4
 
 ---
 
-## v0.3 — iOS depth and Apple Watch (next)
+## v0.3 — iOS depth ✅ partially shipped, partially descoped
 
-**Objective**: deep Apple ecosystem integration, with the Apple Watch
-app becoming a reason to install Kadō on its own.
+**Objective, as written**: deep Apple ecosystem integration, with the
+Apple Watch app becoming a reason to install Kadō on its own.
 
-**Estimate**: 3-4 weeks.
+**Outcome**: the App Intents track shipped in 1.1 and is used. The
+Apple Watch and HealthKit tracks were [descoped](#descoped) in
+September 2026 for lack of demand. Live Activities is the only part
+still planned.
 
-### App Intents and Siri ✅ shipped
+### App Intents and Siri ✅ shipped in 1.1
 - [x] `CompleteHabitIntent`: "Hey Siri, mark [habit] as done"
 - [x] `LogHabitValueIntent`: for counters/timers ("I drank 2 glasses
       of water")
@@ -152,109 +233,83 @@ app becoming a reason to install Kadō on its own.
       via `AppShortcutsProvider`; morning/evening predicates via
       `ShortcutTile` deferred)
 
-### HealthKit
-- [ ] Read-only HealthKit permission, granular
-- [ ] Auto-completion based on Apple Health types: steps, exercise
-      minutes, mindfulness, sleep, workouts
-- [ ] Configurable mapping: a "Meditate 10 min" habit can be linked to
-      mindfulMinutes with a threshold
-- [ ] Clear UI to indicate a habit is auto-completed vs manual
-- [ ] Score continues to work with auto-completion without distortion
+### HealthKit ❌ descoped
+See [Descoped](#descoped).
 
-### Live Activities
-- [ ] Live Activity for habits with a running timer
-- [ ] Dynamic Island compact + expanded
-- [ ] Timer background persistence (respecting iOS limitations)
+### Live Activities — planned
+See [Next](#next).
 
-### Apple Watch
-- [ ] Native watchOS app (SwiftUI + WatchKit)
-- [ ] Today view: tappable list of due habits
-- [ ] Circular complication (longest current streak)
-- [ ] Rectangular complication (number of completed / total habits)
-- [ ] Sync with iPhone via SwiftData + CloudKit (no custom
-      WatchConnectivity unless needed)
-- [ ] Haptic feedback on completion
-
-### Exit criteria for v0.3
-- [ ] I can complete a habit without taking my iPhone out of my pocket
-- [ ] A morning run auto-logs via HealthKit before I open the app
-- [ ] The watchOS complication is useful on the wrist, not just a
-      gimmick
+### Apple Watch ❌ descoped
+See [Descoped](#descoped).
 
 ---
 
-## v1.0 — Public launch
+## v1.0 — Public launch ✅ shipped
 
 **Objective**: first-impression quality. App Store, polished GitHub
 README, landing page, first wave of downloads.
 
-**Estimate**: 2-3 weeks after v0.3.
-
-**Status (2026-04-19)**: the first public build is **in App Store
-review**, ahead of the nominal v0.3 gate. The scope below still
-reflects the target for the 1.0 label — a few items (biometrics,
-themes, Streaks import) are not in the review build and will ship
-in a follow-up update before the final 1.0 marketing push.
+The first public build was submitted 2026-04-19 and approved. The
+items below that were not in the launch build shipped across 1.1–1.7,
+noted inline.
 
 ### Final features
 - [x] **"Day starts at" setting** — a configurable day-rollover hour
       (midnight…6 AM, default midnight) so late-night logging keeps
       the one-tap Today flow. One injected `DayBoundary` resolves the
       logical day for every surface; completions are normalised on
-      write, so changing the setting never re-buckets history. See
-      `docs/plans/2026-08/day-start-hour/`.
-- [ ] Import from Streaks (format to reverse-engineer or document if
-      no official export)
-- [ ] Core themes: light, dark, sepia, high contrast
-- [ ] Optional biometrics (Face ID / Touch ID) to open the app
-- [ ] Habit archive with history preservation
-- [ ] Categories/tags for organization
-- [ ] Manual backup as `.kado` file (zipped JSON)
-- [ ] Restore from a backup
+      write, so changing the setting never re-buckets history.
+      Shipped in 1.6, see `docs/plans/2026-08/day-start-hour/`.
+- [x] Habit archive with history preservation
+- [ ] Import from Streaks — still open
+- [ ] Core themes: light, dark, sepia, high contrast — still open
+- [ ] Optional biometrics (Face ID / Touch ID) — still open
+- [ ] Categories/tags for organization — still open
+- [ ] Manual backup as `.kado` file, and restore — still open
 
 ### Localization
 - [x] Complete native FR (not machine-translated) — **shipped in
       v0.2 stream**, see `docs/plans/2026-04/french-translations/`.
       Covers main app + widget extension (dual-catalog setup).
-- [ ] Pseudo-locale IDE smoke test pass before App Store submission
-- [ ] Accessibility: VoiceOver verified on every view, clear labels in
-      EN and FR
+- [ ] Accessibility: VoiceOver verified end-to-end on every view, in
+      EN and FR (labels are in place throughout; the systematic pass
+      is still open)
 - [x] App Store screenshots in 2 languages (6.7" iPhone + 13" iPad,
       EN + FR) — regenerated by `make screenshots`, captures in
       `docs/app-store/screenshots/` and the framed images to upload in
       `docs/app-store/marketing/`. See `docs/app-store/README.md`.
 - [x] Listing copy and screenshots pushed from the command line —
       `make listing`, no retyping into App Store Connect
+- [ ] Pseudo-locale IDE smoke test pass
 
 ### Quality
+- [x] UI tests on the critical flows — `KadoUITests`, `make e2e`
+- [x] Privacy Nutrition Label filled honestly (nothing collected)
 - [ ] Unit test suite with >80% coverage on business logic
-- [ ] UI tests on the 3-4 critical flows (create habit, complete, view
-      detail, export)
-- [ ] Manual smoke test on iPhone SE, iPhone 15, iPad, Apple Watch
-- [x] Privacy Nutrition Label filled honestly (nothing collected) —
-      submitted with first review build
+- [ ] Manual smoke test on iPhone SE, iPhone 15, iPad
 
 ### Monetization
-- [ ] Tip Jar (consumable or non-consumable IAP) without RevenueCat
-      for simplicity
-- [ ] No Pro tier at launch. Wait-and-see for 3 months, decide after.
+- [x] Tip Jar (StoreKit 2 IAP, no RevenueCat) — shipped in 1.5, with
+      an earned-it nudge at the bottom of Today
+- [x] No Pro tier at launch — still the position
 
 ### Communication
 - [x] GitHub README with screenshots, features, stack, philosophy
-- [ ] Simple landing page (single HTML) on GitHub Pages
+- [x] Landing page on GitHub Pages — `site/`, live at getkado.app,
+      EN + FR, screenshots regenerated from the same captures as the
+      listing
 - [ ] Launch post on r/iOSProgramming, r/ClaudeAI (category "Built
       with Claude"), r/opensource, Hacker News (Show HN)
 - [ ] Submission to AlternativeTo facing Streaks and Loop
 
 ### Exit criteria for v1.0
-- [ ] App Store review passed (first build submitted 2026-04-19 —
-      awaiting outcome)
+- [x] App Store review passed
 - [ ] 100+ downloads in the first week
 - [ ] Consistent user feedback on the habit score's value
 
 ---
 
-## Post-v1.0 — to be decided after user listening
+## Later — to be decided after user listening
 
 **To consider based on feedback**:
 - **Rollover-aware widget refresh** — `SnapshotTimelineProvider` asks
@@ -275,6 +330,8 @@ in a follow-up update before the final 1.0 marketing push.
 - macOS app (Mac Catalyst or native SwiftUI)
 
 **Do not do without proof of real need**:
+- Native Apple Watch app and HealthKit auto-completion (see
+  [Descoped](#descoped))
 - Multi-profiles on the same device
 - Real-time collaboration between unrelated users
 - Bidirectional calendar integration
@@ -284,19 +341,21 @@ in a follow-up update before the final 1.0 marketing push.
 
 ## Prioritization under time constraints
 
-If time runs short, here is the order of sacrifice (most to least
-sacrificable):
+Order of sacrifice for what remains (most to least sacrificable):
 
-1. ~~Import from Streaks (v1.0)~~ — sacrificable
-2. ~~Advanced themes (v1.0)~~ — sacrificable
-3. ~~Categories/tags (v1.0)~~ — can wait for post-launch
-4. ~~Biometrics (v1.0)~~ — nice-to-have, not blocking
+1. Import from Streaks — sacrificable
+2. Advanced themes — sacrificable
+3. Categories/tags — can wait
+4. Biometrics — nice-to-have, not blocking
+5. Live Activities — worth doing, but only timer habits benefit
 
-On the other hand, **non-sacrificable** at these stages:
-- Habit score correctly implemented and tested (v0.1)
-- JSON export / import round-trip (v0.2) — CSV was reclassified
-  as a post-v0.2 follow-up during the build
-- Native watchOS app (v0.3) — the big differentiator vs Teymia and
-  Loop
-- FR localization at v1.0 launch (a marketing and personal
-  differentiator)
+**Non-sacrificable**, at any stage:
+- The habit score, correctly implemented and tested
+- Lossless export / import round-trips (JSON and CSV)
+- FR parity with EN on every user-facing string
+- The privacy position: no telemetry, no third-party SDK, no account
+
+The one entry that used to sit in this list — "native watchOS app,
+the big differentiator" — is the cautionary tale. It was
+non-sacrificable on the strength of a competitor comparison, and
+nobody ever asked for it. Demand, not differentiation on paper.

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -102,15 +102,15 @@
           </article>
           <article>
             <h3>Natif Apple</h3>
-            <p>SwiftUI, SwiftData, CloudKit, WidgetKit, App Intents. Widgets d'écran d'accueil et d'écran verrouillé. Pensé pour ressembler à une app Apple, pas à un portage multiplateforme.</p>
+            <p>SwiftUI, SwiftData, CloudKit, WidgetKit, App Intents. Widgets d'écran d'accueil et d'écran verrouillé. Siri et Raccourcis : complète une habitude, saisis une valeur ou demande ta série, mains libres. Pensé pour ressembler à une app Apple, pas à un portage multiplateforme.</p>
           </article>
           <article>
             <h3>Horaires flexibles</h3>
-            <p>Quotidien, N jours par semaine, jours précis, ou tous les N jours. Habitudes binaires, compteurs, ou chronométrées — change de mode sans perdre ce que tu as déjà saisi.</p>
+            <p>Quotidien, N jours par semaine, jours précis, ou tous les N jours — et le cycle « tous les N jours » repart du jour où tu l'as vraiment faite, donc t'y prendre en avance ne te coûte jamais une journée. Habitudes binaires, compteurs, ou chronométrées.</p>
           </article>
           <article>
             <h3>Aperçu d'un coup d'œil</h3>
-            <p>Une matrice habitudes × jours avec des cellules teintées selon le score — le motif Loop / Way of Life avec l'ADN du score de Kadō. Défile dans l'historique, touche une cellule pour ouvrir la journée.</p>
+            <p>Une matrice habitudes × jours avec des cellules teintées selon le score — le motif Loop / Way of Life avec l'ADN du score de Kadō. Défile dans l'historique, touche une cellule pour ouvrir la journée. Les jours où tu as fait une habitude hors programme s'affichent aussi, au lieu d'être masqués comme des jours de repos.</p>
           </article>
           <article>
             <h3>Des rappels sans bruit</h3>
@@ -118,7 +118,15 @@
           </article>
           <article>
             <h3>Importe, exporte, quitte</h3>
-            <p>L'import/export JSON sans perte est déjà livré. L'export CSV et l'import depuis Loop, Streaks, ou CSV générique arriveront peu après la v0.2. Anti-enfermement dès le départ.</p>
+            <p>Export et import sans perte, en JSON comme en CSV, testés en aller-retour. Ouvre une sauvegarde CSV dans Numbers ou Excel, modifie-la, réimporte-la — notes comprises. Anti-enfermement dès le départ.</p>
+          </article>
+          <article>
+            <h3>Un historique qui se corrige</h3>
+            <p>Oublié de noter hier ? Touche n'importe quel jour du calendrier et corrige-le — même les jours antérieurs à la création de l'habitude. Ajoute une courte note à une complétion, et remonte les mois passés.</p>
+          </article>
+          <article>
+            <h3>Réglé sur ta journée</h3>
+            <p>Tu notes après minuit ? Décale le changement de journée jusqu'à 6 h du matin : un seul appui tombe toujours sur la bonne date. Et glisse tes habitudes dans l'ordre où tu les fais vraiment — l'ordre se synchronise entre tes appareils.</p>
           </article>
           <article>
             <h3>Accessible par défaut</h3>
@@ -127,6 +135,10 @@
           <article>
             <h3>Anglais et français natif</h3>
             <p>Traduit par une personne francophone, pas par une machine. <code>tu</code>, <code>série</code>, <code>habitude</code> — ça sonne juste, pas traduit.</p>
+          </article>
+          <article>
+            <h3>Gratuite, et ça ne changera pas</h3>
+            <p>Aucun abonnement, aucune publicité, aucune fonctionnalité payante, aucune relance. Une cagnotte de pourboires existe dans les réglages si tu veux soutenir le travail — elle ne débloque rien, puisque rien n'est verrouillé.</p>
           </article>
         </div>
       </div>
@@ -150,7 +162,7 @@
           <details class="faq-item">
             <summary>Combien coûte Kadō ?</summary>
             <div class="faq-answer">
-              <p>L'app est gratuite et open source sous licence MIT. Aucun abonnement, aucune publicité, aucune fonctionnalité essentielle payante. Un pourboire optionnel — et éventuellement une version "Pro" cosmétique plus tard, pour des thèmes supplémentaires — sont les seules pistes de monétisation envisagées.</p>
+              <p>L'app est gratuite et open source sous licence MIT. Aucun abonnement, aucune publicité, aucune fonctionnalité payante. Une cagnotte de pourboires facultative se trouve dans Réglages → Soutenir Kadō si tu souhaites financer le travail ; elle ne débloque rien, et l'app reste entièrement gratuite dans tous les cas.</p>
             </div>
           </details>
 
@@ -178,21 +190,21 @@
           <details class="faq-item">
             <summary>Y a-t-il une app Apple Watch ?</summary>
             <div class="faq-answer">
-              <p>Pas encore. Une app Apple Watch native est prévue pour la v0.3, avec les App Intents / raccourcis Siri, l'auto-complétion HealthKit, et les Live Activities avec l'îlot dynamique. Voir la <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">feuille de route</a>.</p>
+              <p>Non, et ce n'est pas prévu. Une app watchOS et l'auto-complétion HealthKit figuraient sur la feuille de route, et depuis le lancement personne ne les a demandées — elles ont donc été abandonnées plutôt que laissées en promesse indéfinie. Si ça change, <a href="https://github.com/scastiel/kado/issues">ouvre un ticket</a> : une vraie demande les ramènerait. Siri et Raccourcis couvrent déjà la saisie mains libres sur iPhone et iPad. Voir la <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">feuille de route</a>.</p>
             </div>
           </details>
 
           <details class="faq-item">
             <summary>Puis-je importer mes habitudes depuis une autre app ?</summary>
             <div class="faq-answer">
-              <p>L'import/export JSON est livré et testé en aller-retour. L'export CSV, l'import CSV générique, et l'import direct depuis Loop Habit Tracker et Streaks sont sur la feuille de route à court terme. Tu ne devrais jamais te sentir coincé dans une app.</p>
+              <p>L'import/export JSON et CSV sont livrés et testés en aller-retour — exporte, modifie dans un tableur si tu veux, réimporte sans rien perdre. L'import direct depuis Loop Habit Tracker et Streaks reste sur la feuille de route. Tu ne devrais jamais te sentir coincé dans une app.</p>
             </div>
           </details>
 
           <details class="faq-item">
             <summary>Quels appareils et versions d'iOS sont pris en charge ?</summary>
             <div class="faq-answer">
-              <p>iPhone et iPad sous iOS 18 ou plus récent. Le support watchOS, de l'îlot dynamique, et de macOS est prévu mais pas encore livré.</p>
+              <p>iPhone et iPad sous iOS 18 ou plus récent — une seule app universelle. Les Live Activities avec l'îlot dynamique sont prévues ; une app Mac reste un peut-être ; watchOS n'est pas prévu.</p>
             </div>
           </details>
 
@@ -206,7 +218,7 @@
           <details class="faq-item">
             <summary>Que veut dire "Kadō" ?</summary>
             <div class="faq-answer">
-              <p>Kadō (稼働) veut dire "en opération" ou "en fonctionnement" en japonais — l'état d'un système qui fait son travail discrètement, jour après jour. Un nom qui va bien à une habitude qui tient dans la durée. C'est un nom de travail ; le nom public définitif sera confirmé avant la v1.0.</p>
+              <p>Kadō (稼働) veut dire "en opération" ou "en fonctionnement" en japonais — l'état d'un système qui fait son travail discrètement, jour après jour. Un nom qui va bien à une habitude qui tient dans la durée.</p>
             </div>
           </details>
         </div>
@@ -216,9 +228,9 @@
     <section class="block">
       <div class="container">
         <div class="next">
-          <div class="section-kicker">La suite</div>
-          <h2>v0.3 : Siri, HealthKit, Watch</h2>
-          <p>App Intents et raccourcis Siri, auto-complétion HealthKit, Live Activities avec îlot dynamique, et une app Apple Watch native. <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">Voir la feuille de route →</a></p>
+          <div class="section-kicker">Dernière version</div>
+          <h2>La version 1.7 est disponible</h2>
+          <p>Export et import CSV, avec un aller-retour qui conserve tout — notes comprises. Et les habitudes « tous les N jours » comptent désormais à partir du jour où tu les as vraiment faites : t'y prendre en avance n'apparaît plus comme un oubli. Ensuite : les Live Activities pour les habitudes chronométrées, puis les thèmes et Face ID. <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">Voir la feuille de route →</a></p>
         </div>
       </div>
     </section>

--- a/site/index.html
+++ b/site/index.html
@@ -101,15 +101,15 @@
           </article>
           <article>
             <h3>Native to Apple</h3>
-            <p>SwiftUI, SwiftData, CloudKit, WidgetKit, App Intents. Home-screen and lock-screen widgets. Designed to feel like a first-party iOS app, not a cross-platform port.</p>
+            <p>SwiftUI, SwiftData, CloudKit, WidgetKit, App Intents. Home-screen and lock-screen widgets. Siri and Shortcuts: complete a habit, log a value, or ask for a streak, hands-free. Designed to feel like a first-party iOS app, not a cross-platform port.</p>
           </article>
           <article>
             <h3>Flexible schedules</h3>
-            <p>Daily, N days per week, specific weekdays, or every N days. Binary, counter, or timer habit types — switch without losing what you already entered.</p>
+            <p>Daily, N days per week, specific weekdays, or every N days — and the "every N days" cycle re-anchors each time you actually do it, so finishing early never costs you a day. Binary, counter, or timer habit types.</p>
           </article>
           <article>
             <h3>Overview at a glance</h3>
-            <p>A habits × days matrix with score-shaded cells — the Loop / Way of Life pattern with Kadō's score DNA. Scroll back through history, tap any cell to open its day.</p>
+            <p>A habits × days matrix with score-shaded cells — the Loop / Way of Life pattern with Kadō's score DNA. Scroll back through history, tap any cell to open its day. Days you did something off-schedule show up too, instead of hiding as rest days.</p>
           </article>
           <article>
             <h3>Reminders without noise</h3>
@@ -117,7 +117,15 @@
           </article>
           <article>
             <h3>Import, export, leave</h3>
-            <p>Lossless JSON round-trip is shipped. CSV export and import from Loop, Streaks, and generic CSV arrive shortly after v0.2. Anti-lock-in from day one.</p>
+            <p>Lossless export and import in both JSON and CSV, round-trip tested. Open a CSV backup in Numbers or Excel, edit it, bring it back in — notes and all. Anti-lock-in from day one.</p>
+          </article>
+          <article>
+            <h3>History you can fix</h3>
+            <p>Forgot to log yesterday? Tap any day in the calendar and set it right — including days before the habit existed. Add a short note to any completion, and page back through the months.</p>
+          </article>
+          <article>
+            <h3>Shaped around your day</h3>
+            <p>Log after midnight? Push the day rollover as late as 6 AM and one tap still lands on the day you mean. Drag your habits into the order you actually do them — it syncs across your devices.</p>
           </article>
           <article>
             <h3>Accessible by default</h3>
@@ -126,6 +134,10 @@
           <article>
             <h3>English and native French</h3>
             <p>Translated by a French speaker, not a machine. <code>tu</code>, <code>série</code>, <code>habitude</code> — it reads right, not translated.</p>
+          </article>
+          <article>
+            <h3>Free, and staying that way</h3>
+            <p>No subscription, no ads, no paywalled features, no upsell. There is a Tip Jar in Settings if you want to support the work — it unlocks nothing, because there is nothing locked.</p>
           </article>
         </div>
       </div>
@@ -149,7 +161,7 @@
           <details class="faq-item">
             <summary>How much does Kadō cost?</summary>
             <div class="faq-answer">
-              <p>The app is free and open source under the MIT license. No subscription, no ads, no paywalled core features. A one-time tip jar — and possibly an optional cosmetic "Pro" tier later, for things like extra themes — are the only monetization paths ever considered.</p>
+              <p>The app is free and open source under the MIT license. No subscription, no ads, no paywalled features. There's an optional Tip Jar in Settings → Support Kadō if you'd like to fund the work; it unlocks nothing, and the whole app stays free either way.</p>
             </div>
           </details>
 
@@ -177,21 +189,21 @@
           <details class="faq-item">
             <summary>Is there an Apple Watch app?</summary>
             <div class="faq-answer">
-              <p>Not yet. A native Apple Watch app is planned for v0.3, alongside App Intents / Siri support, HealthKit auto-completion, and Live Activities with Dynamic Island. See the <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">roadmap</a>.</p>
+              <p>No, and it isn't planned. A watchOS app and HealthKit auto-completion were both on the roadmap, and in the months since launch nobody has asked for either — so they've been dropped rather than left dangling as vapourware. If that changes, <a href="https://github.com/scastiel/kado/issues">open an issue</a>; real demand would bring them back. Siri and Shortcuts already cover hands-free logging on iPhone and iPad. See the <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">roadmap</a>.</p>
             </div>
           </details>
 
           <details class="faq-item">
             <summary>Can I import my habits from another tracker?</summary>
             <div class="faq-answer">
-              <p>JSON import/export is shipped and round-trip tested. CSV export, generic CSV import, and direct import from Loop Habit Tracker and Streaks are on the short-term roadmap. You should never feel stuck in an app.</p>
+              <p>JSON and CSV import/export are both shipped and round-trip tested — export, edit in a spreadsheet if you like, import back with nothing lost. Direct import from Loop Habit Tracker and Streaks is still on the roadmap. You should never feel stuck in an app.</p>
             </div>
           </details>
 
           <details class="faq-item">
             <summary>What devices and iOS versions are supported?</summary>
             <div class="faq-answer">
-              <p>iPhone and iPad on iOS 18 or later. watchOS, Dynamic Island, and macOS support are planned but not shipped yet.</p>
+              <p>iPhone and iPad on iOS 18 or later — one universal app. Live Activities with Dynamic Island are planned; a Mac app is a maybe; watchOS isn't planned.</p>
             </div>
           </details>
 
@@ -205,7 +217,7 @@
           <details class="faq-item">
             <summary>What does "Kadō" mean?</summary>
             <div class="faq-answer">
-              <p>Kadō (稼働) is Japanese for "in operation" or "running" — the state of a system that's quietly doing its job, day after day. A fitting name for a habit that keeps going. It's a working name; the final public name will be confirmed before v1.0.</p>
+              <p>Kadō (稼働) is Japanese for "in operation" or "running" — the state of a system that's quietly doing its job, day after day. A fitting name for a habit that keeps going.</p>
             </div>
           </details>
         </div>
@@ -215,9 +227,9 @@
     <section class="block">
       <div class="container">
         <div class="next">
-          <div class="section-kicker">What's next</div>
-          <h2>v0.3: Siri, HealthKit, Watch</h2>
-          <p>App Intents and Siri shortcuts, HealthKit auto-completion, Live Activities with Dynamic Island, and a native Apple Watch app. <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">See the roadmap →</a></p>
+          <div class="section-kicker">Latest release</div>
+          <h2>Version 1.7 is out</h2>
+          <p>CSV export and import, with a round-trip that keeps everything — notes included. And habits on an "every N days" schedule now count from the last day you actually did them, so finishing early no longer shows up as a miss. Next up: Live Activities for timer habits, then themes and Face ID. <a href="https://github.com/scastiel/kado/blob/main/docs/ROADMAP.md">See the roadmap →</a></p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Why?

- The three public-facing docs had drifted to a **v0.2-era picture** while the app is on **1.7** in the App Store.
- README said the first public build was "currently in review" and pointed at a v0.3 that includes HealthKit and Apple Watch.
- `docs/ROADMAP.md`'s status block was dated **2026-04-20**.
- getkado.app (EN + FR) still advertised **"v0.3: Siri, HealthKit, Watch"** as what's next, described CSV as "arriving shortly after v0.2", and told visitors Kadō was a "working name" pending v1.0.
- Seven releases' worth of shipped features were described nowhere.

## What?

**README**
- A 1.0 → 1.7 release table, built from the What's New entries in `docs/app-store-connect.md`.
- Feature list brought current: Siri/Shortcuts, per-day notes, backdating, month navigation, drag-to-reorder, "Day starts at", CSV + JSON round-trip, Tip Jar, honest sync status, off-schedule completions in Overview.
- App Store version badge; `KadoUITests/`, `Scripts/`, `site/`, `docs/app-store/` added to the repo layout.
- `make test` / `make e2e` / `make build` documented in place of the raw `xcodebuild` line.

**ROADMAP**
- Restructured around what actually shipped: a post-launch release table, v0.2's CSV items closed out, v1.0 marked shipped with the not-yet-done items called out inline.
- New **Descoped** section for Apple Watch and HealthKit, with the reasoning and what would bring them back.
- Prioritization list rebuilt around what's left.

**Site (EN + FR)**
- Three new feature cards: editable history (notes / backdate / month navigation), "shaped around your day" ("Day starts at" + reorder), and free-with-an-optional-tip.
- CSV described as shipped; the Apple Watch, import, devices, cost and name FAQs rewritten.
- "What's next" block replaced with a 1.7 release note.

**Descope.** Apple Watch and HealthKit auto-completion are *removed*, not deferred. Both were scoped for v0.3 on the strength of a competitor comparison, and nobody has asked for either since launch. The site now says so plainly rather than leaving them as open promises.

## How?

- Feature history reconstructed from the version-bump commits and the per-version What's New copy in `docs/app-store-connect.md` — the authoritative record of what each release contained.
- Site edits applied as **exact-match replacements that must each apply exactly once**, so untouched markup stays byte-identical and a stale expectation fails loudly instead of silently no-op'ing. 22 edits, all applied.
- Verified: both pages parse with balanced tags (12 feature cards, 10 FAQ items, 5 screenshots each), every `/assets/` reference resolves, and both locales were rendered in Chrome at 1280px and eyeballed.
- **Screenshots were not regenerated.** `site/assets/` is gitignored and rebuilt by the Pages workflow (`make -C site build`) from `docs/screenshots/iphone-67-appstore/`, which already holds the current captures — so the live site picks them up on the next deploy with no commit. Checksums confirm the two trees match; dimensions are unchanged at 1284×2778, so there's no layout shift.
- Dropped a claim I could not support: the Watch FAQ initially said Shortcuts "work from the Watch". `CompleteHabitIntent` and `LogHabitValueIntent` both set `openAppWhenRun = true`, so they need the iOS app — the FAQ now says iPhone and iPad.

## Next steps

- **`docs/PRODUCT.md` still contradicts this.** It names "Apple Watch/HealthKit integration" in the positioning statement (line 10), marks Kadō ✅ for both in the competitive table (lines 75-76), and lists them as differentiators #2 and #3 (lines 90-94). Left untouched deliberately: replacing a product's stated differentiators is a product call, not a docs cleanup. Worth a follow-up.
- FR copy follows the project's locked conventions (`tu`, `série`, `habitude` feminine) but deserves a native-speaker read before merge, per `CLAUDE.md`.
- Roadmap keeps "100+ downloads in the first week" and ">80% coverage" as open v1.0 exit criteria — update if the real numbers are known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP1jXFivpu8FZ3WGCDHBgf
