### PR TITLE
feat(settings): start the week where the region starts it, not always Monday

### DIFF
--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -50,7 +50,15 @@ struct KadoApp: App {
         #endif
         DevModeDefaults.migrateFromStandardIfNeeded()
         KadoFont.register()
-        let scheduler = DefaultNotificationScheduler(center: LiveUserNotificationCenter())
+        // The scheduler's reminder copy quotes a streak, and a
+        // days-per-week streak is counted in calendar weeks — so it
+        // needs the user's week, not the region's. Read from
+        // `UserDefaults` rather than `@AppStorage`: `init` runs before
+        // any property wrapper is readable.
+        let scheduler = DefaultNotificationScheduler(
+            center: LiveUserNotificationCenter(),
+            calendar: WeekStartDefaults.calendar()
+        )
         _notificationScheduler = State(initialValue: scheduler)
         _notificationManager = State(initialValue: NotificationManager(scheduler: scheduler))
     }
@@ -101,6 +109,12 @@ struct KadoApp: App {
         .environment(\.notificationScheduler, notificationScheduler)
         .environment(\.tipJarStore, tipJarStore)
         .environment(\.calendar, weekCalendar)
+        // The one calculator that reads `firstWeekday`: a
+        // `.daysPerWeek` streak is counted in whole calendar weeks, so
+        // the week it counts has to be the week the calendar draws.
+        // The score and frequency evaluators answer `.daysPerWeek` over
+        // a rolling seven days and are unaffected.
+        .environment(\.streakCalculator, DefaultStreakCalculator(calendar: weekCalendar))
         .environment(\.today, boundary.startOfDay(for: clockMark))
         .environment(\.dayBoundary, boundary)
         .onChange(of: scenePhase) { _, newPhase in

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -7,6 +7,8 @@ struct KadoApp: App {
     @AppStorage(DevModeDefaults.key, store: DevModeDefaults.sharedDefaults) private var isDevMode = false
     @AppStorage(DayStartDefaults.key, store: DayStartDefaults.sharedDefaults)
     private var dayStartHour = DayStartDefaults.defaultHour
+    @AppStorage(WeekStartDefaults.key, store: WeekStartDefaults.sharedDefaults)
+    private var weekStart: WeekStart = WeekStartDefaults.defaultValue
     @Environment(\.scenePhase) private var scenePhase
 
     @State private var devModeController = DevModeController()
@@ -21,10 +23,23 @@ struct KadoApp: App {
     /// immediately without needing its own invalidation path.
     @State private var clockMark: Date = .now
 
+    /// `Calendar.current` with the user's "Week starts on" choice
+    /// applied, injected as `\.calendar` at the root.
+    ///
+    /// The preference travels as a calendar rather than as a setting
+    /// of its own because `Calendar` already models it: a view asking
+    /// `calendar.firstWeekday` gets the region's answer by default and
+    /// the user's the moment they override it, with nothing to wire up
+    /// per view. The day boundary is built on the same calendar so the
+    /// app has one, not two that agree by accident.
+    private var weekCalendar: Calendar {
+        weekStart.calendar()
+    }
+
     /// Rebuilt on every `body` evaluation, so it always reflects the
     /// live `dayStartHour`.
     private var dayBoundary: DayBoundary {
-        DayBoundary(calendar: .current, startHour: DayStartDefaults.clamp(dayStartHour))
+        DayBoundary(calendar: weekCalendar, startHour: DayStartDefaults.clamp(dayStartHour))
     }
 
     init() {
@@ -85,6 +100,7 @@ struct KadoApp: App {
         .environment(\.cloudAccountStatus, cloudAccountStatus)
         .environment(\.notificationScheduler, notificationScheduler)
         .environment(\.tipJarStore, tipJarStore)
+        .environment(\.calendar, weekCalendar)
         .environment(\.today, boundary.startOfDay(for: clockMark))
         .environment(\.dayBoundary, boundary)
         .onChange(of: scenePhase) { _, newPhase in

--- a/Kado/Extensions/Calendar+WeekStart.swift
+++ b/Kado/Extensions/Calendar+WeekStart.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Calendar {
+    /// `Calendar.current` re-anchored on Sunday, for previews of the
+    /// views whose layout follows `firstWeekday`.
+    ///
+    /// Previews render under the previewing Mac's own calendar, so on a
+    /// Monday-first machine every one of them shows the order the app
+    /// used to hard-code — the new state would be visible only by
+    /// changing the machine's region. This is the one line that makes
+    /// it previewable instead.
+    static var sundayFirst: Calendar {
+        var calendar = Calendar.current
+        calendar.firstWeekday = 1
+        return calendar
+    }
+}

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -4179,19 +4179,19 @@
         }
       }
     },
-    "Sets the day the calendar on a habit's screen opens on, and the order of the day pickers. Automatic follows your region." : {
+    "Sets where a week begins: the calendar on a habit's screen, the order of the day pickers, and which days count together for a habit measured in days per week. Automatic follows your region." : {
       "comment" : "Footer under the week-start picker, saying what it changes.",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sets the day the calendar on a habit's screen opens on, and the order of the day pickers. Automatic follows your region."
+            "value" : "Sets where a week begins: the calendar on a habit's screen, the order of the day pickers, and which days count together for a habit measured in days per week. Automatic follows your region."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "D\u00e9termine le jour par lequel s'ouvre le calendrier d'une habitude, ainsi que l'ordre des s\u00e9lecteurs de jours. Automatique suit ta r\u00e9gion."
+            "value" : "Détermine où commence une semaine : le calendrier d'une habitude, l'ordre des sélecteurs de jours, et les jours qui comptent ensemble pour une habitude mesurée en jours par semaine. Automatique suit ta région."
           }
         }
       }

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -4161,6 +4161,74 @@
           }
         }
       }
+    },
+    "Automatic (%@)" : {
+      "comment" : "Week-start picker option that follows the region. %@ is the resolved day.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic (%@)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatique (%@)"
+          }
+        }
+      }
+    },
+    "Sets the day the calendar on a habit's screen opens on, and the order of the day pickers. Automatic follows your region." : {
+      "comment" : "Footer under the week-start picker, saying what it changes.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sets the day the calendar on a habit's screen opens on, and the order of the day pickers. Automatic follows your region."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "D\u00e9termine le jour par lequel s'ouvre le calendrier d'une habitude, ainsi que l'ordre des s\u00e9lecteurs de jours. Automatique suit ta r\u00e9gion."
+          }
+        }
+      }
+    },
+    "Week" : {
+      "comment" : "Settings section header above the week-start picker.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Week"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Semaine"
+          }
+        }
+      }
+    },
+    "Week starts on" : {
+      "comment" : "Settings picker label: the day a week starts on.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Week starts on"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La semaine commence le"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/Kado/Support/UITestSupport.swift
+++ b/Kado/Support/UITestSupport.swift
@@ -99,6 +99,13 @@ nonisolated enum UITestSupport {
             flag(Argument.devModeConfirmed, in: arguments),
             forKey: DevModeDefaults.hasConfirmedKey
         )
+        // Cleared for the same reason, and to nothing rather than to a
+        // value: absent means "follow the region", which is what pins a
+        // screenshot run's calendar to the language it was launched in.
+        // `Scripts/screenshots.sh` reuses its simulator between runs,
+        // so a week start set by hand once would otherwise reorder
+        // every capture taken after it.
+        WeekStartDefaults.sharedDefaults.removeObject(forKey: WeekStartDefaults.key)
         applyTipNudgeState(arguments)
     }
 

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -5,6 +5,9 @@ import KadoCore
 /// Renders as a 7-column `LazyVGrid` with weekday headers and
 /// leading blanks that align the first day of the month to its
 /// weekday column.
+///
+/// Which day opens the week comes from the injected calendar's
+/// `firstWeekday`, which `KadoApp` derives from Settings → Week.
 struct MonthlyCalendarView<PopoverContent: View>: View {
     let habit: Habit
     let completions: [Completion]
@@ -145,15 +148,17 @@ struct MonthlyCalendarView<PopoverContent: View>: View {
         }
     }
 
+    /// Blank cells before the 1st, so it lands under its own weekday
+    /// header. Follows `calendar.firstWeekday` — the region's day by
+    /// default, the user's once they set "Week starts on" — rather
+    /// than the Monday this used to hard-code.
     private var leadingBlanks: Int {
-        let firstWeekday = calendar.component(.weekday, from: monthStart)
-        // Shift so Monday (2) becomes column 0, Tuesday column 1, ..., Sunday column 6.
-        let monStart = (firstWeekday + 5) % 7
-        return monStart
+        let weekday = calendar.component(.weekday, from: monthStart)
+        return Weekday(rawValue: weekday)?.column(inWeekStartingOn: calendar.firstWeekday) ?? 0
     }
 
     private var weekdayDisplayOrder: [Weekday] {
-        [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
+        Weekday.week(startingOn: calendar.firstWeekday)
     }
 
     @ViewBuilder

--- a/Kado/UIComponents/MonthlyCalendarView.swift
+++ b/Kado/UIComponents/MonthlyCalendarView.swift
@@ -358,6 +358,27 @@ extension MonthlyCalendarView where PopoverContent == EmptyView {
         .padding()
 }
 
+/// Sunday-first, which is what most of the world outside Europe sees
+/// and what no other preview here shows: the previewing Mac's own
+/// calendar decides every one of them.
+#Preview("Week starts on Sunday") {
+    let habit = Habit(
+        name: "Meditate",
+        frequency: .daily,
+        type: .binary,
+        createdAt: Calendar.current.date(byAdding: .day, value: -20, to: .now)!
+    )
+    let completions = [1, 2, 3, 5, 7, 8, 10, 12, 13, 14, 18].map { offset in
+        Completion(
+            habitID: habit.id,
+            date: Calendar.current.date(byAdding: .day, value: -offset, to: .now)!
+        )
+    }
+    return MonthlyCalendarView(habit: habit, completions: completions)
+        .padding()
+        .environment(\.calendar, .sundayFirst)
+}
+
 #Preview("Empty history") {
     let habit = Habit(
         name: "Read",

--- a/Kado/UIComponents/WeekdayPicker.swift
+++ b/Kado/UIComponents/WeekdayPicker.swift
@@ -1,18 +1,23 @@
 import SwiftUI
 import KadoCore
 
-/// Horizontal row of 7 toggleable capsules, Monday through Sunday.
+/// Horizontal row of 7 toggleable capsules, one week's worth.
 /// Each capsule toggles membership in the bound set.
+///
+/// Laid out from the injected calendar's `firstWeekday` (Settings →
+/// Week), so the row reads in the same direction as the calendar grid
+/// on a habit's screen.
 struct WeekdayPicker: View {
     @Binding var selection: Set<Weekday>
+    @Environment(\.calendar) private var calendar
 
-    private static let displayOrder: [Weekday] = [
-        .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday
-    ]
+    private var displayOrder: [Weekday] {
+        Weekday.week(startingOn: calendar.firstWeekday)
+    }
 
     var body: some View {
         HStack(spacing: 6) {
-            ForEach(Self.displayOrder, id: \.self) { day in
+            ForEach(displayOrder, id: \.self) { day in
                 capsule(for: day)
             }
         }

--- a/Kado/UIComponents/WeekdayPicker.swift
+++ b/Kado/UIComponents/WeekdayPicker.swift
@@ -60,6 +60,14 @@ struct WeekdayPicker: View {
     StatefulPreview(initial: [])
 }
 
+/// The state the previewing Mac never shows on its own: every preview
+/// above renders under `Calendar.current`, so on a Monday-first machine
+/// they are indistinguishable from the order this row used to hard-code.
+#Preview("Week starts on Sunday") {
+    StatefulPreview(initial: [.monday, .wednesday, .friday])
+        .environment(\.calendar, .sundayFirst)
+}
+
 #Preview("Dark") {
     StatefulPreview(initial: [.monday, .wednesday, .friday])
         .preferredColorScheme(.dark)

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -401,7 +401,7 @@ struct HabitDetailView: View {
         case .daysPerWeek(let n):
             return String(localized: "\(n) days per week")
         case .specificDays(let days):
-            let ordered: [Weekday] = [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
+            let ordered = Weekday.week(startingOn: calendar.firstWeekday)
             let labels = ordered.filter(days.contains).map(\.localizedMedium)
             return labels.joined(separator: " · ")
         case .everyNDays(let n):

--- a/Kado/Views/NewHabit/NewHabitFormView.swift
+++ b/Kado/Views/NewHabit/NewHabitFormView.swift
@@ -12,6 +12,7 @@ struct NewHabitFormView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.notificationScheduler) private var notificationScheduler
     @Environment(\.dayBoundary) private var dayBoundary
+    @Environment(\.calendar) private var calendar
 
     @FocusState private var nameFocused: Bool
     @State private var saveTick: Int = 0
@@ -169,7 +170,7 @@ struct NewHabitFormView: View {
         case .daysPerWeek(let n):
             return String(localized: "\(n) days each week")
         case .specificDays(let days):
-            let ordered: [Weekday] = [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
+            let ordered = Weekday.week(startingOn: calendar.firstWeekday)
             return ordered.filter(days.contains).map(\.localizedMedium).joined(separator: " · ")
         case .everyNDays(let n):
             return String(localized: "every \(n) days")

--- a/Kado/Views/Settings/SettingsView.swift
+++ b/Kado/Views/Settings/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
             Form {
                 SyncStatusSection()
                 DayStartSection()
+                WeekStartSection()
                 NotificationsSection()
                 BackupSection()
                 SupportSection()

--- a/Kado/Views/Settings/WeekStartLabel.swift
+++ b/Kado/Views/Settings/WeekStartLabel.swift
@@ -1,0 +1,21 @@
+import Foundation
+import KadoCore
+
+/// Renders a "Week starts on" option the way the Settings picker
+/// offers it.
+///
+/// `localeCalendar` must be a calendar whose `firstWeekday` still
+/// comes from the region — `Calendar.current`, not the one in
+/// `\.calendar`. The environment's copy already carries the user's
+/// choice, so feeding it here would make the Automatic row describe
+/// itself: pick Monday in a Sunday region and it would read
+/// "Automatic (Monday)".
+enum WeekStartLabel {
+    static func text(for weekStart: WeekStart, localeCalendar: Calendar = .current) -> String {
+        guard let weekday = weekStart.weekday else {
+            let region = Weekday(rawValue: localeCalendar.firstWeekday)?.localizedFull ?? ""
+            return String(localized: "Automatic (\(region))")
+        }
+        return weekday.localizedFull
+    }
+}

--- a/Kado/Views/Settings/WeekStartLabel.swift
+++ b/Kado/Views/Settings/WeekStartLabel.swift
@@ -13,8 +13,11 @@ import KadoCore
 enum WeekStartLabel {
     static func text(for weekStart: WeekStart, localeCalendar: Calendar = .current) -> String {
         guard let weekday = weekStart.weekday else {
-            let region = Weekday(rawValue: localeCalendar.firstWeekday)?.localizedFull ?? ""
-            return String(localized: "Automatic (\(region))")
+            // Through `Weekday.week(startingOn:)` rather than
+            // `Weekday(rawValue:)`, so a `firstWeekday` outside 1...7
+            // folds into a real day instead of rendering "Automatic ()".
+            let region = Weekday.week(startingOn: localeCalendar.firstWeekday)[0]
+            return String(localized: "Automatic (\(region.localizedFull))")
         }
         return weekday.localizedFull
     }

--- a/Kado/Views/Settings/WeekStartSection.swift
+++ b/Kado/Views/Settings/WeekStartSection.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+import KadoCore
+
+/// Settings control for the day a week starts on.
+///
+/// The calendar on a habit's screen used to open every week on
+/// Monday, which is right for most of Europe and wrong for the
+/// Americas, Japan, and much of Asia. The default here is
+/// ``WeekStart/automatic`` — the region's own answer, by way of
+/// `Calendar.firstWeekday` — so the fix needs no visit to Settings;
+/// the picker is for people whose habit of reading a week disagrees
+/// with their region's.
+///
+/// Purely a display preference: no completion, score, or streak is
+/// computed per week, so changing it moves columns and nothing else.
+struct WeekStartSection: View {
+    @AppStorage(WeekStartDefaults.key, store: WeekStartDefaults.sharedDefaults)
+    private var weekStart: WeekStart = WeekStartDefaults.defaultValue
+
+    var body: some View {
+        WeekStartPicker(weekStart: $weekStart)
+    }
+}
+
+/// The section itself, over a plain binding so previews can drive it
+/// without touching the shared `UserDefaults` suite.
+private struct WeekStartPicker: View {
+    @Binding var weekStart: WeekStart
+
+    /// Deliberately not `@Environment(\.calendar)`: see
+    /// ``WeekStartLabel``.
+    var localeCalendar: Calendar = .current
+
+    var body: some View {
+        Section {
+            Picker("Week starts on", selection: $weekStart) {
+                ForEach(WeekStart.allCases, id: \.self) { option in
+                    Text(WeekStartLabel.text(for: option, localeCalendar: localeCalendar))
+                        .tag(option)
+                }
+            }
+        } header: {
+            Text("Week")
+        } footer: {
+            Text("Sets the day the calendar on a habit's screen opens on, and the order of the day pickers. Automatic follows your region.")
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .listRowBackground(Color.kadoBackgroundSecondary)
+    }
+}
+
+// MARK: - Previews
+
+private struct WeekStartSectionPreview: View {
+    @State private var weekStart: WeekStart
+    private let localeCalendar: Calendar
+
+    init(weekStart: WeekStart, regionFirstWeekday: Int = 2) {
+        _weekStart = State(initialValue: weekStart)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = regionFirstWeekday
+        self.localeCalendar = calendar
+    }
+
+    var body: some View {
+        Form {
+            WeekStartPicker(weekStart: $weekStart, localeCalendar: localeCalendar)
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.kadoBackground.ignoresSafeArea())
+    }
+}
+
+#Preview("Automatic (default)") {
+    WeekStartSectionPreview(weekStart: .automatic)
+}
+
+#Preview("Automatic in a Sunday region") {
+    WeekStartSectionPreview(weekStart: .automatic, regionFirstWeekday: 1)
+}
+
+#Preview("Pinned to Monday") {
+    WeekStartSectionPreview(weekStart: .monday)
+}
+
+#Preview("Dark") {
+    WeekStartSectionPreview(weekStart: .saturday)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Dynamic Type XXXL") {
+    WeekStartSectionPreview(weekStart: .monday)
+        .environment(\.dynamicTypeSize, .accessibility3)
+}

--- a/Kado/Views/Settings/WeekStartSection.swift
+++ b/Kado/Views/Settings/WeekStartSection.swift
@@ -11,8 +11,14 @@ import KadoCore
 /// the picker is for people whose habit of reading a week disagrees
 /// with their region's.
 ///
-/// Purely a display preference: no completion, score, or streak is
-/// computed per week, so changing it moves columns and nothing else.
+/// Not purely cosmetic, though it looks it: a `.daysPerWeek` streak is
+/// counted in whole calendar weeks, so this decides which days fall in
+/// the same week as each other. `KadoApp` hands the resolved calendar
+/// to `DefaultStreakCalculator` for exactly that reason — a streak
+/// counting Sunday-to-Saturday under a Monday-first grid would break
+/// where the grid says it shouldn't. Everything else about a habit —
+/// the score, whether it's due — answers `.daysPerWeek` over a rolling
+/// seven days and doesn't care where a week begins.
 struct WeekStartSection: View {
     @AppStorage(WeekStartDefaults.key, store: WeekStartDefaults.sharedDefaults)
     private var weekStart: WeekStart = WeekStartDefaults.defaultValue
@@ -39,10 +45,11 @@ private struct WeekStartPicker: View {
                         .tag(option)
                 }
             }
+            .accessibilityIdentifier(AccessibilityID.Settings.weekStartPicker)
         } header: {
             Text("Week")
         } footer: {
-            Text("Sets the day the calendar on a habit's screen opens on, and the order of the day pickers. Automatic follows your region.")
+            Text("Sets where a week begins: the calendar on a habit's screen, the order of the day pickers, and which days count together for a habit measured in days per week. Automatic follows your region.")
                 .fixedSize(horizontal: false, vertical: true)
         }
         .listRowBackground(Color.kadoBackgroundSecondary)

--- a/KadoTests/Helpers/TestCalendar.swift
+++ b/KadoTests/Helpers/TestCalendar.swift
@@ -28,6 +28,17 @@ enum TestCalendar {
         utc.date(byAdding: .day, value: offset, to: referenceDate)!
     }
 
+    /// UTC and Gregorian like ``utc``, but opening the week on
+    /// `firstWeekday` (a `Calendar.firstWeekday` value, 1 = Sunday).
+    /// For anything whose answer depends on where a week begins —
+    /// the week-start preference, and `.daysPerWeek` streaks, which
+    /// are bucketed into whole calendar weeks.
+    static func utc(firstWeekday: Int) -> Calendar {
+        var cal = utc
+        cal.firstWeekday = firstWeekday
+        return cal
+    }
+
     /// Europe/Paris — the DST-crossing zone used whenever day
     /// arithmetic has to survive a spring-forward or fall-back.
     /// 2026 transitions: **2026-03-29** (02:00 → 03:00, the day is 23

--- a/KadoTests/StreakCalculatorTests.swift
+++ b/KadoTests/StreakCalculatorTests.swift
@@ -233,6 +233,31 @@ struct StreakCalculatorTests {
         #expect(calc.best(for: h, completions: completions, asOf: asOf) == 1)
     }
 
+    /// The week start is not only a layout choice: a `.daysPerWeek`
+    /// streak is counted in whole calendar weeks, so moving where the
+    /// week begins moves which completions fall inside the same one.
+    /// A Saturday and the Sunday after it are one week's work under a
+    /// Monday-first calendar and two separate half-weeks under a
+    /// Sunday-first one — which is why `KadoApp` hands the user's
+    /// chosen calendar to this calculator and not just to the views.
+    @Test(".daysPerWeek streaks follow the calendar's first weekday")
+    func daysPerWeekFollowsFirstWeekday() {
+        let h = habit(frequency: .daysPerWeek(2), createdAtOffset: -30)
+        let completions = [
+            completion(for: h, dayOffset: -2), // Sat Apr 11
+            completion(for: h, dayOffset: -1), // Sun Apr 12
+        ]
+
+        let sundayFirst = DefaultStreakCalculator(calendar: TestCalendar.utc(firstWeekday: 1))
+        let mondayFirst = DefaultStreakCalculator(calendar: TestCalendar.utc(firstWeekday: 2))
+
+        // Sunday-first: the two completions straddle Apr 11/12, so the
+        // week before the current one holds just one and breaks the run.
+        #expect(sundayFirst.current(for: h, completions: completions, asOf: asOf) == 1)
+        // Monday-first: both fall inside Apr 6-12, which qualifies.
+        #expect(mondayFirst.current(for: h, completions: completions, asOf: asOf) == 2)
+    }
+
     // MARK: - Negative habits
 
     @Test("Negative habit streak counts days without completion")

--- a/KadoTests/WeekOrderTests.swift
+++ b/KadoTests/WeekOrderTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Testing
+import KadoCore
+
+/// The week-layout arithmetic every surface that draws a week shares.
+/// Asserted as invariants over all seven possible first days rather
+/// than as examples: the Monday-only version of this code was correct
+/// for every case anyone thought to check, because there was only one.
+@Suite("Week order")
+struct WeekOrderTests {
+
+    @Test("A week is seven distinct days opening on the one asked for")
+    func weekIsSevenDistinctDays() {
+        for firstWeekday in 1...7 {
+            let week = Weekday.week(startingOn: firstWeekday)
+
+            #expect(week.count == 7)
+            #expect(Set(week).count == 7)
+            #expect(week.first?.rawValue == firstWeekday)
+        }
+    }
+
+    /// The shape the app shipped with, kept as a regression: a
+    /// Monday-first user must see exactly the order they had before
+    /// the preference existed.
+    @Test("Monday-first is the order the app used to hard-code")
+    func mondayFirstMatchesTheFormerHardCoding() {
+        #expect(
+            Weekday.week(startingOn: 2)
+                == [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
+        )
+    }
+
+    @Test("Sunday-first and Saturday-first roll around correctly")
+    func otherRegionsRollAround() {
+        #expect(
+            Weekday.week(startingOn: 1)
+                == [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
+        )
+        #expect(
+            Weekday.week(startingOn: 7)
+                == [.saturday, .sunday, .monday, .tuesday, .wednesday, .thursday, .friday]
+        )
+    }
+
+    /// The invariant the calendar grid depends on: a day's column is
+    /// the index of its own header.
+    @Test("A day's column is where its header sits")
+    func columnIndexesIntoTheHeaderRow() {
+        for firstWeekday in 1...7 {
+            let week = Weekday.week(startingOn: firstWeekday)
+            for day in Weekday.allCases {
+                let column = day.column(inWeekStartingOn: firstWeekday)
+
+                #expect((0..<7).contains(column))
+                #expect(week[column] == day)
+            }
+        }
+    }
+
+    /// `firstWeekday` arrives from `UserDefaults` by way of
+    /// `Calendar`, so nonsense must fold into a real day rather than
+    /// shifting the grid or trapping.
+    @Test("Out-of-range first weekdays fold into the 1...7 they mean")
+    func outOfRangeFoldsIn() {
+        #expect(Weekday.week(startingOn: 8) == Weekday.week(startingOn: 1))
+        #expect(Weekday.week(startingOn: 0) == Weekday.week(startingOn: 7))
+        #expect(Weekday.week(startingOn: -6) == Weekday.week(startingOn: 1))
+        #expect(Weekday.monday.column(inWeekStartingOn: 9) == Weekday.monday.column(inWeekStartingOn: 2))
+    }
+
+    /// What the month grid actually asks for: the blanks before the
+    /// 1st have to leave it under its own weekday header, in every
+    /// month and for every possible week start.
+    @Test("Leading blanks land the 1st under its own header")
+    func leadingBlanksAlignTheFirstOfTheMonth() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(identifier: "UTC"))
+
+        for firstWeekday in 1...7 {
+            for month in 1...12 {
+                let monthStart = try #require(
+                    calendar.date(from: DateComponents(year: 2026, month: month, day: 1))
+                )
+                let weekday = try #require(
+                    Weekday(rawValue: calendar.component(.weekday, from: monthStart))
+                )
+                let blanks = weekday.column(inWeekStartingOn: firstWeekday)
+
+                #expect(Weekday.week(startingOn: firstWeekday)[blanks] == weekday)
+            }
+        }
+    }
+}

--- a/KadoTests/WeekStartDefaultsTests.swift
+++ b/KadoTests/WeekStartDefaultsTests.swift
@@ -14,12 +14,6 @@ struct WeekStartDefaultsTests {
         UserDefaults().removePersistentDomain(forName: name)
     }
 
-    private func calendar(firstWeekday: Int) -> Calendar {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.firstWeekday = firstWeekday
-        return calendar
-    }
-
     @Test("An unset key reads as automatic")
     func defaultsToAutomatic() {
         let (suite, name) = makeSuite()
@@ -54,13 +48,13 @@ struct WeekStartDefaultsTests {
     @Test("Automatic takes the region's first weekday, whatever it is")
     func automaticFollowsTheRegion() {
         for firstWeekday in 1...7 {
-            #expect(WeekStart.automatic.firstWeekday(in: calendar(firstWeekday: firstWeekday)) == firstWeekday)
+            #expect(WeekStart.automatic.firstWeekday(in: TestCalendar.utc(firstWeekday: firstWeekday)) == firstWeekday)
         }
     }
 
     @Test("A pinned day overrides the region")
     func pinnedDayOverridesTheRegion() {
-        let sundayRegion = calendar(firstWeekday: 1)
+        let sundayRegion = TestCalendar.utc(firstWeekday: 1)
 
         #expect(WeekStart.monday.firstWeekday(in: sundayRegion) == 2)
         #expect(WeekStart.saturday.firstWeekday(in: sundayRegion) == 7)
@@ -87,7 +81,7 @@ struct WeekStartDefaultsTests {
     func storedOptionDrivesTheCalendar() {
         let (suite, name) = makeSuite()
         defer { tearDown(name) }
-        let sundayRegion = calendar(firstWeekday: 1)
+        let sundayRegion = TestCalendar.utc(firstWeekday: 1)
 
         #expect(WeekStartDefaults.calendar(base: sundayRegion, in: suite).firstWeekday == 1)
 

--- a/KadoTests/WeekStartDefaultsTests.swift
+++ b/KadoTests/WeekStartDefaultsTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+import KadoCore
+
+@Suite("WeekStartDefaults")
+struct WeekStartDefaultsTests {
+    private func makeSuite() -> (UserDefaults, String) {
+        let name = "week-start-tests-\(UUID().uuidString)"
+        let suite = UserDefaults(suiteName: name)!
+        return (suite, name)
+    }
+
+    private func tearDown(_ name: String) {
+        UserDefaults().removePersistentDomain(forName: name)
+    }
+
+    private func calendar(firstWeekday: Int) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = firstWeekday
+        return calendar
+    }
+
+    @Test("An unset key reads as automatic")
+    func defaultsToAutomatic() {
+        let (suite, name) = makeSuite()
+        defer { tearDown(name) }
+
+        #expect(WeekStartDefaults.weekStart(in: suite) == .automatic)
+    }
+
+    @Test("Every option round-trips")
+    func everyOptionRoundTrips() {
+        let (suite, name) = makeSuite()
+        defer { tearDown(name) }
+
+        for option in WeekStart.allCases {
+            WeekStartDefaults.setWeekStart(option, in: suite)
+            #expect(WeekStartDefaults.weekStart(in: suite) == option)
+        }
+    }
+
+    /// A future build could add cases; downgrading must not leave the
+    /// app resolving weeks against a raw value it can't render.
+    @Test("A raw value outside the cases falls back to automatic")
+    func unknownRawValueFallsBack() {
+        let (suite, name) = makeSuite()
+        defer { tearDown(name) }
+
+        suite.set(42, forKey: WeekStartDefaults.key)
+
+        #expect(WeekStartDefaults.weekStart(in: suite) == .automatic)
+    }
+
+    @Test("Automatic takes the region's first weekday, whatever it is")
+    func automaticFollowsTheRegion() {
+        for firstWeekday in 1...7 {
+            #expect(WeekStart.automatic.firstWeekday(in: calendar(firstWeekday: firstWeekday)) == firstWeekday)
+        }
+    }
+
+    @Test("A pinned day overrides the region")
+    func pinnedDayOverridesTheRegion() {
+        let sundayRegion = calendar(firstWeekday: 1)
+
+        #expect(WeekStart.monday.firstWeekday(in: sundayRegion) == 2)
+        #expect(WeekStart.saturday.firstWeekday(in: sundayRegion) == 7)
+    }
+
+    /// The whole preference travels as a calendar, so applying it must
+    /// change `firstWeekday` and nothing else.
+    @Test("Applying an option leaves the rest of the calendar alone")
+    func applyingLeavesTheCalendarOtherwiseIntact() {
+        var base = Calendar(identifier: .gregorian)
+        base.firstWeekday = 1
+        base.timeZone = TimeZone(identifier: "Asia/Tokyo")!
+        base.locale = Locale(identifier: "ja_JP")
+
+        let applied = WeekStart.monday.calendar(base: base)
+
+        #expect(applied.firstWeekday == 2)
+        #expect(applied.timeZone == base.timeZone)
+        #expect(applied.locale == base.locale)
+        #expect(applied.identifier == base.identifier)
+    }
+
+    @Test("The stored option is what the calendar helper applies")
+    func storedOptionDrivesTheCalendar() {
+        let (suite, name) = makeSuite()
+        defer { tearDown(name) }
+        let sundayRegion = calendar(firstWeekday: 1)
+
+        #expect(WeekStartDefaults.calendar(base: sundayRegion, in: suite).firstWeekday == 1)
+
+        WeekStartDefaults.setWeekStart(.thursday, in: suite)
+
+        #expect(WeekStartDefaults.calendar(base: sundayRegion, in: suite).firstWeekday == 5)
+    }
+}

--- a/KadoTests/WeekStartPresentationTests.swift
+++ b/KadoTests/WeekStartPresentationTests.swift
@@ -7,16 +7,10 @@ import KadoCore
 @Suite("Week-start presentation")
 @MainActor
 struct WeekStartPresentationTests {
-    private func calendar(firstWeekday: Int) -> Calendar {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.firstWeekday = firstWeekday
-        return calendar
-    }
-
     @Test("Every offerable option has a distinct, non-empty label")
     func labelsAreDistinct() {
         let labels = WeekStart.allCases.map {
-            WeekStartLabel.text(for: $0, localeCalendar: calendar(firstWeekday: 2))
+            WeekStartLabel.text(for: $0, localeCalendar: TestCalendar.utc(firstWeekday: 2))
         }
 
         #expect(labels.allSatisfy { !$0.isEmpty })
@@ -38,8 +32,8 @@ struct WeekStartPresentationTests {
     /// Monday.
     @Test("Automatic names the region's day")
     func automaticNamesTheRegionDay() {
-        let sunday = WeekStartLabel.text(for: .automatic, localeCalendar: calendar(firstWeekday: 1))
-        let monday = WeekStartLabel.text(for: .automatic, localeCalendar: calendar(firstWeekday: 2))
+        let sunday = WeekStartLabel.text(for: .automatic, localeCalendar: TestCalendar.utc(firstWeekday: 1))
+        let monday = WeekStartLabel.text(for: .automatic, localeCalendar: TestCalendar.utc(firstWeekday: 2))
 
         #expect(sunday.contains(Weekday.sunday.localizedFull))
         #expect(monday.contains(Weekday.monday.localizedFull))

--- a/KadoTests/WeekStartPresentationTests.swift
+++ b/KadoTests/WeekStartPresentationTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import Kado
+import KadoCore
+
+/// Presentation contracts for the "Week starts on" picker.
+@Suite("Week-start presentation")
+@MainActor
+struct WeekStartPresentationTests {
+    private func calendar(firstWeekday: Int) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = firstWeekday
+        return calendar
+    }
+
+    @Test("Every offerable option has a distinct, non-empty label")
+    func labelsAreDistinct() {
+        let labels = WeekStart.allCases.map {
+            WeekStartLabel.text(for: $0, localeCalendar: calendar(firstWeekday: 2))
+        }
+
+        #expect(labels.allSatisfy { !$0.isEmpty })
+        #expect(Set(labels).count == labels.count)
+    }
+
+    @Test("A pinned option is named by its day")
+    func pinnedOptionsAreNamedByTheirDay() {
+        for option in WeekStart.allCases {
+            guard let weekday = option.weekday else { continue }
+            #expect(WeekStartLabel.text(for: option) == weekday.localizedFull)
+        }
+    }
+
+    /// The Automatic row has to describe the *region*, not the current
+    /// choice — reading it off the environment calendar (which already
+    /// has the user's pick applied) would make it read
+    /// "Automatic (Monday)" for someone in a Sunday region who pinned
+    /// Monday.
+    @Test("Automatic names the region's day")
+    func automaticNamesTheRegionDay() {
+        let sunday = WeekStartLabel.text(for: .automatic, localeCalendar: calendar(firstWeekday: 1))
+        let monday = WeekStartLabel.text(for: .automatic, localeCalendar: calendar(firstWeekday: 2))
+
+        #expect(sunday.contains(Weekday.sunday.localizedFull))
+        #expect(monday.contains(Weekday.monday.localizedFull))
+        #expect(sunday != monday)
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Models/Weekday.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Models/Weekday.swift
@@ -38,3 +38,37 @@ public extension Weekday {
         return symbols[rawValue - 1]
     }
 }
+
+public extension Weekday {
+    /// The seven days in the order a week starting on `firstWeekday`
+    /// lays them out — `firstWeekday` being a `Calendar.firstWeekday`
+    /// value (1 = Sunday, 2 = Monday).
+    ///
+    /// Every surface that renders a week horizontally goes through
+    /// this rather than hard-coding `[.monday, ..., .sunday]`: the
+    /// calendar grid on a habit's screen, the day picker in the new
+    /// habit form, and the "Mon · Wed · Fri" frequency subtitles.
+    /// Keeping one implementation is what stops them disagreeing
+    /// after the user changes the preference.
+    static func week(startingOn firstWeekday: Int) -> [Weekday] {
+        let start = normalize(firstWeekday)
+        return (0..<7).compactMap { offset in
+            Weekday(rawValue: (start - 1 + offset) % 7 + 1)
+        }
+    }
+
+    /// Zero-based column this day occupies in a week starting on
+    /// `firstWeekday` — i.e. how many blank cells a month grid needs
+    /// before the day that opens the month.
+    func column(inWeekStartingOn firstWeekday: Int) -> Int {
+        (rawValue - Weekday.normalize(firstWeekday) + 7) % 7
+    }
+
+    /// Folds any integer into `1...7`. The value arrives from
+    /// `UserDefaults` by way of `Calendar.firstWeekday`, so a build
+    /// that wrote something nonsensical must not shift the grid or
+    /// trap — it lands on a real weekday instead.
+    private static func normalize(_ firstWeekday: Int) -> Int {
+        ((firstWeekday - 1) % 7 + 7) % 7 + 1
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/WeekStartDefaults.swift
+++ b/Packages/KadoCore/Sources/KadoCore/WeekStartDefaults.swift
@@ -46,11 +46,13 @@ public extension WeekStart {
 ///
 /// Mirrors ``DayStartDefaults``: stored in `UserDefaults` rather than
 /// on a `@Model` so the SwiftData — and therefore CloudKit Production
-/// — schema stays untouched, and in the App Group suite so an
-/// extension can read it without a second store. Being device-local
-/// is the right shape for a display preference: two devices
-/// disagreeing changes nothing about the data, only about which
-/// column Monday lands in.
+/// — schema stays untouched, and in the App Group suite so it sits
+/// beside the other preference keys rather than in a second store.
+/// Nothing outside the app process reads it today; the widget's
+/// snapshot is built in-app, where ``calendar(base:in:)`` resolves it.
+/// Being device-local is the right shape for a display preference: two
+/// devices disagreeing changes nothing about the data, only about
+/// which column Monday lands in.
 nonisolated public enum WeekStartDefaults {
     public static let key = "kado.weekStart"
 

--- a/Packages/KadoCore/Sources/KadoCore/WeekStartDefaults.swift
+++ b/Packages/KadoCore/Sources/KadoCore/WeekStartDefaults.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The day a week starts on, as offered by Settings → Week.
+///
+/// Raw values are `Calendar.firstWeekday` values (1 = Sunday, 2 =
+/// Monday), which makes ``firstWeekday(in:)`` a plain read for every
+/// case but ``automatic``. Zero is free because no weekday uses it,
+/// so it carries "follow the region" without a parallel flag.
+nonisolated public enum WeekStart: Int, CaseIterable, Hashable, Codable, Sendable {
+    /// Whatever the user's region says — the default, and what every
+    /// user gets until they deliberately change it.
+    case automatic = 0
+    case sunday = 1
+    case monday = 2
+    case tuesday = 3
+    case wednesday = 4
+    case thursday = 5
+    case friday = 6
+    case saturday = 7
+}
+
+public extension WeekStart {
+    /// The day this option pins to, or `nil` for ``automatic``.
+    var weekday: Weekday? {
+        Weekday(rawValue: rawValue)
+    }
+
+    /// Resolves to a `Calendar.firstWeekday` value. ``automatic``
+    /// defers to `base`, whose `firstWeekday` Foundation already
+    /// derives from the region — so "automatic" needs no locale table
+    /// of its own.
+    func firstWeekday(in base: Calendar = .current) -> Int {
+        weekday?.rawValue ?? base.firstWeekday
+    }
+
+    /// `base` with this option applied. Everything else about the
+    /// calendar — identity, time zone, locale — is left alone.
+    func calendar(base: Calendar = .current) -> Calendar {
+        var calendar = base
+        calendar.firstWeekday = firstWeekday(in: base)
+        return calendar
+    }
+}
+
+/// Single source of truth for the "Week starts on" preference.
+///
+/// Mirrors ``DayStartDefaults``: stored in `UserDefaults` rather than
+/// on a `@Model` so the SwiftData — and therefore CloudKit Production
+/// — schema stays untouched, and in the App Group suite so an
+/// extension can read it without a second store. Being device-local
+/// is the right shape for a display preference: two devices
+/// disagreeing changes nothing about the data, only about which
+/// column Monday lands in.
+nonisolated public enum WeekStartDefaults {
+    public static let key = "kado.weekStart"
+
+    public static let defaultValue: WeekStart = .automatic
+
+    /// UserDefaults suite shared between the main app and the widget
+    /// extension. Returns `.standard` when the App Group suite can't
+    /// be opened so the app still launches.
+    nonisolated(unsafe) public static let sharedDefaults: UserDefaults = {
+        UserDefaults(suiteName: SharedStore.appGroupID) ?? .standard
+    }()
+
+    /// Reads the stored choice. An unset key, or a raw value written
+    /// by a future build with more cases, both resolve to
+    /// ``WeekStart/automatic`` rather than trapping.
+    public static func weekStart(in defaults: UserDefaults = sharedDefaults) -> WeekStart {
+        guard defaults.object(forKey: key) != nil else { return defaultValue }
+        return WeekStart(rawValue: defaults.integer(forKey: key)) ?? defaultValue
+    }
+
+    public static func setWeekStart(_ weekStart: WeekStart, in defaults: UserDefaults = sharedDefaults) {
+        defaults.set(weekStart.rawValue, forKey: key)
+    }
+
+    /// The calendar views should lay weeks out with, for code that has
+    /// no SwiftUI `Environment` to read `\.calendar` from.
+    ///
+    /// Views should use `@Environment(\.calendar)` instead — `KadoApp`
+    /// injects this at the root, and reading `UserDefaults` directly
+    /// wouldn't re-evaluate the body when the setting changes.
+    public static func calendar(
+        base: Calendar = .current,
+        in defaults: UserDefaults = sharedDefaults
+    ) -> Calendar {
+        weekStart(in: defaults).calendar(base: base)
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
@@ -168,8 +168,15 @@ public enum WidgetSnapshotBuilder {
     /// mutation site.
     public static func rebuildAndWrite(using context: ModelContext) {
         // Widgets render a pre-computed snapshot and never ask what day
-        // it is, so the day boundary has to be resolved here, once.
-        let snapshot = build(from: context, asOf: DayStartDefaults.boundary().startOfDay(for: .now))
+        // it is — nor which day a week opens on — so both preferences
+        // have to be resolved here, once. The week start reaches the
+        // streak calculator, whose `.daysPerWeek` count is bucketed
+        // into whole calendar weeks.
+        let snapshot = build(
+            from: context,
+            asOf: DayStartDefaults.boundary().startOfDay(for: .now),
+            calendar: WeekStartDefaults.calendar()
+        )
         WidgetSnapshotStore.write(snapshot)
     }
 

--- a/Shared/AccessibilityID.swift
+++ b/Shared/AccessibilityID.swift
@@ -123,5 +123,9 @@ enum AccessibilityID {
         /// alert. A test that launches with the flag already confirmed
         /// never sees it.
         static let devModeConfirmButton = "settings.devMode.confirm"
+        /// Addressed by identifier rather than by label, which reads
+        /// "Week starts on" on one simulator and "La semaine commence
+        /// le" on the other.
+        static let weekStartPicker = "settings.weekStart.picker"
     }
 }


### PR DESCRIPTION
## Why?

- The calendar on a habit's screen opened every week on Monday, hard-coded. That is right for most of Europe and wrong for the Americas, Japan and much of Asia — and there was no way to change it.
- Three other surfaces carried their own copy of the same Monday-first array, so fixing only the grid would have left them disagreeing with the calendar right above them.

## What?

- **Settings → Week → "Week starts on"**: Automatic, plus all seven days.
- **Automatic is the default**, and resolves through `Calendar.firstWeekday` — the region's day, or the user's own if they have set First Day of Week in iOS Settings → General → Language & Region. Most people never need to open the picker; the ones whose habit of reading a week disagrees with where they live now can.
- The row names what Automatic resolves to, so the setting explains itself rather than hiding its answer.
- Applies everywhere a week is laid out horizontally: the month grid on a habit's screen, the day picker in the New Habit form, and the "Mon · Wed · Fri" frequency subtitles — and to which days count together for a habit measured in days per week, since that streak is counted in whole calendar weeks.
- EN + FR both ship.

| Settings → Week | Region starts Monday | Region starts Sunday |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/scastiel/kado/pr-assets/week-start-setting/settings-week.png" alt="Settings showing the new Week section with Week starts on set to Automatic (Monday)"> | <img src="https://raw.githubusercontent.com/scastiel/kado/pr-assets/week-start-setting/habit-detail-monday.png" alt="Habit detail calendar opening the week on Monday"> | <img src="https://raw.githubusercontent.com/scastiel/kado/pr-assets/week-start-setting/habit-detail-sunday.png" alt="The same build with the simulator's first day of week set to Sunday, calendar opening on Sunday"> |

The two calendars are the same build and the same data; only the simulator's first-day-of-week preference differs.

## How?

- **The preference travels as a calendar, not as a setting of its own.** `KadoApp` injects `Calendar.current` with the choice applied as `\.calendar`, so a view asks `calendar.firstWeekday` and gets the region's answer by default and the user's the moment they override it — nothing to wire up per view. The day boundary is built on the same calendar, so the app has one rather than two that agree by accident.
- `Weekday.week(startingOn:)` and `Weekday.column(inWeekStartingOn:)` land in `KadoCore` and replace three copies of `[.monday … .sunday]` plus the grid's `(firstWeekday + 5) % 7`.
- `WeekStartDefaults` stores the choice in the App Group `UserDefaults` suite, mirroring `DayStartDefaults`. **No SwiftData or CloudKit schema change** — nothing to deploy to CloudKit Production.
- `WeekStartLabel` reads the region from `Calendar.current`, deliberately *not* from `\.calendar`: the environment copy already carries the user's pick, so feeding it there would make the Automatic row describe itself — "Automatic (Monday)" for someone in a Sunday region who pinned Monday.
- **It is not purely a display preference, though it looks like one.** `DefaultStreakCalculator` buckets a `.daysPerWeek` streak into whole calendar weeks via `dateInterval(of: .weekOfYear)`, so the chosen calendar is handed to it as well — in the `\.streakCalculator` environment, in the widget's snapshot builder, and in the notification scheduler, whose reminder copy quotes a streak. Otherwise a streak would break on a week the grid right above it drew as complete. The score and the frequency evaluator answer `.daysPerWeek` over a rolling seven days and are unaffected.
- `UITestSupport` clears the key on every UI-test launch: `make screenshots` reuses its simulator, so a week start set by hand once would quietly reorder every capture taken afterwards.

**Verification**

- `test_sim`: 542 pass, 16 of them new (`WeekOrderTests`, `WeekStartDefaultsTests`, `WeekStartPresentationTests`, plus a `StreakCalculatorTests` case pinning that a `.daysPerWeek` streak follows the calendar's first weekday — a Saturday and the Sunday after it are one week's work under a Monday-first calendar and two half-weeks under a Sunday-first one). The ordering is asserted as invariants over all seven possible first days rather than as examples — "a day's column is the index of its own header", swept over every month — because the Monday-only version of this code was correct for every case anyone thought to check.
- Full `KadoUITests` suite green (re-run after the `UITestSupport` change); `build_sim` clean on iPhone 17 Pro and iPad Air M4, no new warnings.
- Previews pinned to a Sunday-first calendar were added for `WeekdayPicker` and `MonthlyCalendarView`: every other preview renders under the previewing Mac's own calendar, so on a Monday-first machine none of them showed the new state.
- Captures taken with the simulator's first-day-of-week set both ways, which is what proves the chain end to end rather than just the arithmetic.

## Next steps

- **`make screenshots` will produce different English captures.** The listing runs English as `en-CA` (Sunday-first) and French as `fr-FR` (Monday-first), so the English habit-detail shot flips the next time it is regenerated. Nothing under `docs/app-store/` changed in this PR.
- Release notes for the next version should mention the setting (`docs/app-store-connect.md`).
- Worth considering later, alongside the same open question for "Day starts at": syncing the choice through `NSUbiquitousKeyValueStore` so iPhone and iPad don't each need it set.
- The screenshots above live on the `pr-assets/week-start-setting` branch, which exists only to host them. Delete it once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrTW7xi5QkeHBU4e4kAxH1
