### PR TITLE
fix(widgets): roll the widgets over to the new day without the app

### DIFF
--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -140,11 +140,19 @@ struct KadoApp: App {
             // to the foreground — handles clock-drift, day-rollover,
             // and cases where a background reminder fired while
             // the app was suspended.
-            if newPhase == .active {
+            guard newPhase == .active else { return }
+            if boundary.isDate(clockMark, inSameDayAs: .now) {
                 RemindersSync.rescheduleAll(using: container.mainContext)
-                if !boundary.isDate(clockMark, inSameDayAs: .now) {
-                    clockMark = .now
-                }
+            } else {
+                clockMark = .now
+                // A new day since the app was last awake. Bumping
+                // `clockMark` restarts the day-edge task, but for the
+                // *next* edge — the one that just passed fired into a
+                // suspended process and never ran. Rebuild now, or the
+                // widget's pre-computed days run out with nothing to
+                // replace them until the next habit mutation (#82).
+                // `reloadAll` reschedules reminders too.
+                WidgetReloader.reloadAll(using: container.mainContext)
             }
         }
         .onChange(of: dayStartHour) { _, _ in

--- a/Kado/App/KadoApp.swift
+++ b/Kado/App/KadoApp.swift
@@ -141,17 +141,25 @@ struct KadoApp: App {
             // and cases where a background reminder fired while
             // the app was suspended.
             guard newPhase == .active else { return }
-            if boundary.isDate(clockMark, inSameDayAs: .now) {
+            guard !boundary.isDate(clockMark, inSameDayAs: .now) else {
                 RemindersSync.rescheduleAll(using: container.mainContext)
-            } else {
-                clockMark = .now
-                // A new day since the app was last awake. Bumping
-                // `clockMark` restarts the day-edge task, but for the
-                // *next* edge — the one that just passed fired into a
-                // suspended process and never ran. Rebuild now, or the
-                // widget's pre-computed days run out with nothing to
-                // replace them until the next habit mutation (#82).
-                // `reloadAll` reschedules reminders too.
+                return
+            }
+            // A new day since the app was last awake. The edge task that
+            // was sleeping towards it either never woke (the process was
+            // frozen, then resumed just now) or is waking at this very
+            // moment — and bumping `clockMark` *first* is what settles
+            // it: the bump restarts that task for the next edge,
+            // cancelling a waking one before it reaches its own reload,
+            // so the rebuild below happens exactly once. Reorder these
+            // two and a resumed task and this branch can both run a
+            // multi-second series build back to back (#82).
+            clockMark = .now
+            // Deferred a tick so the resumed frame renders first — the
+            // series build is synchronous on MainActor and, for a long
+            // history, not instant. `reloadAll` reschedules reminders
+            // too, so the branch above's call is not repeated here.
+            Task { @MainActor in
                 WidgetReloader.reloadAll(using: container.mainContext)
             }
         }

--- a/Kado/App/WidgetReloader.swift
+++ b/Kado/App/WidgetReloader.swift
@@ -1,11 +1,11 @@
 import Foundation
 import SwiftData
-import WidgetKit
 import KadoCore
 
-/// Rebuilds the App Group JSON snapshot the widget reads, then
-/// asks WidgetKit to reload all timelines so the changes surface
-/// within a second or two.
+/// The app's "after a habit mutation" postamble: rebuild the App Group
+/// snapshot the widget reads (which reloads the timelines itself, so
+/// the change surfaces within a second or two) and reconcile the
+/// pending reminders.
 ///
 /// The widget extension can't safely open SwiftData (two
 /// processes can't both attach CloudKit to the same store), so
@@ -15,7 +15,6 @@ import KadoCore
 enum WidgetReloader {
     static func reloadAll(using context: ModelContext) {
         WidgetSnapshotBuilder.rebuildAndWrite(using: context)
-        WidgetCenter.shared.reloadAllTimelines()
         // Reminders share the same "after a habit mutation" cadence
         // as widgets. Piggyback here so callers don't have to
         // remember two sync calls.

--- a/KadoTests/DayBoundaryTests.swift
+++ b/KadoTests/DayBoundaryTests.swift
@@ -366,6 +366,37 @@ struct DayBoundaryTests {
         }
     }
 
+    /// `rollover(into:)` is the inverse of `startOfDay(for:)` at the
+    /// day's first instant, and agrees with `nextRollover(after:)` day
+    /// by day. A widget timeline dates each day's entry with it, so an
+    /// instant a second off puts yesterday on the Home Screen for a day.
+    @Test("rollover(into:) begins its own day and chains through nextRollover", arguments: dstZones)
+    func rolloverIntoBeginsItsOwnDay(zone: String) throws {
+        let cal = try #require(Self.calendar(zone))
+
+        for hour in DayStartDefaults.allowedHours {
+            let boundary = DayBoundary(calendar: cal, startHour: hour)
+            for start in Self.transitionWindows(cal) {
+                var day = boundary.startOfDay(for: start)
+                for _ in 0..<5 {
+                    let begins = boundary.rollover(into: day)
+                    #expect(
+                        boundary.startOfDay(for: begins) == day,
+                        "\(zone) hour \(hour): \(begins) does not open \(day)"
+                    )
+                    #expect(
+                        boundary.nextRollover(after: begins) == boundary.rollover(into: cal.date(byAdding: .day, value: 1, to: day)!),
+                        "\(zone) hour \(hour): the rollover after \(begins) is not the next day's"
+                    )
+                    if hour == 0 {
+                        #expect(begins == day, "\(zone): under midnight the day begins at its midnight")
+                    }
+                    day = boundary.startOfDay(for: boundary.nextRollover(after: begins))
+                }
+            }
+        }
+    }
+
     /// The other half of the contract: what a write lands on is the
     /// same day the read reports. If these two ever disagree, a user
     /// taps a habit and watches the tick appear on a different day.

--- a/KadoTests/HabitScoreCalculatorTests.swift
+++ b/KadoTests/HabitScoreCalculatorTests.swift
@@ -762,4 +762,39 @@ struct HabitScoreCalculatorTests {
             createdAt: TestCalendar.day(createdOffset)
         )
     }
+
+    // MARK: DST
+
+    @Test("A perfect run across a midnight DST transition scores as it would anywhere else")
+    func perfectRunAcrossMidnightTransition() {
+        // America/Havana springs forward *at* midnight on 2026-03-08, so
+        // that day's first instant is 01:00. A walk that steps forward
+        // with `date(byAdding: .day)` keeps that 01:00 for every day
+        // after, and stops matching the completions it is scoring —
+        // which are bucketed at true midnights. Paris cannot catch this:
+        // its transitions are at 02:00.
+        let havana = TestCalendar.havana
+        let start = TestCalendar.instant(havana, 2026, 3, 1, 9)
+        let days = (0..<14).map { havana.date(byAdding: .day, value: $0, to: start)! }
+        let habit = Habit(
+            id: UUID(),
+            name: "Test",
+            frequency: .daily,
+            type: .binary,
+            createdAt: start
+        )
+        let completions = days.map { Completion(habitID: habit.id, date: $0) }
+        let scored = DefaultHabitScoreCalculator(alpha: 0.05, calendar: havana)
+            .currentScore(for: habit, completions: completions, asOf: days.last!)
+
+        // Same fourteen perfect days in a zone with nothing to trip over.
+        let plain = makeHabit(createdOffset: 0)
+        let expected = calculator.currentScore(
+            for: plain,
+            completions: (0..<14).map { Completion(habitID: plain.id, date: TestCalendar.day($0)) },
+            asOf: TestCalendar.day(13)
+        )
+        #expect(scored == expected)
+        #expect(scored > 0.5)
+    }
 }

--- a/KadoTests/StreakCalculatorTests.swift
+++ b/KadoTests/StreakCalculatorTests.swift
@@ -355,4 +355,31 @@ struct StreakCalculatorTests {
         let calc = calculator()
         #expect(calc.current(for: h, completions: completions, asOf: asOf) == 4)
     }
+
+    // MARK: - DST
+
+    @Test("A perfect run across a midnight DST transition is one streak, walking either way")
+    func perfectRunAcrossMidnightTransition() {
+        // America/Havana springs forward *at* midnight on 2026-03-08, so
+        // that day's first instant is 01:00. `current` walks backward
+        // and `best` forward, both a day at a time; a step that keeps
+        // the 01:00 stops matching the completed-day set, which is
+        // bucketed at true midnights, and the run reads as broken at
+        // the transition.
+        let havana = TestCalendar.havana
+        let start = TestCalendar.instant(havana, 2026, 3, 1, 9)
+        let days = (0..<14).map { havana.date(byAdding: .day, value: $0, to: start)! }
+        let h = Habit(
+            id: UUID(),
+            name: "Test",
+            frequency: .daily,
+            type: .binary,
+            createdAt: start
+        )
+        let completions = days.map { Completion(id: UUID(), habitID: h.id, date: $0) }
+        let calc = DefaultStreakCalculator(calendar: havana)
+
+        #expect(calc.current(for: h, completions: completions, asOf: days.last!) == 14)
+        #expect(calc.best(for: h, completions: completions, asOf: days.last!) == 14)
+    }
 }

--- a/KadoTests/WidgetSnapshotBuilderTests.swift
+++ b/KadoTests/WidgetSnapshotBuilderTests.swift
@@ -540,16 +540,36 @@ struct WidgetSnapshotBuilderTests {
         #expect(kept.days[1].today.first?.streak == 2)
     }
 
-    @Test("Every day of a series is exactly what a build of that day would be")
-    func seriesDaysMatchStandaloneBuilds() throws {
+    /// Reference instants whose forty-day history and seven-day series
+    /// straddle a DST transition, one per shape that breaks naive day
+    /// arithmetic: the ordinary 02:00 case (Paris, both ways) and the
+    /// midnight case (Havana), plus a plain UTC control. The series
+    /// keys per-day lookups by `Date`, which is exactly what CLAUDE.md
+    /// says needs a midnight-transition fixture — and the score walk's
+    /// drift after Havana's 2026-03-08 was invisible in UTC.
+    nonisolated private static let parityProbes: [(String, Calendar, Date)] = [
+        ("UTC", TestCalendar.utc, TestCalendar.day(0)),
+        ("Paris, series after spring-forward", TestCalendar.paris, TestCalendar.instant(TestCalendar.paris, 2026, 3, 31, 12)),
+        ("Paris, series across fall-back", TestCalendar.paris, TestCalendar.instant(TestCalendar.paris, 2026, 10, 22, 12)),
+        ("Havana, series after the midnight transition", TestCalendar.havana, TestCalendar.instant(TestCalendar.havana, 2026, 3, 10, 12)),
+        ("Havana, series across the midnight transition", TestCalendar.havana, TestCalendar.instant(TestCalendar.havana, 2026, 3, 6, 12)),
+    ]
+
+    @Test("Every day of a series is exactly what a build of that day would be", arguments: parityProbes)
+    func seriesDaysMatchStandaloneBuilds(zone: String, calendar: Calendar, reference: Date) throws {
         // The series shares one score walk per habit across its days
         // rather than re-walking from the first completion seven
         // times. That is only a shortcut if the numbers are the same —
         // and they are by construction, since `currentScore` is the
         // prefix of the same fold. Pinned here across every frequency
-        // shape, with the rest of the day's derivation for company.
+        // shape, with the rest of the day's derivation for company:
+        // this is also what showed the best streak *cannot* be shared
+        // the same way — for a negative habit, two unlogged days are
+        // two clean days, and its best grows.
         let container = try makeContainer()
-        let calendar = TestCalendar.utc
+        func daysAgo(_ n: Int) -> Date {
+            calendar.date(byAdding: .day, value: -n, to: reference)!
+        }
         let shapes: [(String, Frequency, HabitType)] = [
             ("Daily", .daily, .binary),
             ("Weekly", .daysPerWeek(3), .binary),
@@ -562,14 +582,14 @@ struct WidgetSnapshotBuilderTests {
                 name: name,
                 frequency: frequency,
                 type: type,
-                createdAt: TestCalendar.day(-40)
+                createdAt: daysAgo(40)
             )
             container.mainContext.insert(habit)
             // A patchy history, so scores are mid-range and streaks
             // have somewhere to break.
-            for daysAgo in stride(from: 0, through: 39, by: 1) where daysAgo % 5 != 2 {
+            for n in 0...39 where n % 5 != 2 {
                 container.mainContext.insert(
-                    CompletionRecord(date: TestCalendar.day(-daysAgo), value: 5, habit: habit)
+                    CompletionRecord(date: daysAgo(n), value: 5, habit: habit)
                 )
             }
         }
@@ -577,26 +597,31 @@ struct WidgetSnapshotBuilderTests {
 
         let series = WidgetSnapshotBuilder.buildSeries(
             from: container.mainContext,
-            asOf: TestCalendar.day(0),
+            asOf: reference,
             calendar: calendar,
             horizonDays: 7
         )
-        #expect(series.days.count == 7)
+        #expect(series.days.count == 7, "\(zone)")
         for (offset, day) in series.days.enumerated() {
             let single = WidgetSnapshotBuilder.build(
                 from: container.mainContext,
-                asOf: TestCalendar.day(offset),
+                asOf: calendar.date(byAdding: .day, value: offset, to: reference)!,
                 calendar: calendar
             )
-            #expect(day.habits.map(\.currentScore) == single.habits.map(\.currentScore), "day \(offset) scores")
-            #expect(day.habits.map(\.currentStreak) == single.habits.map(\.currentStreak), "day \(offset) streaks")
-            #expect(day.habits.map(\.bestStreak) == single.habits.map(\.bestStreak), "day \(offset) best")
-            #expect(day.today.map(\.id) == single.today.map(\.id), "day \(offset) due set")
-            #expect(day.completedToday == single.completedToday, "day \(offset) completed")
-            #expect(day.matrix.map(\.cells) == single.matrix.map(\.cells), "day \(offset) matrix")
+            let label = "\(zone), day \(offset)"
+            #expect(day.logicalDay == single.logicalDay, "\(label) logical day")
+            #expect(day.habits.map(\.currentScore) == single.habits.map(\.currentScore), "\(label) scores")
+            #expect(day.habits.map(\.currentStreak) == single.habits.map(\.currentStreak), "\(label) streaks")
+            #expect(day.habits.map(\.bestStreak) == single.habits.map(\.bestStreak), "\(label) best")
+            #expect(day.today.map(\.id) == single.today.map(\.id), "\(label) due set")
+            #expect(day.completedToday == single.completedToday, "\(label) completed")
+            #expect(day.matrix.map(\.cells) == single.matrix.map(\.cells), "\(label) matrix")
+            // And none of it is degenerate: a lookup that silently
+            // missed would agree with a standalone build that also
+            // missed, at zero.
+            #expect(day.habits.contains { $0.currentScore > 0 }, "\(label) has live scores")
         }
     }
-
     @Test("A negative habit is done tomorrow until it slips, as on Today")
     func negativeHabitIsDoneTomorrow() throws {
         let container = try makeContainer()

--- a/KadoTests/WidgetSnapshotBuilderTests.swift
+++ b/KadoTests/WidgetSnapshotBuilderTests.swift
@@ -540,6 +540,63 @@ struct WidgetSnapshotBuilderTests {
         #expect(kept.days[1].today.first?.streak == 2)
     }
 
+    @Test("Every day of a series is exactly what a build of that day would be")
+    func seriesDaysMatchStandaloneBuilds() throws {
+        // The series shares one score walk per habit across its days
+        // rather than re-walking from the first completion seven
+        // times. That is only a shortcut if the numbers are the same —
+        // and they are by construction, since `currentScore` is the
+        // prefix of the same fold. Pinned here across every frequency
+        // shape, with the rest of the day's derivation for company.
+        let container = try makeContainer()
+        let calendar = TestCalendar.utc
+        let shapes: [(String, Frequency, HabitType)] = [
+            ("Daily", .daily, .binary),
+            ("Weekly", .daysPerWeek(3), .binary),
+            ("Tue/Thu", .specificDays([.tuesday, .thursday]), .counter(target: 5)),
+            ("Cycle", .everyNDays(3), .binary),
+            ("No sugar", .daily, .negative),
+        ]
+        for (name, frequency, type) in shapes {
+            let habit = HabitRecord(
+                name: name,
+                frequency: frequency,
+                type: type,
+                createdAt: TestCalendar.day(-40)
+            )
+            container.mainContext.insert(habit)
+            // A patchy history, so scores are mid-range and streaks
+            // have somewhere to break.
+            for daysAgo in stride(from: 0, through: 39, by: 1) where daysAgo % 5 != 2 {
+                container.mainContext.insert(
+                    CompletionRecord(date: TestCalendar.day(-daysAgo), value: 5, habit: habit)
+                )
+            }
+        }
+        try container.mainContext.save()
+
+        let series = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 7
+        )
+        #expect(series.days.count == 7)
+        for (offset, day) in series.days.enumerated() {
+            let single = WidgetSnapshotBuilder.build(
+                from: container.mainContext,
+                asOf: TestCalendar.day(offset),
+                calendar: calendar
+            )
+            #expect(day.habits.map(\.currentScore) == single.habits.map(\.currentScore), "day \(offset) scores")
+            #expect(day.habits.map(\.currentStreak) == single.habits.map(\.currentStreak), "day \(offset) streaks")
+            #expect(day.habits.map(\.bestStreak) == single.habits.map(\.bestStreak), "day \(offset) best")
+            #expect(day.today.map(\.id) == single.today.map(\.id), "day \(offset) due set")
+            #expect(day.completedToday == single.completedToday, "day \(offset) completed")
+            #expect(day.matrix.map(\.cells) == single.matrix.map(\.cells), "day \(offset) matrix")
+        }
+    }
+
     @Test("A negative habit is done tomorrow until it slips, as on Today")
     func negativeHabitIsDoneTomorrow() throws {
         let container = try makeContainer()

--- a/KadoTests/WidgetSnapshotBuilderTests.swift
+++ b/KadoTests/WidgetSnapshotBuilderTests.swift
@@ -387,4 +387,179 @@ struct WidgetSnapshotBuilderTests {
         #expect(slipped.dayProgress == DayProgress(completed: 1, total: 2))
         #expect(!slipped.dayProgress.isComplete)
     }
+
+    // MARK: - Upcoming days
+
+    /// The series is what makes the widget roll over without the app:
+    /// each day after the first is "that morning, nothing further
+    /// logged". These pin what that means per habit shape — the due
+    /// set moves, the ticks clear, and a streak answers for *that*
+    /// morning rather than copying today's.
+
+    @Test("A series covers consecutive logical days, each anchored on its own trailing matrix day")
+    func seriesCoversConsecutiveDays() throws {
+        let container = try makeContainer()
+        let calendar = TestCalendar.utc
+        container.mainContext.insert(HabitRecord(name: "A", frequency: .daily, type: .binary))
+        try container.mainContext.save()
+
+        let series = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 7
+        )
+        let expected = (0..<7).map { calendar.startOfDay(for: TestCalendar.day($0)) }
+        #expect(series.days.map(\.logicalDay) == expected)
+        for day in series.days {
+            #expect(day.matrixDays.last == day.logicalDay)
+        }
+    }
+
+    @Test("Tomorrow starts clean: today's tick is gone and the row is back to none")
+    func tomorrowStartsClean() throws {
+        let container = try makeContainer()
+        let calendar = TestCalendar.utc
+        let habit = HabitRecord(
+            name: "Water",
+            frequency: .daily,
+            type: .counter(target: 8),
+            createdAt: TestCalendar.day(-10)
+        )
+        container.mainContext.insert(habit)
+        container.mainContext.insert(CompletionRecord(date: TestCalendar.day(0), value: 8, habit: habit))
+        try container.mainContext.save()
+
+        let series = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 2
+        )
+        let today = try #require(series.days.first)
+        #expect(today.completedToday == 1)
+        #expect(today.today.first?.status == .complete)
+
+        let tomorrow = try #require(series.days.dropFirst().first)
+        let row = try #require(tomorrow.today.first)
+        #expect(tomorrow.completedToday == 0)
+        #expect(tomorrow.totalDueToday == 1)
+        #expect(row.status == .none)
+        #expect(row.progress == 0.0)
+        #expect(row.valueToday == nil)
+    }
+
+    @Test("A bonus completion keeps today's row but leaves tomorrow's")
+    func bonusCompletionLeavesTomorrowsRows() throws {
+        let container = try makeContainer()
+        let calendar = TestCalendar.utc
+        let habit = HabitRecord(
+            name: "Run",
+            frequency: .daysPerWeek(1),
+            type: .binary,
+            createdAt: TestCalendar.day(-30)
+        )
+        container.mainContext.insert(habit)
+        container.mainContext.insert(CompletionRecord(date: TestCalendar.day(0), value: 1, habit: habit))
+        try container.mainContext.save()
+
+        let series = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 2
+        )
+        // Today: quota met by today's run, kept by the "or logged" arm.
+        #expect(series.days[0].today.map(\.habit.name) == ["Run"])
+        // Tomorrow: the week's quota is met and nothing is logged, so
+        // the widget must not ask for it.
+        #expect(series.days[1].today.isEmpty)
+        #expect(series.days[1].totalDueToday == 0)
+    }
+
+    @Test("A specific-days habit is absent today and present on its day tomorrow")
+    func specificDaysAppearOnTheirDay() throws {
+        let container = try makeContainer()
+        let calendar = TestCalendar.utc
+        // Day 0 is a Monday; a Tuesday-only habit is tomorrow's business.
+        let habit = HabitRecord(
+            name: "Gym",
+            frequency: .specificDays([.tuesday]),
+            type: .binary,
+            createdAt: TestCalendar.day(-30)
+        )
+        container.mainContext.insert(habit)
+        try container.mainContext.save()
+
+        let series = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 2
+        )
+        #expect(series.days[0].today.isEmpty)
+        #expect(series.days[1].today.map(\.habit.name) == ["Gym"])
+        #expect(series.days[1].totalDueToday == 1)
+    }
+
+    @Test("Tomorrow's streak is tomorrow morning's truth: alive if today was done, broken if not")
+    func tomorrowsStreakReflectsTodaysOutcome() throws {
+        let container = try makeContainer()
+        let calendar = TestCalendar.utc
+        let habit = HabitRecord(
+            name: "Meditate",
+            frequency: .daily,
+            type: .binary,
+            createdAt: TestCalendar.day(-10)
+        )
+        container.mainContext.insert(habit)
+        container.mainContext.insert(CompletionRecord(date: TestCalendar.day(-1), value: 1, habit: habit))
+        try container.mainContext.save()
+
+        // Only yesterday done: as of tomorrow, today is a miss.
+        let missed = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 2
+        )
+        #expect(missed.days[0].habits.first?.currentStreak == 1)
+        #expect(missed.days[1].habits.first?.currentStreak == 0)
+
+        container.mainContext.insert(CompletionRecord(date: TestCalendar.day(0), value: 1, habit: habit))
+        try container.mainContext.save()
+
+        let kept = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 2
+        )
+        #expect(kept.days[0].habits.first?.currentStreak == 2)
+        #expect(kept.days[1].habits.first?.currentStreak == 2)
+        #expect(kept.days[1].today.first?.streak == 2)
+    }
+
+    @Test("A negative habit is done tomorrow until it slips, as on Today")
+    func negativeHabitIsDoneTomorrow() throws {
+        let container = try makeContainer()
+        let calendar = TestCalendar.utc
+        container.mainContext.insert(
+            HabitRecord(
+                name: "No sugar",
+                frequency: .daily,
+                type: .negative,
+                createdAt: TestCalendar.day(-10)
+            )
+        )
+        try container.mainContext.save()
+
+        let series = WidgetSnapshotBuilder.buildSeries(
+            from: container.mainContext,
+            asOf: TestCalendar.day(0),
+            calendar: calendar,
+            horizonDays: 2
+        )
+        #expect(series.days[1].dayProgress == DayProgress(completed: 1, total: 1))
+    }
 }

--- a/KadoTests/WidgetSnapshotSeriesTests.swift
+++ b/KadoTests/WidgetSnapshotSeriesTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+import KadoCore
+
+/// The on-disk shape the widgets read: a run of consecutive logical
+/// days, each a `WidgetSnapshot` computed "as of that morning". Pins
+/// two things the widget cannot afford to get wrong — that a file
+/// written by the previous app version still decodes, and which day's
+/// snapshot answers for a given instant.
+@Suite("WidgetSnapshotSeries")
+struct WidgetSnapshotSeriesTests {
+    private let calendar = TestCalendar.utc
+
+    /// One recognisable snapshot per day: `completedToday` doubles as
+    /// the day's label so a wrong pick reads as the wrong number.
+    private func snapshot(day: Date, completed: Int) -> WidgetSnapshot {
+        let matrixDays = (0..<7).reversed().compactMap {
+            calendar.date(byAdding: .day, value: -$0, to: day)
+        }
+        return WidgetSnapshot(
+            generatedAt: TestCalendar.referenceDate,
+            habits: [],
+            today: [],
+            totalDueToday: 3,
+            completedToday: completed,
+            matrix: [],
+            matrixDays: matrixDays,
+            logicalDay: day
+        )
+    }
+
+    private func series(days: Int) -> WidgetSnapshotSeries {
+        let first = calendar.startOfDay(for: TestCalendar.referenceDate)
+        return WidgetSnapshotSeries(
+            generatedAt: TestCalendar.referenceDate,
+            days: (0..<days).map { offset in
+                snapshot(
+                    day: calendar.date(byAdding: .day, value: offset, to: first)!,
+                    completed: offset
+                )
+            }
+        )
+    }
+
+    private func day(_ offset: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
+        let first = calendar.startOfDay(for: TestCalendar.referenceDate)
+        let day = calendar.date(byAdding: .day, value: offset, to: first)!
+        return calendar.date(bySettingHour: hour, minute: minute, second: 0, of: day)!
+    }
+
+    // MARK: - Codec
+
+    @Test("A series round-trips through the store's codec with every logicalDay intact")
+    func seriesRoundTrips() throws {
+        let original = series(days: 3)
+        let data = try WidgetSnapshotStore.encode(original)
+        let decoded = try #require(WidgetSnapshotStore.decode(data))
+
+        #expect(decoded.days.map(\.logicalDay) == original.days.map(\.logicalDay))
+        #expect(decoded.days.map(\.completedToday) == [0, 1, 2])
+        #expect(decoded.generatedAt == original.generatedAt)
+    }
+
+    @Test("A pre-upgrade file — one bare snapshot, no logicalDay — decodes as a one-day series on its trailing matrix day")
+    func legacyFileDecodesAsOneDaySeries() throws {
+        // The fixture is real encoder output with the new key removed,
+        // not a hand-typed blob: what an older build wrote is exactly
+        // "the current shape minus the fields it didn't have".
+        let legacy = snapshot(day: day(0), completed: 2)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var object = try #require(
+            try JSONSerialization.jsonObject(with: encoder.encode(legacy)) as? [String: Any]
+        )
+        object.removeValue(forKey: "logicalDay")
+        let data = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try #require(WidgetSnapshotStore.decode(data))
+        #expect(decoded.days.count == 1)
+        let only = try #require(decoded.days.first)
+        #expect(only.completedToday == 2)
+        #expect(only.logicalDay == legacy.matrixDays.last)
+        #expect(decoded.generatedAt == legacy.generatedAt)
+    }
+
+    @Test("A bare snapshot with no matrix days falls back to the calendar midnight of generatedAt")
+    func legacyFileWithoutMatrixFallsBackToGeneratedAt() throws {
+        let generatedAt = TestCalendar.referenceDate
+        let legacy = WidgetSnapshot(
+            generatedAt: generatedAt,
+            habits: [],
+            today: [],
+            totalDueToday: 0,
+            completedToday: 0,
+            matrix: [],
+            matrixDays: []
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var object = try #require(
+            try JSONSerialization.jsonObject(with: encoder.encode(legacy)) as? [String: Any]
+        )
+        object.removeValue(forKey: "logicalDay")
+        let data = try JSONSerialization.data(withJSONObject: object)
+
+        let decoded = try #require(WidgetSnapshotStore.decode(data))
+        #expect(decoded.days.first?.logicalDay == Calendar.current.startOfDay(for: generatedAt))
+    }
+
+    @Test("Bytes that are neither shape decode to nil, not to a trap")
+    func garbageDecodesToNil() {
+        #expect(WidgetSnapshotStore.decode(Data("not json".utf8)) == nil)
+        #expect(WidgetSnapshotStore.decode(Data("{}".utf8)) == nil)
+    }
+
+    // MARK: - Which day answers
+
+    @Test("snapshot(on:) picks the greatest logical day not after the instant")
+    func picksGreatestDayNotAfterNow() {
+        let boundary = DayBoundary(calendar: calendar, startHour: 0)
+        let three = series(days: 3)
+
+        #expect(three.snapshot(on: day(0, 9), boundary: boundary).completedToday == 0)
+        #expect(three.snapshot(on: day(1, 15), boundary: boundary).completedToday == 1)
+        #expect(three.snapshot(on: day(2, 23, 59), boundary: boundary).completedToday == 2)
+        // Past the horizon: the latest day we have, never the first
+        // one's ticks.
+        #expect(three.snapshot(on: day(5), boundary: boundary).completedToday == 2)
+    }
+
+    @Test("Before the first day, the first day answers")
+    func beforeTheSeriesTheFirstDayAnswers() {
+        let boundary = DayBoundary(calendar: calendar, startHour: 0)
+        #expect(series(days: 3).snapshot(on: day(-1, 12), boundary: boundary).completedToday == 0)
+    }
+
+    @Test("An empty series resolves to the empty snapshot")
+    func emptySeriesResolvesToEmpty() {
+        let boundary = DayBoundary(calendar: calendar, startHour: 0)
+        let resolved = WidgetSnapshotSeries.empty.snapshot(on: day(0, 12), boundary: boundary)
+        #expect(resolved.habits.isEmpty)
+        #expect(resolved.today.isEmpty)
+        #expect(resolved.totalDueToday == 0)
+        #expect(resolved.matrixDays.isEmpty)
+    }
+
+    @Test("Under a 4 AM day start, 02:00 still belongs to the previous day")
+    func dayStartHourShiftsSelection() {
+        let boundary = DayBoundary(calendar: calendar, startHour: 4)
+        let three = series(days: 3)
+
+        #expect(three.snapshot(on: day(1, 2), boundary: boundary).completedToday == 0)
+        #expect(three.snapshot(on: day(1, 4), boundary: boundary).completedToday == 1)
+        #expect(three.snapshot(on: day(2, 3, 59), boundary: boundary).completedToday == 1)
+    }
+}

--- a/KadoTests/WidgetSnapshotSeriesTests.swift
+++ b/KadoTests/WidgetSnapshotSeriesTests.swift
@@ -103,8 +103,8 @@ struct WidgetSnapshotSeriesTests {
         object.removeValue(forKey: "logicalDay")
         let data = try JSONSerialization.data(withJSONObject: object)
 
-        let decoded = try #require(WidgetSnapshotStore.decode(data))
-        #expect(decoded.days.first?.logicalDay == Calendar.current.startOfDay(for: generatedAt))
+        let decoded = try #require(WidgetSnapshotStore.decode(data, calendar: calendar))
+        #expect(decoded.days.first?.logicalDay == calendar.startOfDay(for: generatedAt))
     }
 
     @Test("Bytes that are neither shape decode to nil, not to a trap")

--- a/KadoTests/WidgetTimelinePlanTests.swift
+++ b/KadoTests/WidgetTimelinePlanTests.swift
@@ -107,6 +107,55 @@ struct WidgetTimelinePlanTests {
         #expect(plan.slots[2].date == day(2, 4))
     }
 
+    @Test("A gap in the series costs nothing: the days after it are still dated on their own midnights")
+    func gapDoesNotDropLaterDays() {
+        let boundary = DayBoundary(calendar: utc, startHour: 0)
+        let full = series(from: d0, calendar: utc)
+        // Drop D2: the builder never writes a gap, but a slot placed
+        // relative to its neighbour would slide every later day back.
+        let gapped = WidgetSnapshotSeries(
+            generatedAt: full.generatedAt,
+            days: full.days.filter { $0.completedToday != 2 }
+        )
+        let plan = WidgetTimelinePlan.make(series: gapped, now: day(0, 10), boundary: boundary)
+
+        #expect(plan.slots.map(\.snapshot.completedToday) == [0, 1, 3, 4, 5, 6])
+        #expect(plan.slots[2].date == day(3))
+        #expect(plan.slots[5].date == day(6))
+    }
+
+    @Test("A day whose logicalDay isn't a midnight here is left out, and only that day")
+    func misalignedDayIsDroppedAlone() {
+        // Written in one zone, read in another: the stored midnight is
+        // some afternoon here. Placing it on the calendar day it falls
+        // in would collide with the real entry for that day.
+        let boundary = DayBoundary(calendar: utc, startHour: 0)
+        let full = series(from: d0, calendar: utc)
+        let skewed = full.days.map { snapshot -> WidgetSnapshot in
+            guard snapshot.completedToday == 3 else { return snapshot }
+            return WidgetSnapshot(
+                generatedAt: snapshot.generatedAt,
+                habits: [],
+                today: [],
+                totalDueToday: 3,
+                completedToday: 3,
+                matrix: [],
+                matrixDays: snapshot.matrixDays,
+                logicalDay: snapshot.logicalDay.addingTimeInterval(-6 * 3600)
+            )
+        }
+        let plan = WidgetTimelinePlan.make(
+            series: WidgetSnapshotSeries(generatedAt: full.generatedAt, days: skewed),
+            now: day(0, 10),
+            boundary: boundary
+        )
+
+        #expect(plan.slots.map(\.snapshot.completedToday) == [0, 1, 2, 4, 5, 6])
+        for (previous, next) in zip(plan.slots, plan.slots.dropFirst()) {
+            #expect(next.date > previous.date)
+        }
+    }
+
     @Test("The reload lands one hour after now — the safety net the providers always had")
     func reloadAfterIsOneHour() {
         let boundary = DayBoundary(calendar: utc, startHour: 0)

--- a/KadoTests/WidgetTimelinePlanTests.swift
+++ b/KadoTests/WidgetTimelinePlanTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+import KadoCore
+
+/// Specifies the entries a widget hands WidgetKit: one per pre-computed
+/// day, dated at the instant that day begins, so the render server
+/// turns the page at the boundary with neither process awake.
+///
+/// The invariant sweep at the end matters more than the examples: a
+/// rollover that lands a second off a DST edge shows yesterday for a
+/// day, and the example-shaped tests only cover the shapes already
+/// thought of.
+@Suite("WidgetTimelinePlan")
+struct WidgetTimelinePlanTests {
+
+    /// Seven consecutive logical days from `first`, each labelled by
+    /// `completedToday` so a misdated slot reads as the wrong number.
+    private func series(from first: Date, calendar: Calendar, days: Int = 7) -> WidgetSnapshotSeries {
+        WidgetSnapshotSeries(
+            generatedAt: first,
+            days: (0..<days).map { offset in
+                // Re-anchored like the builder does: adding a day to a
+                // midnight does not always land on one (Havana).
+                let day = calendar.startOfDay(
+                    for: calendar.date(byAdding: .day, value: offset, to: first)!
+                )
+                return WidgetSnapshot(
+                    generatedAt: first,
+                    habits: [],
+                    today: [],
+                    totalDueToday: 3,
+                    completedToday: offset,
+                    matrix: [],
+                    matrixDays: [day],
+                    logicalDay: day
+                )
+            }
+        )
+    }
+
+    private let utc = TestCalendar.utc
+    private var d0: Date { utc.startOfDay(for: TestCalendar.referenceDate) }
+    private func day(_ offset: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
+        let day = utc.date(byAdding: .day, value: offset, to: d0)!
+        return utc.date(bySettingHour: hour, minute: minute, second: 0, of: day)!
+    }
+
+    // MARK: - Examples
+
+    @Test("Seven days: one slot at now, then one at each following midnight")
+    func oneSlotPerDay() {
+        let boundary = DayBoundary(calendar: utc, startHour: 0)
+        let now = day(0, 10)
+        let plan = WidgetTimelinePlan.make(series: series(from: d0, calendar: utc), now: now, boundary: boundary)
+
+        #expect(plan.slots.count == 7)
+        #expect(plan.slots.first?.date == now)
+        #expect(plan.slots.map(\.snapshot.completedToday) == [0, 1, 2, 3, 4, 5, 6])
+        for (offset, slot) in plan.slots.enumerated().dropFirst() {
+            #expect(slot.date == day(offset), "slot \(offset) is dated at its own midnight")
+        }
+    }
+
+    @Test("Days already over are dropped; the current day is slot 0 at now")
+    func pastDaysAreDropped() {
+        let boundary = DayBoundary(calendar: utc, startHour: 0)
+        let now = day(2, 9)
+        let plan = WidgetTimelinePlan.make(series: series(from: d0, calendar: utc), now: now, boundary: boundary)
+
+        #expect(plan.slots.map(\.snapshot.completedToday) == [2, 3, 4, 5, 6])
+        #expect(plan.slots.first?.date == now)
+        #expect(plan.slots[1].date == day(3))
+    }
+
+    @Test("Past the horizon: a single slot with the latest day, never the first day's ticks")
+    func beyondHorizonShowsLatestDay() {
+        let boundary = DayBoundary(calendar: utc, startHour: 0)
+        let now = day(9, 8)
+        let plan = WidgetTimelinePlan.make(series: series(from: d0, calendar: utc), now: now, boundary: boundary)
+
+        #expect(plan.slots.count == 1)
+        #expect(plan.slots.first?.date == now)
+        #expect(plan.slots.first?.snapshot.completedToday == 6)
+    }
+
+    @Test("An empty series still yields one slot, the empty snapshot, at now")
+    func emptySeriesYieldsOneEmptySlot() {
+        let boundary = DayBoundary(calendar: utc, startHour: 0)
+        let now = day(0, 12)
+        let plan = WidgetTimelinePlan.make(series: .empty, now: now, boundary: boundary)
+
+        #expect(plan.slots.count == 1)
+        #expect(plan.slots.first?.date == now)
+        #expect(plan.slots.first?.snapshot.today.isEmpty == true)
+        #expect(plan.slots.first?.snapshot.totalDueToday == 0)
+    }
+
+    @Test("Under a 4 AM day start, 02:00 is still yesterday and the page turns at 04:00")
+    func dayStartHourShiftsTheSwitch() {
+        let boundary = DayBoundary(calendar: utc, startHour: 4)
+        let now = day(1, 2)
+        let plan = WidgetTimelinePlan.make(series: series(from: d0, calendar: utc), now: now, boundary: boundary)
+
+        #expect(plan.slots.map(\.snapshot.completedToday) == [0, 1, 2, 3, 4, 5, 6])
+        #expect(plan.slots.first?.date == now)
+        #expect(plan.slots[1].date == day(1, 4))
+        #expect(plan.slots[2].date == day(2, 4))
+    }
+
+    @Test("The reload lands one hour after now — the safety net the providers always had")
+    func reloadAfterIsOneHour() {
+        let boundary = DayBoundary(calendar: utc, startHour: 0)
+        let now = day(0, 10, 30)
+        let plan = WidgetTimelinePlan.make(series: series(from: d0, calendar: utc), now: now, boundary: boundary)
+
+        #expect(plan.reloadAfter == utc.date(byAdding: .hour, value: 1, to: now))
+    }
+
+    // MARK: - Invariants
+
+    /// Instants that exist in their zone, chosen around the transitions
+    /// `TestCalendar` documents: the evening before, the small hours
+    /// after, and a plain day for contrast.
+    private var probes: [(Calendar, Date)] {
+        let p = TestCalendar.paris
+        let h = TestCalendar.havana
+        return [
+            (utc, TestCalendar.instant(utc, 2026, 4, 13, 10)),
+            (p, TestCalendar.instant(p, 2026, 3, 28, 22)),
+            (p, TestCalendar.instant(p, 2026, 3, 29, 1, 30)),
+            (p, TestCalendar.instant(p, 2026, 3, 29, 3, 30)),
+            (p, TestCalendar.instant(p, 2026, 10, 24, 23)),
+            (p, TestCalendar.instant(p, 2026, 10, 25, 1, 30)),
+            (p, TestCalendar.instant(p, 2026, 10, 25, 3, 30)),
+            (h, TestCalendar.instant(h, 2026, 3, 7, 23, 30)),
+            (h, TestCalendar.instant(h, 2026, 3, 8, 1, 30)),
+            (h, TestCalendar.instant(h, 2026, 3, 8, 12)),
+        ]
+    }
+
+    @Test("Across zones, day starts and DST edges: every slot begins its own logical day and sits at the rollover after the one before")
+    func slotsAlignWithRolloversEverywhere() {
+        for (calendar, now) in probes {
+            for startHour in [0, 4] {
+                let boundary = DayBoundary(calendar: calendar, startHour: startHour)
+                let first = boundary.startOfDay(for: now)
+                let plan = WidgetTimelinePlan.make(
+                    series: series(from: first, calendar: calendar),
+                    now: now,
+                    boundary: boundary
+                )
+                let label = "\(calendar.timeZone.identifier) start \(startHour) at \(now)"
+
+                #expect(plan.slots.count == 7, "\(label): every day gets a slot")
+                #expect(plan.slots.first?.date == now, "\(label): slot 0 is now")
+                for slot in plan.slots {
+                    #expect(
+                        boundary.startOfDay(for: slot.date) == slot.snapshot.logicalDay,
+                        "\(label): slot at \(slot.date) shows its own day"
+                    )
+                }
+                for (previous, next) in zip(plan.slots, plan.slots.dropFirst()) {
+                    #expect(next.date > previous.date, "\(label): ascending")
+                    #expect(
+                        next.date == boundary.nextRollover(after: previous.date),
+                        "\(label): \(next.date) is the rollover after \(previous.date)"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Services/DayBoundary.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DayBoundary.swift
@@ -126,6 +126,18 @@ nonisolated public struct DayBoundary: Equatable, Sendable {
         return rolloverInstant(onDayStartingAt: nextMidnight) ?? nextMidnight
     }
 
+    /// The wall-clock instant at which the logical day `day` begins —
+    /// its midnight under the default hour, its `startHour` otherwise.
+    ///
+    /// `day` names a day, not an instant: it is a calendar midnight as
+    /// ``startOfDay(for:)`` returns them, so under a 4 AM start the
+    /// answer for `D 00:00` is `D 04:00`, the first instant of logical
+    /// day D. What a widget timeline dates a day's entry at.
+    public func rollover(into day: Date) -> Date {
+        let midnight = calendar.startOfDay(for: day)
+        return rolloverInstant(onDayStartingAt: midnight) ?? midnight
+    }
+
     // MARK: - Internals
 
     /// The wall-clock rollover instant on the calendar day starting at

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultHabitScoreCalculator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultHabitScoreCalculator.swift
@@ -76,7 +76,12 @@ public struct DefaultHabitScoreCalculator: HabitScoreCalculating {
                 score = (1 - alpha) * score + alpha * value
             }
             result.append(DailyScore(date: day, score: score))
-            day = calendar.date(byAdding: .day, value: 1, to: day)!
+            // Re-anchored, because adding a day to a midnight does not
+            // always land on one: in a zone whose DST transition happens
+            // *at* 00:00 (America/Havana) the day's first instant is
+            // 01:00, and every step after keeps that hour — while the
+            // completions being scored are bucketed at true midnights.
+            day = calendar.startOfDay(for: calendar.date(byAdding: .day, value: 1, to: day)!)
         }
         return result
     }

--- a/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/DefaultStreakCalculator.swift
@@ -136,7 +136,7 @@ public struct DefaultStreakCalculator: StreakCalculating {
         // regardless of how many completions have landed.
         streak += 1
 
-        var weekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: endWeek.start)!
+        var weekStart = self.weekStart(-1, from: endWeek.start)
 
         while weekStart >= startDay ||
               calendar.dateInterval(of: .weekOfYear, for: startDay)!.start == weekStart {
@@ -147,7 +147,7 @@ public struct DefaultStreakCalculator: StreakCalculating {
             } else {
                 break
             }
-            weekStart = calendar.date(byAdding: .weekOfYear, value: -1, to: weekStart)!
+            weekStart = self.weekStart(-1, from: weekStart)
         }
         return streak
     }
@@ -182,19 +182,30 @@ public struct DefaultStreakCalculator: StreakCalculating {
             } else {
                 run = 0
             }
-            weekStart = calendar.date(byAdding: .weekOfYear, value: 1, to: weekStart)!
+            weekStart = self.weekStart(1, from: weekStart)
         }
         return best
     }
 
     // MARK: - Day helpers
 
+    /// Both re-anchored, because stepping a day from a midnight does not
+    /// always land on one: in a zone whose DST transition happens *at*
+    /// 00:00 (America/Havana) the day's first instant is 01:00, and every
+    /// step after keeps that hour — while `completedDaySet` is bucketed
+    /// at true midnights, so the walk would stop matching it at the
+    /// transition and read a perfect run as broken.
     private func previousDay(_ day: Date) -> Date {
-        calendar.date(byAdding: .day, value: -1, to: day)!
+        calendar.startOfDay(for: calendar.date(byAdding: .day, value: -1, to: day)!)
     }
 
     private func nextDay(_ day: Date) -> Date {
-        calendar.date(byAdding: .day, value: 1, to: day)!
+        calendar.startOfDay(for: calendar.date(byAdding: .day, value: 1, to: day)!)
+    }
+
+    /// Same re-anchoring for the week walks.
+    private func weekStart(_ weeks: Int, from weekStart: Date) -> Date {
+        calendar.startOfDay(for: calendar.date(byAdding: .weekOfYear, value: weeks, to: weekStart)!)
     }
 
     /// Deliberately **not** delegated to the shared

--- a/Packages/KadoCore/Sources/KadoCore/Services/Intents/CompleteHabitIntent.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/Intents/CompleteHabitIntent.swift
@@ -1,7 +1,6 @@
 import AppIntents
 import Foundation
 import SwiftData
-import WidgetKit
 
 /// Toggles today's completion for a binary or negative habit.
 /// Counter and timer habits need the app's per-type input UI, so
@@ -54,7 +53,6 @@ public struct CompleteHabitIntent: AppIntent {
         // so the snapshot is already current.
         if outcome != .opensApp {
             WidgetSnapshotBuilder.rebuildAndWrite(using: container.mainContext)
-            WidgetCenter.shared.reloadAllTimelines()
         }
         return .result(dialog: Self.dialog(for: outcome, habitName: habit.name))
     }

--- a/Packages/KadoCore/Sources/KadoCore/Services/Intents/LogHabitValueIntent.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Services/Intents/LogHabitValueIntent.swift
@@ -1,7 +1,6 @@
 import AppIntents
 import Foundation
 import SwiftData
-import WidgetKit
 
 /// Logs a numeric value for a counter or timer habit. Spoken from
 /// Siri as "Log 2 for Water" or "Log 15 for Read"; the value's
@@ -82,7 +81,6 @@ public struct LogHabitValueIntent: AppIntent {
         )
         if case .logged = outcome {
             WidgetSnapshotBuilder.rebuildAndWrite(using: container.mainContext)
-            WidgetCenter.shared.reloadAllTimelines()
         }
         return .result(dialog: Self.dialog(for: outcome, habitName: habit.name))
     }

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/PickedSnapshotProvider.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/PickedSnapshotProvider.swift
@@ -5,6 +5,9 @@ import Foundation
 /// `AppIntentTimelineProvider` for the lock widgets that pick a
 /// single habit. Emits an entry with the snapshot + the configured
 /// habit ID; the view plucks the matching row out of the snapshot.
+///
+/// Same timeline shape as `SnapshotTimelineProvider`: one entry per
+/// pre-computed day at its rollover, hourly reload as the safety net.
 public struct PickedSnapshotProvider: AppIntentTimelineProvider {
     public typealias Intent = PickHabitIntent
     public typealias Entry = PickedSnapshotEntry
@@ -24,15 +27,12 @@ public struct PickedSnapshotProvider: AppIntentTimelineProvider {
     }
 
     public func timeline(for configuration: PickHabitIntent, in context: Context) async -> Timeline<PickedSnapshotEntry> {
-        let now = Date.now
-        let entry = PickedSnapshotEntry(
-            date: now,
-            snapshot: WidgetSnapshotStore.read(),
-            habitID: configuration.habit?.id
-        )
-        let nextRefresh = Calendar.current.date(byAdding: .hour, value: 1, to: now)
-            ?? now.addingTimeInterval(3600)
-        return Timeline(entries: [entry], policy: .after(nextRefresh))
+        let plan = WidgetTimelinePlan.make(series: WidgetSnapshotStore.readSeries())
+        let habitID = configuration.habit?.id
+        let entries = plan.slots.map {
+            PickedSnapshotEntry(date: $0.date, snapshot: $0.snapshot, habitID: habitID)
+        }
+        return Timeline(entries: entries, policy: .after(plan.reloadAfter))
     }
 }
 

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/SnapshotTimelineProvider.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/SnapshotTimelineProvider.swift
@@ -2,9 +2,15 @@ import Foundation
 @preconcurrency import WidgetKit
 
 /// Static-configuration provider for widgets that just read the
-/// current `WidgetSnapshot`. Each reload re-reads the App Group
+/// current `WidgetSnapshotSeries`. Each reload re-reads the App Group
 /// JSON file the main app writes on mutations, so the widget
 /// reflects the latest state without ever opening SwiftData.
+///
+/// The timeline carries one entry per pre-computed day, dated at that
+/// day's rollover — under the user's "Day starts at" hour, read from
+/// the same App Group suite the app writes — so the widget shows the
+/// fresh day the moment it begins, app asleep or not. The hourly
+/// reload is the safety net, not the rollover.
 public struct SnapshotTimelineProvider: TimelineProvider, Sendable {
     public init() {}
 
@@ -18,12 +24,9 @@ public struct SnapshotTimelineProvider: TimelineProvider, Sendable {
     }
 
     public func getTimeline(in context: Context, completion: @escaping @Sendable (Timeline<SnapshotEntry>) -> Void) {
-        let now = Date.now
-        let snapshot = WidgetSnapshotStore.read()
-        let entry = SnapshotEntry(date: now, snapshot: snapshot)
-        let nextRefresh = Calendar.current.date(byAdding: .hour, value: 1, to: now)
-            ?? now.addingTimeInterval(3600)
-        completion(Timeline(entries: [entry], policy: .after(nextRefresh)))
+        let plan = WidgetTimelinePlan.make(series: WidgetSnapshotStore.readSeries())
+        let entries = plan.slots.map { SnapshotEntry(date: $0.date, snapshot: $0.snapshot) }
+        completion(Timeline(entries: entries, policy: .after(plan.reloadAfter)))
     }
 }
 

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshot.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshot.swift
@@ -60,6 +60,12 @@ public struct WidgetSnapshot: Codable, Sendable {
         )
     }
 
+    /// The calendar a decoder falls back on for a legacy file's
+    /// `logicalDay` when it has no matrix days to anchor on, passed in
+    /// `Decoder.userInfo`. `WidgetSnapshotStore.decode` sets it; without
+    /// it the device calendar is used.
+    public static let calendarUserInfoKey = CodingUserInfoKey(rawValue: "dev.scastiel.kado.calendar")!
+
     // Backward-compatible decoding: a file written before the series
     // existed carries no `logicalDay`. Its trailing matrix day *is*
     // the logical day it was built for (the builder has always ended
@@ -78,12 +84,17 @@ public struct WidgetSnapshot: Codable, Sendable {
         self.completedToday = try c.decode(Int.self, forKey: .completedToday)
         self.matrix = try c.decode([WidgetMatrixRow].self, forKey: .matrix)
         self.matrixDays = try c.decode([Date].self, forKey: .matrixDays)
+        let calendar = decoder.userInfo[Self.calendarUserInfoKey] as? Calendar ?? .current
         self.logicalDay = try c.decodeIfPresent(Date.self, forKey: .logicalDay)
-            ?? Self.impliedLogicalDay(matrixDays: matrixDays, generatedAt: generatedAt)
+            ?? Self.impliedLogicalDay(matrixDays: matrixDays, generatedAt: generatedAt, calendar: calendar)
     }
 
-    private static func impliedLogicalDay(matrixDays: [Date], generatedAt: Date) -> Date {
-        matrixDays.last ?? Calendar.current.startOfDay(for: generatedAt)
+    private static func impliedLogicalDay(
+        matrixDays: [Date],
+        generatedAt: Date,
+        calendar: Calendar = .current
+    ) -> Date {
+        matrixDays.last ?? calendar.startOfDay(for: generatedAt)
     }
 
     /// The two counts as one value, so the lock-screen ring and the

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshot.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshot.swift
@@ -1,12 +1,22 @@
 import Foundation
 
-/// The data the widget extension reads. Two SwiftData processes
+/// One logical day as the widgets render it. Two SwiftData processes
 /// can't both attach CloudKit to the same store, so widgets stop
-/// using SwiftData altogether. The main app builds this snapshot
-/// after every mutation and writes it as JSON into the App Group;
-/// widgets just decode it.
+/// using SwiftData altogether. The main app builds this after every
+/// mutation and writes it as JSON into the App Group; widgets just
+/// decode it.
+///
+/// A snapshot describes exactly one day — `today`, the counts and the
+/// matrix are all "as of `logicalDay`". The file on disk is a
+/// `WidgetSnapshotSeries`: this day and the ones after it, each
+/// computed as if nothing further were logged, so the widget can turn
+/// the page at the day boundary without either process being awake.
 public struct WidgetSnapshot: Codable, Sendable {
     public let generatedAt: Date
+    /// Midnight of the day this snapshot describes — the logical day
+    /// under the user's "Day starts at" hour, so under a 4 AM start
+    /// a snapshot built at 02:00 names the previous calendar day.
+    public let logicalDay: Date
     public let habits: [WidgetHabit]
     public let today: [WidgetTodayRow]
     public let totalDueToday: Int
@@ -14,6 +24,9 @@ public struct WidgetSnapshot: Codable, Sendable {
     public let matrix: [WidgetMatrixRow]
     public let matrixDays: [Date]
 
+    /// `logicalDay` defaults to the trailing matrix day, which the
+    /// builder already anchors to the logical day — one fewer thing
+    /// for previews and tests to spell out.
     public init(
         generatedAt: Date,
         habits: [WidgetHabit],
@@ -21,7 +34,8 @@ public struct WidgetSnapshot: Codable, Sendable {
         totalDueToday: Int,
         completedToday: Int,
         matrix: [WidgetMatrixRow],
-        matrixDays: [Date]
+        matrixDays: [Date],
+        logicalDay: Date? = nil
     ) {
         self.generatedAt = generatedAt
         self.habits = habits
@@ -30,6 +44,8 @@ public struct WidgetSnapshot: Codable, Sendable {
         self.completedToday = completedToday
         self.matrix = matrix
         self.matrixDays = matrixDays
+        self.logicalDay = logicalDay
+            ?? Self.impliedLogicalDay(matrixDays: matrixDays, generatedAt: generatedAt)
     }
 
     public static var empty: WidgetSnapshot {
@@ -42,6 +58,32 @@ public struct WidgetSnapshot: Codable, Sendable {
             matrix: [],
             matrixDays: []
         )
+    }
+
+    // Backward-compatible decoding: a file written before the series
+    // existed carries no `logicalDay`. Its trailing matrix day *is*
+    // the logical day it was built for (the builder has always ended
+    // the window there), so the fallback loses nothing.
+    private enum CodingKeys: String, CodingKey {
+        case generatedAt, logicalDay, habits, today
+        case totalDueToday, completedToday, matrix, matrixDays
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.generatedAt = try c.decode(Date.self, forKey: .generatedAt)
+        self.habits = try c.decode([WidgetHabit].self, forKey: .habits)
+        self.today = try c.decode([WidgetTodayRow].self, forKey: .today)
+        self.totalDueToday = try c.decode(Int.self, forKey: .totalDueToday)
+        self.completedToday = try c.decode(Int.self, forKey: .completedToday)
+        self.matrix = try c.decode([WidgetMatrixRow].self, forKey: .matrix)
+        self.matrixDays = try c.decode([Date].self, forKey: .matrixDays)
+        self.logicalDay = try c.decodeIfPresent(Date.self, forKey: .logicalDay)
+            ?? Self.impliedLogicalDay(matrixDays: matrixDays, generatedAt: generatedAt)
+    }
+
+    private static func impliedLogicalDay(matrixDays: [Date], generatedAt: Date) -> Date {
+        matrixDays.last ?? Calendar.current.startOfDay(for: generatedAt)
     }
 
     /// The two counts as one value, so the lock-screen ring and the

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftData
+import WidgetKit
 
 /// Builds a `WidgetSnapshot` from SwiftData state. Called on the
 /// app side (main process) after every mutation so the widget
@@ -67,10 +68,14 @@ public enum WidgetSnapshotBuilder {
     /// Costs about one `build`, not seven. The store is read once, and
     /// the score — an EMA walked day by day from the habit's first
     /// completion, by far the expensive part — is walked once per habit
-    /// to the last day, each day reading its own value off that walk.
+    /// to the last day, each day reading its own value off that walk;
     /// `currentScore(asOf:)` is the prefix of the same fold, so the
-    /// numbers are identical; only the streaks, rows and matrix are
-    /// re-derived per day, and those are cheap.
+    /// numbers are identical. Everything else is re-derived per day,
+    /// the best streak included: it looks like a maximum nothing
+    /// unlogged could raise, but for a negative habit an unlogged day
+    /// is a clean one, and two of them in a row *do* raise it.
+    /// `seriesDaysMatchStandaloneBuilds` holds every day of a series to
+    /// a standalone build of that day, across DST shapes.
     public static func buildSeries(
         from context: ModelContext,
         asOf reference: Date = .now,
@@ -103,7 +108,13 @@ public enum WidgetSnapshotBuilder {
                 from: habit.effectiveStart(completions: completions, calendar: calendar),
                 to: last
             )
-            let byDay = Dictionary(history.map { ($0.date, $0.score) }, uniquingKeysWith: { $1 })
+            // Keyed through `startOfDay` on both sides so the match does
+            // not ride on the walk and the series agreeing about which
+            // instant a day begins at.
+            let byDay = Dictionary(
+                history.map { (calendar.startOfDay(for: $0.date), $0.score) },
+                uniquingKeysWith: { $1 }
+            )
             for day in days {
                 // A day before the habit existed has no entry, and
                 // `currentScore` answers zero for it too.
@@ -125,16 +136,20 @@ public enum WidgetSnapshotBuilder {
         )
     }
 
-    /// Convenience: build from the production container and write
-    /// to the App Group JSON in one shot. Safe to call from any
-    /// mutation site.
+    /// Convenience: build from the production container, write to the
+    /// App Group JSON, and tell WidgetKit — in one shot. Safe to call
+    /// from any mutation site.
     ///
-    /// Also where the day-complete celebration is fed. This is the one
-    /// call every mutation path already makes — the views through
-    /// `WidgetReloader`, the intents directly, the app at launch and
-    /// at the day edge — so reporting the day's progress here means no
-    /// surface can complete the day without the confetti hearing about
-    /// it, and none has to remember a second call.
+    /// The reload lives here, not with the callers, for the same reason
+    /// the day-complete celebration does: this is the one call every
+    /// path already makes — the views through `WidgetReloader`, the
+    /// intents directly, the app at launch, at the day edge and on
+    /// foregrounding into a new day. A file written without a reload
+    /// leaves the Home Screen on the old one for up to an hour, and
+    /// with the reload paired by hand at each site that is exactly what
+    /// the launch path did. Reporting the day's progress here likewise
+    /// means no surface can complete the day without the confetti
+    /// hearing about it.
     public static func rebuildAndWrite(using context: ModelContext) {
         // Widgets render a pre-computed snapshot and never ask what day
         // it is — nor which day a week opens on — so both preferences
@@ -148,6 +163,7 @@ public enum WidgetSnapshotBuilder {
             calendar: WeekStartDefaults.calendar()
         )
         WidgetSnapshotStore.write(series)
+        WidgetCenter.shared.reloadAllTimelines()
         // Today's progress only: the days after it are computed with
         // nothing logged, and a day that hasn't started can't be done.
         if let today = series.days.first {

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
@@ -166,7 +166,8 @@ public enum WidgetSnapshotBuilder {
             totalDueToday: todayRows.count,
             completedToday: completed,
             matrix: widgetMatrix,
-            matrixDays: matrixDays
+            matrixDays: matrixDays,
+            logicalDay: today
         )
     }
 
@@ -192,7 +193,9 @@ public enum WidgetSnapshotBuilder {
             asOf: day,
             calendar: WeekStartDefaults.calendar()
         )
-        WidgetSnapshotStore.write(snapshot)
+        WidgetSnapshotStore.write(
+            WidgetSnapshotSeries(generatedAt: snapshot.generatedAt, days: [snapshot])
+        )
         DayCompletionCelebration.shared.observe(snapshot.dayProgress, on: day)
     }
 

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotBuilder.swift
@@ -6,6 +6,11 @@ import SwiftData
 /// always reads fresh data.
 @MainActor
 public enum WidgetSnapshotBuilder {
+    /// How many days `rebuildAndWrite` computes ahead. A week: someone
+    /// who leaves the app closed that long still sees the right due set
+    /// each morning.
+    nonisolated public static let horizonDays = 7
+
     /// Gather everything the widgets need from `context` and
     /// serialize to a single `WidgetSnapshot` value.
     ///
@@ -26,93 +31,197 @@ public enum WidgetSnapshotBuilder {
         streakCalculator: (any StreakCalculating)? = nil,
         frequencyEvaluator: (any FrequencyEvaluating)? = nil
     ) -> WidgetSnapshot {
-        let frequencyEvaluator = frequencyEvaluator
-            ?? DefaultFrequencyEvaluator(calendar: calendar)
-        let scoreCalculator = scoreCalculator
-            ?? DefaultHabitScoreCalculator(
-                calendar: calendar,
-                frequencyEvaluator: frequencyEvaluator
-            )
-        let streakCalculator = streakCalculator
-            ?? DefaultStreakCalculator(calendar: calendar)
-
-        let descriptor = FetchDescriptor<HabitRecord>(
-            sortBy: [SortDescriptor(\.sortOrder)]
+        let services = Services(
+            calendar: calendar,
+            score: scoreCalculator,
+            streak: streakCalculator,
+            frequency: frequencyEvaluator
         )
-        let records = (try? context.fetch(descriptor)) ?? []
-        let active = records.filter { $0.archivedAt == nil }
+        let source = Source(context: context)
+        let scores = source.habits.reduce(into: [UUID: Double]()) { scores, habit in
+            scores[habit.id] = services.score.currentScore(
+                for: habit,
+                completions: source.completions(for: habit),
+                asOf: reference
+            )
+        }
+        return build(
+            source,
+            asOf: reference,
+            scores: scores,
+            services: services,
+            matrixWindowDays: matrixWindowDays
+        )
+    }
+
+    /// The day `reference` falls in plus the `horizonDays - 1` after it,
+    /// each computed as of that morning with nothing further logged.
+    ///
+    /// Nothing here knows it is looking ahead: every calculator answers
+    /// for the reference day it is given, and a future day simply has
+    /// no completions yet. That is exactly what the app itself would
+    /// render that morning — and anything logged in the meantime
+    /// rewrites the whole series, so a later day is never stale
+    /// relative to what the app knows.
+    ///
+    /// Costs about one `build`, not seven. The store is read once, and
+    /// the score — an EMA walked day by day from the habit's first
+    /// completion, by far the expensive part — is walked once per habit
+    /// to the last day, each day reading its own value off that walk.
+    /// `currentScore(asOf:)` is the prefix of the same fold, so the
+    /// numbers are identical; only the streaks, rows and matrix are
+    /// re-derived per day, and those are cheap.
+    public static func buildSeries(
+        from context: ModelContext,
+        asOf reference: Date = .now,
+        calendar: Calendar = .current,
+        horizonDays: Int = Self.horizonDays,
+        matrixWindowDays: Int = 7,
+        scoreCalculator: (any HabitScoreCalculating)? = nil,
+        streakCalculator: (any StreakCalculating)? = nil,
+        frequencyEvaluator: (any FrequencyEvaluating)? = nil
+    ) -> WidgetSnapshotSeries {
+        let services = Services(
+            calendar: calendar,
+            score: scoreCalculator,
+            streak: streakCalculator,
+            frequency: frequencyEvaluator
+        )
+        let source = Source(context: context)
+        let first = calendar.startOfDay(for: reference)
+        let days = (0..<max(horizonDays, 1)).compactMap { offset in
+            calendar.date(byAdding: .day, value: offset, to: first)
+        }
+        guard let last = days.last else { return .empty }
+
+        var scoresByDay: [Date: [UUID: Double]] = [:]
+        for habit in source.habits {
+            let completions = source.completions(for: habit)
+            let history = services.score.scoreHistory(
+                for: habit,
+                completions: completions,
+                from: habit.effectiveStart(completions: completions, calendar: calendar),
+                to: last
+            )
+            let byDay = Dictionary(history.map { ($0.date, $0.score) }, uniquingKeysWith: { $1 })
+            for day in days {
+                // A day before the habit existed has no entry, and
+                // `currentScore` answers zero for it too.
+                scoresByDay[day, default: [:]][habit.id] = byDay[calendar.startOfDay(for: day)] ?? 0
+            }
+        }
+
+        return WidgetSnapshotSeries(
+            generatedAt: .now,
+            days: days.map { day in
+                build(
+                    source,
+                    asOf: day,
+                    scores: scoresByDay[day] ?? [:],
+                    services: services,
+                    matrixWindowDays: matrixWindowDays
+                )
+            }
+        )
+    }
+
+    /// Convenience: build from the production container and write
+    /// to the App Group JSON in one shot. Safe to call from any
+    /// mutation site.
+    ///
+    /// Also where the day-complete celebration is fed. This is the one
+    /// call every mutation path already makes — the views through
+    /// `WidgetReloader`, the intents directly, the app at launch and
+    /// at the day edge — so reporting the day's progress here means no
+    /// surface can complete the day without the confetti hearing about
+    /// it, and none has to remember a second call.
+    public static func rebuildAndWrite(using context: ModelContext) {
+        // Widgets render a pre-computed snapshot and never ask what day
+        // it is — nor which day a week opens on — so both preferences
+        // have to be resolved here, once. The week start reaches the
+        // streak calculator, whose `.daysPerWeek` count is bucketed
+        // into whole calendar weeks.
+        let day = DayStartDefaults.boundary().startOfDay(for: .now)
+        let series = buildSeries(
+            from: context,
+            asOf: day,
+            calendar: WeekStartDefaults.calendar()
+        )
+        WidgetSnapshotStore.write(series)
+        // Today's progress only: the days after it are computed with
+        // nothing logged, and a day that hasn't started can't be done.
+        if let today = series.days.first {
+            DayCompletionCelebration.shared.observe(today.dayProgress, on: day)
+        }
+    }
+
+    // MARK: - One day
+
+    /// One day's snapshot from an already-read `Source`, with the
+    /// per-habit scores handed in so a series can share one walk.
+    private static func build(
+        _ source: Source,
+        asOf reference: Date,
+        scores: [UUID: Double],
+        services: Services,
+        matrixWindowDays: Int
+    ) -> WidgetSnapshot {
+        let calendar = services.calendar
 
         // Compute per-habit stats once. Reused across the three
         // WidgetHabit construction sites (top-level, today rows,
         // matrix rows) so consumers see consistent values.
         struct HabitStats { let current: Int; let best: Int; let score: Double }
         var statsByID: [UUID: HabitStats] = [:]
-        for record in active {
-            let snap = record.snapshot
-            let comps = (record.completions ?? []).compactMap(\.snapshot)
-            statsByID[snap.id] = HabitStats(
-                current: streakCalculator.current(for: snap, completions: comps, asOf: reference),
-                best: streakCalculator.best(for: snap, completions: comps, asOf: reference),
-                score: scoreCalculator.currentScore(for: snap, completions: comps, asOf: reference)
+        for habit in source.habits {
+            let completions = source.completions(for: habit)
+            statsByID[habit.id] = HabitStats(
+                current: services.streak.current(for: habit, completions: completions, asOf: reference),
+                best: services.streak.best(for: habit, completions: completions, asOf: reference),
+                score: scores[habit.id] ?? 0
             )
         }
 
-        func makeWidgetHabit(from record: HabitRecord) -> WidgetHabit {
-            let stats = statsByID[record.id]
+        func makeWidgetHabit(from habit: Habit) -> WidgetHabit {
+            let stats = statsByID[habit.id]
             return WidgetHabit(
-                id: record.id,
-                name: record.name,
-                color: record.color,
-                icon: record.icon,
-                typeKind: mapTypeKind(record.type),
-                target: mapTarget(record.type),
+                id: habit.id,
+                name: habit.name,
+                color: habit.color,
+                icon: habit.icon,
+                typeKind: mapTypeKind(habit.type),
+                target: mapTarget(habit.type),
                 currentStreak: stats?.current ?? 0,
                 bestStreak: stats?.best ?? 0,
                 currentScore: stats?.score ?? 0
             )
         }
 
-        func makeWidgetHabit(from snap: Habit) -> WidgetHabit {
-            let stats = statsByID[snap.id]
-            return WidgetHabit(
-                id: snap.id,
-                name: snap.name,
-                color: snap.color,
-                icon: snap.icon,
-                typeKind: mapTypeKind(snap.type),
-                target: mapTarget(snap.type),
-                currentStreak: stats?.current ?? 0,
-                bestStreak: stats?.best ?? 0,
-                currentScore: stats?.score ?? 0
-            )
-        }
-
-        let widgetHabits = active.map(makeWidgetHabit(from:))
+        let widgetHabits = source.habits.map(makeWidgetHabit(from:))
 
         var todayRows: [WidgetTodayRow] = []
         var completed = 0
-        for record in active {
-            let snap = record.snapshot
-            let comps = (record.completions ?? []).compactMap(\.snapshot)
+        for habit in source.habits {
+            let completions = source.completions(for: habit)
             // Without the "or logged today" arm a habit vanishes from
             // the widget the moment it is completed past a weekly
             // quota, taking its own tick out of `completedToday`.
             // Shared with the Today tab so the two can't drift.
-            guard frequencyEvaluator.isDueOrLogged(
-                habit: snap,
+            guard services.frequency.isDueOrLogged(
+                habit: habit,
                 on: reference,
-                completions: comps,
+                completions: completions,
                 calendar: calendar
             ) else {
                 continue
             }
             let state = HabitRowState.resolve(
-                habit: snap,
-                completions: comps,
+                habit: habit,
+                completions: completions,
                 calendar: calendar,
                 asOf: reference
             )
-            let widgetHabit = makeWidgetHabit(from: snap)
+            let widgetHabit = makeWidgetHabit(from: habit)
             todayRows.append(
                 WidgetTodayRow(
                     habit: widgetHabit,
@@ -131,7 +240,7 @@ public enum WidgetSnapshotBuilder {
             // Not `status == .complete`: for a negative habit that is a
             // slip, and the day's tally must not count giving in as
             // getting it done.
-            if state.isDone(for: snap) { completed += 1 }
+            if state.isDone(for: habit) { completed += 1 }
         }
 
         // Matrix window (last N days ending today).
@@ -139,15 +248,13 @@ public enum WidgetSnapshotBuilder {
         let matrixDays: [Date] = (0..<matrixWindowDays).reversed().compactMap { offset in
             calendar.date(byAdding: .day, value: -offset, to: today)
         }
-        let habits = active.map(\.snapshot)
-        let allCompletions = active.flatMap { ($0.completions ?? []).compactMap(\.snapshot) }
         let matrix = OverviewMatrix.compute(
-            habits: habits,
-            completions: allCompletions,
+            habits: source.habits,
+            completions: source.allCompletions,
             days: matrixDays,
             today: reference,
             calendar: calendar,
-            frequencyEvaluator: frequencyEvaluator
+            frequencyEvaluator: services.frequency
         )
         let widgetMatrix = matrix.map { row in
             WidgetMatrixRow(
@@ -171,32 +278,58 @@ public enum WidgetSnapshotBuilder {
         )
     }
 
-    /// Convenience: build from the production container and write
-    /// to the App Group JSON in one shot. Safe to call from any
-    /// mutation site.
-    ///
-    /// Also where the day-complete celebration is fed. This is the one
-    /// call every mutation path already makes — the views through
-    /// `WidgetReloader`, the intents directly, the app at launch and
-    /// at the day edge — so reporting the day's progress here means no
-    /// surface can complete the day without the confetti hearing about
-    /// it, and none has to remember a second call.
-    public static func rebuildAndWrite(using context: ModelContext) {
-        // Widgets render a pre-computed snapshot and never ask what day
-        // it is — nor which day a week opens on — so both preferences
-        // have to be resolved here, once. The week start reaches the
-        // streak calculator, whose `.daysPerWeek` count is bucketed
-        // into whole calendar weeks.
-        let day = DayStartDefaults.boundary().startOfDay(for: .now)
-        let snapshot = build(
-            from: context,
-            asOf: day,
-            calendar: WeekStartDefaults.calendar()
-        )
-        WidgetSnapshotStore.write(
-            WidgetSnapshotSeries(generatedAt: snapshot.generatedAt, days: [snapshot])
-        )
-        DayCompletionCelebration.shared.observe(snapshot.dayProgress, on: day)
+    // MARK: - Inputs
+
+    /// The calculators a build runs on, resolved once per call rather
+    /// than per day.
+    private struct Services {
+        let calendar: Calendar
+        let score: any HabitScoreCalculating
+        let streak: any StreakCalculating
+        let frequency: any FrequencyEvaluating
+
+        init(
+            calendar: Calendar,
+            score: (any HabitScoreCalculating)?,
+            streak: (any StreakCalculating)?,
+            frequency: (any FrequencyEvaluating)?
+        ) {
+            let frequency = frequency ?? DefaultFrequencyEvaluator(calendar: calendar)
+            self.calendar = calendar
+            self.frequency = frequency
+            self.score = score
+                ?? DefaultHabitScoreCalculator(calendar: calendar, frequencyEvaluator: frequency)
+            self.streak = streak ?? DefaultStreakCalculator(calendar: calendar)
+        }
+    }
+
+    /// Everything the builder reads from the store, pulled once — and
+    /// once only for a whole series. Faulting every habit's completions
+    /// is the one SwiftData cost here, and it does not depend on the
+    /// day being built.
+    private struct Source {
+        /// Active habits, in the user's order.
+        let habits: [Habit]
+        private let completionsByHabit: [UUID: [Completion]]
+        let allCompletions: [Completion]
+
+        init(context: ModelContext) {
+            let descriptor = FetchDescriptor<HabitRecord>(
+                sortBy: [SortDescriptor(\.sortOrder)]
+            )
+            let records = ((try? context.fetch(descriptor)) ?? []).filter { $0.archivedAt == nil }
+            var byHabit: [UUID: [Completion]] = [:]
+            for record in records {
+                byHabit[record.id] = (record.completions ?? []).compactMap(\.snapshot)
+            }
+            habits = records.map(\.snapshot)
+            completionsByHabit = byHabit
+            allCompletions = habits.flatMap { byHabit[$0.id] ?? [] }
+        }
+
+        func completions(for habit: Habit) -> [Completion] {
+            completionsByHabit[habit.id] ?? []
+        }
     }
 
     // MARK: - Mapping helpers

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotSeries.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotSeries.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// What the App Group file holds: the day the app wrote it on, followed
+/// by the days after it — each one computed as of that morning with
+/// nothing further logged.
+///
+/// The widget cannot rebuild a snapshot (it never opens SwiftData) and
+/// the app cannot be relied on to rebuild one at the boundary (asleep,
+/// it never fires). But every calculator is a pure function of the data
+/// and a reference day, so the app can compute tomorrow *today*, and the
+/// day after, and hand WidgetKit one timeline entry per day. Whatever is
+/// logged later rewrites the whole series, so a future day is never
+/// stale relative to what the app knows.
+public struct WidgetSnapshotSeries: Codable, Sendable {
+    public let generatedAt: Date
+    /// Ascending by `logicalDay`, consecutive, `days[0]` being the day
+    /// the series was written on.
+    public let days: [WidgetSnapshot]
+
+    public init(generatedAt: Date, days: [WidgetSnapshot]) {
+        self.generatedAt = generatedAt
+        self.days = days
+    }
+
+    public static var empty: WidgetSnapshotSeries {
+        WidgetSnapshotSeries(generatedAt: .now, days: [])
+    }
+
+    /// The snapshot that answers for `now`: the latest day not after
+    /// the logical day `now` falls in.
+    ///
+    /// Past the horizon that is the last day we have — a "nothing
+    /// logged" state that can be wrong about which habits are due, but
+    /// can never show ticks from a day that is over. Before the first
+    /// day (a clock set back) the first day answers. An empty series
+    /// resolves to `.empty`, so a missing or unreadable file renders
+    /// the same rest-day state it always has.
+    public func snapshot(on now: Date, boundary: DayBoundary) -> WidgetSnapshot {
+        let current = boundary.startOfDay(for: now)
+        return days.last(where: { $0.logicalDay <= current })
+            ?? days.first
+            ?? .empty
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotStore.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotStore.swift
@@ -56,9 +56,12 @@ public enum WidgetSnapshotStore {
     /// Decodes a series, or a file written before the series existed —
     /// a bare `WidgetSnapshot` object — as a one-day series. Nil for
     /// anything else; never traps on what another build wrote.
-    public static func decode(_ data: Data) -> WidgetSnapshotSeries? {
+    /// `calendar` only matters for a legacy file with no matrix days,
+    /// whose day is taken from `generatedAt`.
+    public static func decode(_ data: Data, calendar: Calendar = .current) -> WidgetSnapshotSeries? {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
+        decoder.userInfo[WidgetSnapshot.calendarUserInfoKey] = calendar
         if let series = try? decoder.decode(WidgetSnapshotSeries.self, from: data) {
             return series
         }

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotStore.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetSnapshotStore.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Reads and writes `WidgetSnapshot` to a JSON file inside the
+/// Reads and writes the `WidgetSnapshotSeries` JSON file inside the
 /// App Group container. The main app writes; the widget reads.
 public enum WidgetSnapshotStore {
     /// Location of the on-disk snapshot file inside the App Group
@@ -12,16 +12,12 @@ public enum WidgetSnapshotStore {
         return dir.appendingPathComponent("widget-snapshot.json")
     }
 
-    /// Encode + write a snapshot. Silent on failure — widgets will
-    /// fall back to their empty state if the file is missing or
-    /// corrupt.
-    public static func write(_ snapshot: WidgetSnapshot) {
+    /// Encode + write a series. Silent on failure — widgets will fall
+    /// back to their empty state if the file is missing or corrupt.
+    public static func write(_ series: WidgetSnapshotSeries) {
         guard let url = url() else { return }
         do {
-            let encoder = JSONEncoder()
-            encoder.dateEncodingStrategy = .iso8601
-            let data = try encoder.encode(snapshot)
-            try data.write(to: url, options: .atomic)
+            try encode(series).write(to: url, options: .atomic)
         } catch {
             // Snapshot write is best-effort; widgets will render
             // whatever the last successful snapshot was, or the
@@ -29,14 +25,46 @@ public enum WidgetSnapshotStore {
         }
     }
 
-    /// Read the snapshot, returning `.empty` on any failure.
-    public static func read() -> WidgetSnapshot {
+    /// Read the whole series, `.empty` on any failure.
+    public static func readSeries() -> WidgetSnapshotSeries {
         guard let url = url(),
               let data = try? Data(contentsOf: url) else {
             return .empty
         }
+        return decode(data) ?? .empty
+    }
+
+    /// The snapshot for the current logical day — for readers that want
+    /// one day and no timeline (`GetHabitStatsIntent`, `HabitEntity`).
+    /// Resolved under the user's "Day starts at" hour, which lives in
+    /// the same App Group suite and so reads the same in both processes.
+    public static func read() -> WidgetSnapshot {
+        readSeries().snapshot(on: .now, boundary: DayStartDefaults.boundary())
+    }
+
+    // MARK: - Codec
+
+    /// The file IO above is untestable without the App Group; the two
+    /// codec halves are what tests pin, the legacy fallback especially.
+
+    public static func encode(_ series: WidgetSnapshotSeries) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(series)
+    }
+
+    /// Decodes a series, or a file written before the series existed —
+    /// a bare `WidgetSnapshot` object — as a one-day series. Nil for
+    /// anything else; never traps on what another build wrote.
+    public static func decode(_ data: Data) -> WidgetSnapshotSeries? {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return (try? decoder.decode(WidgetSnapshot.self, from: data)) ?? .empty
+        if let series = try? decoder.decode(WidgetSnapshotSeries.self, from: data) {
+            return series
+        }
+        guard let legacy = try? decoder.decode(WidgetSnapshot.self, from: data) else {
+            return nil
+        }
+        return WidgetSnapshotSeries(generatedAt: legacy.generatedAt, days: [legacy])
     }
 }

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetTimelinePlan.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetTimelinePlan.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The entries a widget hands WidgetKit, planned from the series on
+/// disk: the current day at `now`, then one slot per pre-computed day
+/// after it, dated at the instant that day begins. WidgetKit turns the
+/// page at each date in its own render server, so the widget rolls
+/// over at the boundary with neither the app nor the extension awake —
+/// the reload iOS may throttle is no longer what the rollover rides on.
+///
+/// Both providers map this into their own entry type; the planning
+/// itself imports nothing from WidgetKit so it can be pinned in the
+/// unit suite, DST edges included.
+public struct WidgetTimelinePlan: Sendable {
+    public struct Slot: Sendable {
+        public let date: Date
+        public let snapshot: WidgetSnapshot
+    }
+
+    /// Never empty; `slots[0].date == now`.
+    public let slots: [Slot]
+
+    /// When to ask for a fresh plan: the hourly reload the providers
+    /// always had, kept as the safety net for a write that reached the
+    /// file without a `reloadAllTimelines` alongside it.
+    public let reloadAfter: Date
+
+    public static func make(
+        series: WidgetSnapshotSeries,
+        now: Date = .now,
+        boundary: DayBoundary = DayStartDefaults.boundary()
+    ) -> WidgetTimelinePlan {
+        let current = boundary.startOfDay(for: now)
+        var slots = [Slot(date: now, snapshot: series.snapshot(on: now, boundary: boundary))]
+
+        // The series is consecutive, so each day after the current one
+        // begins at the next rollover. A day that does not line up with
+        // its edge — a zone change between write and read — is left
+        // out rather than shown on the wrong date.
+        var edge = boundary.nextRollover(after: now)
+        for day in series.days where day.logicalDay > current {
+            guard boundary.startOfDay(for: edge) == day.logicalDay else { continue }
+            slots.append(Slot(date: edge, snapshot: day))
+            edge = boundary.nextRollover(after: edge)
+        }
+
+        let calendar = boundary.calendar
+        let reloadAfter = calendar.date(byAdding: .hour, value: 1, to: now)
+            ?? now.addingTimeInterval(3600)
+        return WidgetTimelinePlan(slots: slots, reloadAfter: reloadAfter)
+    }
+}

--- a/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetTimelinePlan.swift
+++ b/Packages/KadoCore/Sources/KadoCore/Widgets/WidgetTimelinePlan.swift
@@ -32,18 +32,17 @@ public struct WidgetTimelinePlan: Sendable {
         let current = boundary.startOfDay(for: now)
         var slots = [Slot(date: now, snapshot: series.snapshot(on: now, boundary: boundary))]
 
-        // The series is consecutive, so each day after the current one
-        // begins at the next rollover. A day that does not line up with
-        // its edge — a zone change between write and read — is left
-        // out rather than shown on the wrong date.
-        var edge = boundary.nextRollover(after: now)
+        // Each later day is dated from its own `logicalDay`, never
+        // relative to its neighbours, so a gap in the series costs
+        // nothing and a day that isn't a midnight in this zone — a zone
+        // change between write and read — costs only that day, rather
+        // than landing on a neighbour's date.
+        let calendar = boundary.calendar
         for day in series.days where day.logicalDay > current {
-            guard boundary.startOfDay(for: edge) == day.logicalDay else { continue }
-            slots.append(Slot(date: edge, snapshot: day))
-            edge = boundary.nextRollover(after: edge)
+            guard calendar.startOfDay(for: day.logicalDay) == day.logicalDay else { continue }
+            slots.append(Slot(date: boundary.rollover(into: day.logicalDay), snapshot: day))
         }
 
-        let calendar = boundary.calendar
         let reloadAfter = calendar.date(byAdding: .hour, value: 1, to: now)
             ?? now.addingTimeInterval(3600)
         return WidgetTimelinePlan(slots: slots, reloadAfter: reloadAfter)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -100,6 +100,9 @@ flow genuinely can't serve.
       there is no official export)
 
 ### Quality
+- [x] Rollover-aware widgets — the app pre-computes the week ahead and
+      the widget turns the page at the day boundary on its own, app
+      asleep or not (#82; `docs/plans/2026-09/widget-day-rollover/`)
 - [ ] Unit test suite with >80% coverage on business logic
 - [x] UI tests on the critical flows — `KadoUITests` target added,
       `make e2e` runs it
@@ -320,12 +323,6 @@ noted inline.
 ## Later — to be decided after user listening
 
 **To consider based on feedback**:
-- **Rollover-aware widget refresh** — `SnapshotTimelineProvider` asks
-  for a reload every hour and the snapshot is only rebuilt on app
-  mutation, so a widget can show a stale "today" across a day
-  boundary. Pre-existing (true at midnight today), surfaced while
-  building the day-start hour. See
-  `docs/plans/2026-08/day-start-hour/compound.md`.
 - **iCloud-sync the "Day starts at" hour** via
   `NSUbiquitousKeyValueStore` so iPhone and iPad don't each need it
   set. Device-local today; disagreement causes no corruption, since a

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -1,7 +1,7 @@
 # Plan — Widget day rollover
 
 **Date**: 2026-09-11
-**Status**: draft
+**Status**: ready to build
 **Research**: none — planned from
 [issue #82](https://github.com/scastiel/kado/issues/82), whose analysis
 was verified line by line against the code (see *Verified premises*).
@@ -349,12 +349,14 @@ closes #82.**
 
 ## Open questions
 
-- [ ] Confirm the approach — pre-computed days + timeline entries —
-  over shipping raw data to the widget.
-- [ ] Confirm the 7-day horizon (vs. 2–3 days if the Task 6
-  measurement is unkind).
-- [ ] Confirm `BGAppRefreshTask` stays out of scope.
-- [ ] Open a draft PR on `feature/widget-day-rollover` now?
+All four resolved on 2026-09-11 with the plan's recommendations:
+
+- [x] Approach — pre-computed days + timeline entries, not raw data
+  in the widget.
+- [x] Horizon — 7 days (Task 6 still measures; drop to 3 only if the
+  numbers are unkind).
+- [x] `BGAppRefreshTask` — out of scope.
+- [x] Draft PR — opened on `feature/widget-day-rollover`.
 
 ## Out of scope
 

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -1,7 +1,7 @@
 # Plan — Widget day rollover
 
 **Date**: 2026-09-11
-**Status**: ready to build
+**Status**: in progress
 **Research**: none — planned from
 [issue #82](https://github.com/scastiel/kado/issues/82), whose analysis
 was verified line by line against the code (see *Verified premises*).
@@ -111,7 +111,7 @@ Each claim in the issue, checked against `main` (32e79f9):
 
 ## Task list
 
-### Task 1: Series and `logicalDay` — tests
+### Task 1: Series and `logicalDay` — tests ✅
 
 **Goal**: Pin the on-disk shape and the day-selection rule before
 touching the store.
@@ -139,7 +139,7 @@ touching the store.
 
 ---
 
-### Task 2: `WidgetSnapshot.logicalDay` + `WidgetSnapshotSeries` + store
+### Task 2: `WidgetSnapshot.logicalDay` + `WidgetSnapshotSeries` + store ✅
 
 **Goal**: The file carries a list of days; every reader still gets a
 single-day snapshot.

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -1,0 +1,367 @@
+# Plan — Widget day rollover
+
+**Date**: 2026-09-11
+**Status**: draft
+**Research**: none — planned from
+[issue #82](https://github.com/scastiel/kado/issues/82), whose analysis
+was verified line by line against the code (see *Verified premises*).
+
+## Summary
+
+The Home Screen and Lock Screen widgets keep showing yesterday's ticks
+and progress until the user logs a habit, because they render a
+snapshot the app pre-computed for the day it was written on, and
+nothing rebuilds that snapshot across the day boundary while the app is
+asleep. The fix: the app already knows how to compute any day's state
+(`WidgetSnapshotBuilder.build(asOf:)` is a pure function of the data
+and a reference day), so it writes **today plus the next six days** —
+each one "as of that morning, nothing further logged" — and the widget
+hands WidgetKit **one timeline entry per day**, dated at that day's
+rollover instant. WidgetKit flips the entry at the boundary in its own
+render server, with neither process awake. The widget stays a pure
+renderer; the custom "Day starts at" hour is honoured on both sides.
+
+## Verified premises
+
+Each claim in the issue, checked against `main` (32e79f9):
+
+- `SnapshotTimelineProvider.getTimeline` and
+  `PickedSnapshotProvider.timeline` each emit a single entry at `now`
+  with `.after(now + 1h)`, on `Calendar.current`, and never consult
+  `DayStartDefaults`. Confirmed.
+- `KadoApp.advanceAtNextDayEdge` is a `Task.sleep` in-process. On
+  foreground with a changed day, `.onChange(of: scenePhase)` bumps
+  `clockMark`, which cancels that task (`Task.sleep` throws, the body
+  returns before `WidgetReloader.reloadAll`) and restarts it for the
+  *next* edge. No rebuild. Confirmed. The launch `.task` calls
+  `rebuildAndWrite` without `reloadAllTimelines`, so a cold launch
+  rewrites the file but leaves the widget on the old one for up to an
+  hour.
+- Every input to a day's state — `DefaultFrequencyEvaluator`,
+  `DefaultHabitScoreCalculator`, `DefaultStreakCalculator`,
+  `HabitRowState.resolve`, `OverviewMatrix.compute` — is driven by the
+  `asOf:` / `on:` / `today:` argument. **No wall-clock reads** in any
+  of them (grepped `.now` / `Date()`). So `build(asOf: tomorrow)` is
+  well-defined and equals what the app itself would render tomorrow
+  morning before anything is logged.
+- The widget extension carries the App Group entitlement, so
+  `DayStartDefaults.boundary()` resolves to the same hour in both
+  processes. Confirmed (`KadoWidgetsExtension.entitlements`).
+- Other readers of the snapshot file: `GetHabitStatsIntent` and
+  `HabitEntity` (both read `.habits` only), plus the screenshot
+  gallery, which calls `build` directly for one day and is unaffected.
+- The day-start-hour compound already flagged this as "rollover-aware
+  widget refresh", and `docs/ROADMAP.md` carries it under *To consider
+  based on feedback*. That entry gets closed by this work.
+
+## Decisions locked in
+
+- **Pre-compute upcoming days app-side; the widget selects, never
+  derives.** Three options were weighed:
+  - *Reset stale rows in the widget* (clear ticks when the snapshot's
+    day ≠ today) — cheap, but the *set* of due habits is still
+    yesterday's: a `specificDays` habit due only today never appears,
+    a `daysPerWeek` habit that met its quota yesterday keeps showing.
+    Fails the issue's "today's due habits" expectation.
+  - *Ship raw data and re-derive in the widget* — correct, but moves
+    the calculators into the widget process, needs full history for
+    scores, and breaks the "widgets never ask what day it is" rule
+    the rest of the architecture leans on.
+  - *Pre-compute N days in the app* ← chosen. Reuses `build(asOf:)`
+    unchanged, exact for every frequency, zero new logic in the
+    extension, and the switch is done by WidgetKit's timeline rather
+    than by a reload iOS may throttle.
+- **Horizon: 7 days** (today + 6). A user who doesn't open the app
+  all week still sees the right due set each morning. Cost is 7×
+  `build` per mutation — score and streak are O(history) per habit,
+  so on the order of 10⁵ trivial ops for 20 habits with years of
+  data; measured in Task 6 with the dev-mode seed before committing
+  to the number.
+- **A `logicalDay` on every `WidgetSnapshot`, and a
+  `WidgetSnapshotSeries` as the on-disk shape.** The single-day
+  `WidgetSnapshot` keeps its shape (views and previews untouched);
+  the file becomes `{ generatedAt, days: [WidgetSnapshot] }`. A
+  pre-upgrade file on disk (a bare `WidgetSnapshot` object) decodes
+  as a one-day series whose `logicalDay` falls back to
+  `matrixDays.last` — the same fallback `WidgetHabit` already uses
+  for its stats fields.
+- **Timeline planning is a pure, tested function** shared by both
+  providers: `(series, now, boundary) → [(date, snapshot)] +
+  reloadAfter`. Slot 0 is `now` with the current logical day's
+  snapshot; each later slot sits at `boundary.nextRollover` of the
+  previous one. The providers become one-liners over it.
+- **Selection rule when the current day is not in the series**:
+  greatest `logicalDay ≤ current day`, else the first, else `.empty`.
+  Beyond the horizon that is the latest "nothing logged" state — it
+  can still be wrong about the due set, but it can never show stale
+  ticks.
+- **Keep the hourly `.after` reload.** It remains the safety net for
+  a write that wasn't paired with a `reloadAllTimelines` (none exist
+  today, but the intents each call the pair by hand); the entries
+  handle the boundary regardless of when the reload lands.
+- **App side, belt and braces**: foregrounding on a new day calls
+  `WidgetReloader.reloadAll` in addition to bumping `clockMark`.
+  Three lines; covers beyond-horizon staleness and any data that
+  landed while suspended.
+- **No `BGAppRefreshTask`.** With the timeline entries the boundary
+  switch no longer depends on the app running, so the task would only
+  serve the beyond-horizon case and would cost a Background Modes
+  capability plus an `Info.plist` identifier for a run iOS does not
+  promise. Out of scope; revisit only if reports persist past the fix.
+
+## Task list
+
+### Task 1: Series and `logicalDay` — tests
+
+**Goal**: Pin the on-disk shape and the day-selection rule before
+touching the store.
+
+**Changes**:
+- New `KadoTests/WidgetSnapshotSeriesTests.swift`.
+
+**Tests / verification**:
+- A series round-trips through the store's encoder/decoder with
+  `logicalDay` intact on every day.
+- A pre-upgrade file — a bare `WidgetSnapshot` JSON object with no
+  `logicalDay` and no `days` wrapper — decodes as a one-day series
+  whose `logicalDay == matrixDays.last`. Build the fixture by
+  encoding a current snapshot and deleting the key with
+  `JSONSerialization`, per the "don't hand-type serialized strings"
+  rule; a snapshot with empty `matrixDays` falls back to the calendar
+  midnight of `generatedAt`.
+- `snapshot(on:boundary:)` picks the greatest `logicalDay ≤` the
+  current logical day; before the first day it returns the first;
+  on an empty series it returns `.empty`. Under `startHour: 4`,
+  02:00 on calendar day D1 resolves to D0's snapshot.
+- Red at this point: the types don't exist.
+
+**Commit message (suggested)**: `test(widgets): pin the snapshot series shape and day selection`
+
+---
+
+### Task 2: `WidgetSnapshot.logicalDay` + `WidgetSnapshotSeries` + store
+
+**Goal**: The file carries a list of days; every reader still gets a
+single-day snapshot.
+
+**Changes**:
+- `WidgetSnapshot.swift`: add `logicalDay: Date`; an `init(from:)`
+  that falls back as Task 1 specifies; `init(...)` takes
+  `logicalDay: Date? = nil` resolved in the body so `.empty`,
+  `PreviewSnapshots`, and `DayProgressTests` keep compiling. New
+  `WidgetSnapshotSeries: Codable, Sendable` (`generatedAt`,
+  `days` ascending) with `snapshot(on:boundary:)`.
+- `WidgetSnapshotStore.swift`: pure `encode(_:) -> Data` /
+  `decode(_:) -> WidgetSnapshotSeries` statics (series first, legacy
+  single-snapshot fallback) that the file IO calls; `write(_
+  series:)`; `readSeries()`; `read()` becomes
+  `readSeries().snapshot(on: .now, boundary: DayStartDefaults.boundary())`
+  so `GetHabitStatsIntent` / `HabitEntity` are untouched.
+- `WidgetSnapshotBuilder.build` sets `logicalDay` to the reference
+  day; `rebuildAndWrite` writes a one-day series for now.
+- Doc comment on `WidgetSnapshot` explains the day/series split.
+
+**Tests / verification**:
+- Task 1 green; `WidgetSnapshotBuilderTests` and
+  `LogicalDaySurfacesTests` still green; `build_sim` clean.
+
+**Commit message (suggested)**: `feat(widgets): store the snapshot as a series of logical days`
+
+---
+
+### Task 3: Timeline plan — tests
+
+**Goal**: Spec the entries the providers hand WidgetKit, across day
+starts and DST shapes, before writing the planner.
+
+**Changes**:
+- New `KadoTests/WidgetTimelinePlanTests.swift`, on `TestCalendar`
+  fixtures.
+
+**Tests / verification**:
+- Series D0…D6, now = D0 10:00 (UTC, `startHour: 0`): seven slots;
+  slot 0 at `now` with D0; slot *k* at D*k* midnight with D*k*.
+- now = D2 09:00: slot 0 is D2 at `now`; D0 and D1 are dropped;
+  D3…D6 follow.
+- now = D9: a single slot, D6's snapshot — never D0's ticks.
+- Empty series: a single `.empty` slot at `now`.
+- `startHour: 4`, now = D1 02:00: slot 0 is D0; slot 1 at D1 04:00.
+- **Invariant sweep**, per CLAUDE.md, over `utc`, `paris`, `havana`
+  around each zone's transition windows: slot dates are strictly
+  ascending, every slot after the first equals
+  `boundary.nextRollover(after:)` of the previous slot's date, and
+  `boundary.startOfDay(for: slot.date) == slot.snapshot.logicalDay`.
+- `reloadAfter` is one calendar hour after `now`.
+
+**Commit message (suggested)**: `test(widgets): spec the day-aware widget timeline`
+
+---
+
+### Task 4: `WidgetTimelinePlan` and the two providers
+
+**Goal**: Both providers emit one entry per pre-computed day, dated at
+the day's rollover, using the user's day-start hour.
+
+**Changes**:
+- New `Widgets/WidgetTimelinePlan.swift` (`nonisolated`, `Sendable`):
+  `Slot { date, snapshot }`, `slots`, `reloadAfter`,
+  `static func make(series:now:boundary:calendar:)`.
+- `SnapshotTimelineProvider`: `getTimeline` maps the plan into
+  `SnapshotEntry`s with `.after(plan.reloadAfter)`; `getSnapshot`
+  uses `series.snapshot(on:boundary:)`. Boundary from
+  `DayStartDefaults.boundary()`.
+- `PickedSnapshotProvider`: same, carrying `habitID` into each entry.
+- Header comments on both providers rewritten: the hourly reload is
+  the safety net, the entries are the rollover.
+
+**Tests / verification**:
+- Task 3 green. `build_sim` for the `KadoWidgets` scheme as well as
+  `Kado` — `@preconcurrency import WidgetKit` stays; the planner must
+  not import WidgetKit so it is testable without an entry type.
+- Widget previews (`#Preview … timeline:`) unchanged and rendering.
+
+**Commit message (suggested)**: `feat(widgets): plan one timeline entry per logical day`
+
+---
+
+### Task 5: Series builder — tests
+
+**Goal**: Pin what "tomorrow morning, nothing logged" means for each
+habit shape before the builder writes it.
+
+**Changes**:
+- `KadoTests/WidgetSnapshotBuilderTests.swift` additions.
+
+**Tests / verification**:
+- `buildSeries(horizonDays: 7)` yields seven days with consecutive
+  `logicalDay`s, each equal to that day's `matrixDays.last`.
+- A binary habit completed today: `days[0].completedToday == 1`;
+  `days[1]` has the row at `.none`, `progress == 0`,
+  `valueToday == nil`, `completedToday == 0`.
+- `daysPerWeek(1)` completed today: present in `days[0].today` (the
+  "or logged" arm) and absent from `days[1].today`.
+- `specificDays([tomorrow's weekday])`: absent from `days[0].today`,
+  present in `days[1].today` — the property the reset approach could
+  not deliver.
+- Daily habit done yesterday and today: `days[1]` streak is 2; done
+  yesterday only: `days[1]` streak is 0 — documents that a future day
+  is "the truth that morning", not a copy of today.
+- A negative habit is counted done on `days[1]` (until it slips),
+  matching Today.
+
+**Commit message (suggested)**: `test(widgets): spec the pre-computed upcoming days`
+
+---
+
+### Task 6: `buildSeries` + `rebuildAndWrite` writes the horizon
+
+**Goal**: Every mutation writes seven days. **This is the commit that
+closes #82.**
+
+**Changes**:
+- `WidgetSnapshotBuilder.buildSeries(from:asOf:calendar:horizonDays:…)`
+  — `(0..<horizon).map { build(asOf: day + $0) }` through
+  `calendar.date(byAdding: .day, …)`, never raw seconds.
+- `rebuildAndWrite` calls it; `DayCompletionCelebration.observe`
+  reads `days[0]` only — tomorrow's progress must never feed the
+  confetti.
+- Measure: in dev mode with the seeded dataset, time
+  `rebuildAndWrite` before/after on a toggle. If it is visibly slow,
+  hoist the `context.fetch` and `snapshot` mapping out of the per-day
+  loop (the stats must stay per-day). Record the numbers in the
+  compound.
+
+**Tests / verification**:
+- Task 5 green; full `test_sim` green.
+- **Manual flip check on the simulator**: with the widget placed,
+  set the Mac clock (System Settings → General → Date & Time, "set
+  automatically" off) to 23:59, reload the widget, watch it switch
+  to the fresh day at 00:00 with the app killed. Restore the clock.
+  Repeat once with "Day starts at" = 04:00 and the clock at 03:59.
+- Screenshot both widget families after the flip; the empty state
+  and the "0 / N" copy must read correctly (this is the state the
+  reporter sees every morning from now on).
+
+**Commit message (suggested)**: `fix(widgets): pre-compute the upcoming days so the widget rolls over on its own`
+
+---
+
+### Task 7: Foreground on a new day reloads; ROADMAP
+
+**Goal**: The app side of the issue, and the docs that pointed at it.
+
+**Changes**:
+- `KadoApp.onChange(of: scenePhase)`: when the day changed, bump
+  `clockMark` **and** `WidgetReloader.reloadAll(using:)` (which
+  already includes `RemindersSync.rescheduleAll`, so the existing
+  call moves into the unchanged-day branch rather than running
+  twice).
+- `docs/ROADMAP.md`: drop the "Rollover-aware widget refresh" entry
+  or mark it done with a pointer here.
+
+**Tests / verification**:
+- No unit seam for `scenePhase`; verify by hand: background the app
+  with the clock before midnight, advance the clock, foreground —
+  the widget updates within a second without logging anything.
+- `test_sim` and `LocalizationCoverageTests` green (no new strings
+  expected).
+
+**Commit message (suggested)**: `fix(app): rebuild the widget snapshot when foregrounding on a new day`
+
+---
+
+### Task 8: Definition of done
+
+**Goal**: Close out per CLAUDE.md before review.
+
+**Tests / verification**:
+- `build_sim` iPhone 17 Pro and iPad Air (M4), no new warnings — the
+  planner and series are `nonisolated`; the Swift 6 isolation
+  warnings from a `@MainActor`-defaulted type used in the extension
+  are the likely trip-wire.
+- `test_sim` green.
+- Widget gallery still renders (`-uiTestWidgetGallery`) — it builds
+  one day directly and wraps it in a `SnapshotEntry`, so nothing
+  should change; confirm with one screenshot.
+- Overnight on-device check before marking the PR ready: complete a
+  habit in the evening, do not open the app, confirm the widget shows
+  the new day in the morning. This is the reporter's exact scenario
+  and the only end-to-end proof.
+
+## Risks and mitigation
+
+- **7× build cost on MainActor per mutation.** Measured in Task 6;
+  fallback is hoisting the fetch, then lowering the horizon to 3.
+- **Legacy file decode.** The first launch after the update reads a
+  bare-snapshot file and immediately rewrites it as a series; the
+  window is one launch. Pinned by Task 1's fixture test.
+- **Time-zone travel between write and read.** `logicalDay` is an
+  instant; after a zone change the widget's midnight differs from the
+  stored one and the selection rule degrades to "greatest day ≤ now"
+  until the next mutation. Acceptable; noted, not handled.
+- **WidgetKit entry semantics.** Entries must be ascending and slot 0
+  must not be in the future, or WidgetKit shows the placeholder until
+  it is. The planner pins slot 0 to `now`; the sweep test guards
+  ordering.
+- **The `.active` race with the sleeping edge task** (the task can
+  resume before or after `scenePhase` fires). With Task 7 both paths
+  reload; a double reload is idempotent.
+
+## Open questions
+
+- [ ] Confirm the approach — pre-computed days + timeline entries —
+  over shipping raw data to the widget.
+- [ ] Confirm the 7-day horizon (vs. 2–3 days if the Task 6
+  measurement is unkind).
+- [ ] Confirm `BGAppRefreshTask` stays out of scope.
+- [ ] Open a draft PR on `feature/widget-day-rollover` now?
+
+## Out of scope
+
+- `BGAppRefreshTask` (see *Decisions*).
+- CloudKit changes that land while the app is suspended are not
+  reflected in the widget until the next foreground — a separate,
+  pre-existing gap; the Task 7 reload narrows it to "next foreground"
+  rather than "next mutation".
+- Re-deriving anything inside the widget process; iCloud-syncing the
+  day-start hour (still on the ROADMAP).

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -372,6 +372,38 @@ closes #82.**
   before the autosave timer fires). Deleted, as it always was going to
   be; noted so nobody spends a cycle on it again.
 
+- **Code review (8 findings, 7 acted on, 1 disproved).**
+  - *Confirmed, pre-existing, fixed*: the score walk steps with
+    `date(byAdding: .day)` and never re-anchors, so in a
+    midnight-transition zone every entry after the edge sits at 01:00
+    while completions are bucketed at true midnights — a perfect run
+    in Havana scored 0.26 instead of 0.51. The streak walks (`current`
+    backward, `best` forward, and both week walks) had the same shape:
+    14 days read as 7. One-line re-anchors, each with a Havana test.
+    The series now keys its lookup through `startOfDay` on both sides
+    as well.
+  - *Confirmed, fixed*: a cold launch past the horizon wrote the file
+    without a reload. `rebuildAndWrite` reloads timelines itself now;
+    `WidgetReloader` and the two intents drop their hand-paired calls.
+  - *Confirmed, fixed*: the new-day rebuild ran synchronously inside
+    the scene-phase callback; deferred one tick. The comment now states
+    the real ordering dependency — bumping `clockMark` first cancels a
+    waking edge task, so the rebuild runs once.
+  - *Confirmed, fixed*: the planner chained its edge off the previous
+    accepted slot, so one mismatch dropped every later day. Slots are
+    dated from their own day via `DayBoundary.rollover(into:)`.
+  - *Confirmed, fixed*: builder tests were UTC-only; the parity test
+    now sweeps UTC / Paris (both edges) / Havana with histories and
+    series straddling each transition. The legacy decode fallback takes
+    its calendar from the decoder.
+  - **Disproved**: "the best streak is invariant across the horizon,
+    hoist it." It is for binary, counter, timer, every frequency —
+    and *not* for a negative habit, where an unlogged day is a clean
+    day and two of them raise the maximum. The zone-swept parity test
+    failed on exactly that (1 hoisted vs 2 standalone) and the hoist
+    was reverted. Worth remembering: "nothing logged can't change X"
+    is false for negatives by definition.
+
 ## Risks and mitigation
 
 - **7× build cost on MainActor per mutation.** Measured in Task 6;

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -286,7 +286,7 @@ closes #82.**
 
 ---
 
-### Task 7: Foreground on a new day reloads; ROADMAP
+### Task 7: Foreground on a new day reloads; ROADMAP ✅
 
 **Goal**: The app side of the issue, and the docs that pointed at it.
 

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -310,23 +310,32 @@ closes #82.**
 
 ---
 
-### Task 8: Definition of done
+### Task 8: Definition of done ✅ (automated) / ⏳ (by hand)
 
 **Goal**: Close out per CLAUDE.md before review.
 
 **Tests / verification**:
-- `build_sim` iPhone 17 Pro and iPad Air (M4), no new warnings — the
-  planner and series are `nonisolated`; the Swift 6 isolation
-  warnings from a `@MainActor`-defaulted type used in the extension
-  are the likely trip-wire.
-- `test_sim` green.
-- Widget gallery still renders (`-uiTestWidgetGallery`) — it builds
-  one day directly and wraps it in a `SnapshotEntry`, so nothing
-  should change; confirm with one screenshot.
-- Overnight on-device check before marking the PR ready: complete a
-  habit in the evening, do not open the app, confirm the widget shows
-  the new day in the morning. This is the reporter's exact scenario
-  and the only end-to-end proof.
+- [x] `build_sim` iPhone 17 Pro and iPad Air 11-inch (M4), no new
+  warnings — verified by touching every changed file and rebuilding
+  with `-quiet`, which re-emits their diagnostics: none.
+- [x] `test_sim` green — 588 tests, 21 of them new.
+- [x] Widget gallery still renders (`-uiTestWidgetGallery`) — one
+  screenshot on the seeded data, every tile as before.
+- [x] The running app writes the series: launched on the seeded
+  store, `widget-snapshot.json` in the App Group holds seven
+  consecutive days (40 KB for seven habits), the due set moves day to
+  day, daily streaks read 0 from tomorrow because today isn't logged,
+  the negative habit stays done, scores decay.
+- [ ] **By hand — the host-clock flip.** With a widget placed, set the
+  Mac clock (System Settings → General → Date & Time, "set
+  automatically" off) to 23:59, reload the widget, watch it turn the
+  page at 00:00 with the app killed; once more with "Day starts at"
+  04:00 and the clock at 03:59. Restore the clock. Not runnable from
+  a background session (no admin, no taps).
+- [ ] **By hand — overnight on-device** before marking the PR ready:
+  complete a habit in the evening, do not open the app, confirm the
+  widget shows the new day in the morning. This is the reporter's
+  exact scenario and the only end-to-end proof.
 
 ## Notes during build
 

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -224,7 +224,7 @@ the day's rollover, using the user's day-start hour.
 
 ---
 
-### Task 5: Series builder — tests
+### Task 5: Series builder — tests ✅
 
 **Goal**: Pin what "tomorrow morning, nothing logged" means for each
 habit shape before the builder writes it.
@@ -253,7 +253,7 @@ habit shape before the builder writes it.
 
 ---
 
-### Task 6: `buildSeries` + `rebuildAndWrite` writes the horizon
+### Task 6: `buildSeries` + `rebuildAndWrite` writes the horizon ✅
 
 **Goal**: Every mutation writes seven days. **This is the commit that
 closes #82.**
@@ -327,6 +327,41 @@ closes #82.**
   habit in the evening, do not open the app, confirm the widget shows
   the new day in the morning. This is the reporter's exact scenario
   and the only end-to-end proof.
+
+## Notes during build
+
+- **Task 6 — the 7× estimate was wrong by an order of magnitude.** A
+  throwaway timing test on 20 habits × 730 days (10,960 completions,
+  Debug, in-memory SwiftData) put a *single* `build` at **8.8 s** and
+  a naive `buildSeries(7)` at **63.7 s**. Breakdown: score **7.5 s**,
+  first-time SwiftData extraction 1.2 s (0.02 s once faulted), streak
+  `current` and `best` 0.3 s each, rows and matrix negligible. The
+  score is O(days × completions): `scoreHistory` walks every day from
+  the first completion and, per day, `.daysPerWeek` reduces over every
+  completion with a `Calendar` call and `.everyNDays` rescans for its
+  anchor. That cost predates this work — the app pays it on every
+  mutation today — but seven of it was not shippable.
+- **What changed**: `buildSeries` reads the store once (`Source`) and
+  walks the score **once per habit to the last day**, each day reading
+  its value off that walk — `currentScore(asOf:)` is the prefix of the
+  same fold, so the numbers are identical, pinned by
+  `seriesDaysMatchStandaloneBuilds` across all five habit shapes.
+  Streaks, rows and matrix stay per day. Result: **12.2 s** for the
+  extreme dataset (1.5× a single build, not 7.3×) and **0.76 s vs
+  0.51 s** for 5 habits × 365 days. Horizon stays 7; it no longer
+  drives the cost.
+- **Follow-up, not this PR**: the score calculator's per-day evaluator
+  calls are the elephant for *every* caller, not just the widget. The
+  streak calculator already avoids the evaluator for exactly this
+  reason (see its "Deliberately not delegated" note); the score should
+  do the same, or the evaluator should grow a prepared per-habit form.
+  Filed as a next step on the PR.
+- **The throwaway bench crashed the suite** — `EXC_BREAKPOINT` in
+  SwiftData from a Foundation timer on the main run loop, after the
+  bench's 11k-row in-memory container was torn down while other tests
+  kept running. It never crashed when run alone (the process exits
+  before the autosave timer fires). Deleted, as it always was going to
+  be; noted so nobody spends a cycle on it again.
 
 ## Risks and mitigation
 

--- a/docs/plans/2026-09/widget-day-rollover/plan.md
+++ b/docs/plans/2026-09/widget-day-rollover/plan.md
@@ -169,7 +169,7 @@ single-day snapshot.
 
 ---
 
-### Task 3: Timeline plan — tests
+### Task 3: Timeline plan — tests ✅
 
 **Goal**: Spec the entries the providers hand WidgetKit, across day
 starts and DST shapes, before writing the planner.
@@ -197,7 +197,7 @@ starts and DST shapes, before writing the planner.
 
 ---
 
-### Task 4: `WidgetTimelinePlan` and the two providers
+### Task 4: `WidgetTimelinePlan` and the two providers ✅
 
 **Goal**: Both providers emit one entry per pre-computed day, dated at
 the day's rollover, using the user's day-start hour.


### PR DESCRIPTION
Fixes #82.

## Why?

- The Home Screen and Lock Screen widgets kept rendering **yesterday's** ticks and progress until the user opened the app and logged a habit (#82, reported by email on 2026-09-11).
- The widget renders a snapshot the app pre-computed for the day it was written on. `SnapshotTimelineProvider` emitted one entry and re-read the same file hourly, never checking which day it was built for, and ignored the "Day starts at" hour.
- The app only rebuilt while awake: the day-edge `Task.sleep` never fires when suspended, and foregrounding on a new day only bumped `clockMark`. First rebuild = first habit mutation.
- Already flagged as "rollover-aware widget refresh" in the day-start-hour compound and `docs/ROADMAP.md`; that entry is closed here.

## What?

- Widgets turn the page to the fresh day at midnight — or the custom day-start hour — on their own, with neither the app nor the extension awake, and keep doing so for a week without the app being opened.
- Foregrounding the app on a new day refreshes the widget immediately, as belt and braces.
- A snapshot file written by the previous version still decodes; the first launch after updating rewrites it.
- **Also fixed on the way** (found by review of the series): in a zone whose DST transition happens at midnight (America/Havana, 2026-03-08), the score and streak walks drifted to 01:00 after the edge and stopped matching completions — a perfect run scored 0.26 instead of 0.51 and read as a 7-day streak instead of 14. Pre-existing; one-line re-anchors with Havana tests.

## How?

- Every calculator is `asOf`-driven with no wall-clock reads, so `WidgetSnapshotBuilder.build(asOf: tomorrow)` already yields exactly what the app would show tomorrow morning with nothing further logged. `rebuildAndWrite` now writes a `WidgetSnapshotSeries` — **today + the next 6 days** — and each `WidgetSnapshot` carries its `logicalDay`.
- `WidgetTimelinePlan` (pure, no WidgetKit import) turns `(series, now, DayBoundary)` into one timeline entry per day, dated at that day's rollover instant; both providers are one-liners over it and read the boundary from `DayStartDefaults`, which is App-Group-backed and so reads the same in both processes. The hourly reload stays as the safety net. Pinned across UTC / Paris / Havana transition windows.
- **Cost**: a naive 7× build was 63 s on 20 habits × 2 years (Debug) because the score walk is O(days × completions) — pre-existing, the app pays 8.8 s for *one* build on that dataset. `buildSeries` reads the store once and walks the score once per habit to the last day, each day reading its value off that walk (`currentScore` is the prefix of the same fold; `seriesDaysMatchStandaloneBuilds` pins equality across every habit shape). Series = 1.5× a single build: 12.2 s on the extreme dataset, 0.76 s vs 0.51 s on 5 habits × 1 year.
- `rebuildAndWrite` reloads the timelines itself now, so no caller (launch included) can write the file without WidgetKit hearing about it; `WidgetReloader` and the two intents drop their hand-paired calls.
- `KadoApp`'s `scenePhase == .active` handler rebuilds when the day changed, deferred one tick so the resumed frame renders first.
- Review found 8 things; 7 were acted on and one — "hoist the best streak, it can't change on unlogged days" — was disproved by the zone-swept parity test: for a negative habit an unlogged day is a clean day, and two of them raise the maximum. Details in the plan's build notes.
- Plan, decisions, measurements and build notes: [`docs/plans/2026-09/widget-day-rollover/plan.md`](docs/plans/2026-09/widget-day-rollover/plan.md).

**Verified**: 593 unit tests green (26 new, parity swept across UTC / Paris / Havana); iPhone 17 Pro and iPad Air (M4) builds with no new warnings; the widget gallery renders unchanged; the running app writes a 7-day series into the App Group whose due sets, streaks and scores move day to day as the app itself would show them.

## Next steps

- [ ] **By hand before marking ready**: the host-clock flip on the simulator (clock to 23:59, widget placed, app killed, watch it turn at 00:00; again with "Day starts at" 04:00), and the overnight on-device run — the reporter's exact scenario.
- [ ] Compound.
- [ ] **Follow-up PR — score calculator cost.** `scoreHistory` calls the frequency evaluator per day, and `.daysPerWeek` / `.everyNDays` rescan every completion with a `Calendar` call each time. 375 ms per two-year habit in Debug, on MainActor, on every mutation, for every caller. The streak calculator already avoids the evaluator for exactly this reason; the score should too, or the evaluator should grow a prepared per-habit form.
- Out of scope, by decision: `BGAppRefreshTask`; re-deriving anything inside the widget process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cc6ywfpTrVsfc6Qvuf71oW
