### PR TITLE
feat(today): tick on every quick-log tap and show the day's count

### DIFF
--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -957,6 +957,23 @@
         }
       }
     },
+    "%lldm" : {
+      "comment" : "Minutes logged today, before the +5m chip on a timer Today row. Argument is whole minutes.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lldm"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld min"
+          }
+        }
+      }
+    },
     "A few times a week" : {
       "comment" : "Frequency picker option in the new-habit form, selects the 'N days per week' mode.",
       "localizations" : {

--- a/Kado/Services/CompletionLogger.swift
+++ b/Kado/Services/CompletionLogger.swift
@@ -13,6 +13,13 @@ struct CompletionLogger {
         self.calendar = calendar
     }
 
+    /// The day's recorded value, 0 when there is no record. Read
+    /// before a mutation so the quick-log haptic can compare the
+    /// value it moved from with the one it moved to.
+    func value(for habit: HabitRecord, on date: Date = .now) -> Double {
+        todayCompletion(for: habit, on: date)?.value ?? 0
+    }
+
     /// Adds `delta` to today's completion value, creating a record
     /// if none exists.
     func incrementCounter(

--- a/Kado/UIComponents/CounterQuickLogView.swift
+++ b/Kado/UIComponents/CounterQuickLogView.swift
@@ -3,9 +3,10 @@ import KadoCore
 
 /// Quick-log control for counter habits on the detail view.
 /// Shows today's value next to the target, with `−` and `+`
-/// buttons on either side. Minus is disabled at zero. Every tap
-/// ticks; the one that meets `target` plays `.success`
-/// (`QuickLogFeedback`).
+/// buttons on either side. Minus is disabled at zero. Display only:
+/// the haptic for a tap is the detail view's, recorded where the
+/// value is written (`QuickLogEvent`), so it can't fire for a value
+/// that moved for some other reason.
 struct CounterQuickLogView: View {
     let target: Double
     let todayValue: Double
@@ -58,9 +59,6 @@ struct CounterQuickLogView: View {
             RoundedRectangle(cornerRadius: KadoRadius.card)
                 .fill(Color.kadoBackgroundSecondary)
         )
-        .sensoryFeedback(trigger: todayValue) { old, new in
-            QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
-        }
     }
 }
 

--- a/Kado/UIComponents/CounterQuickLogView.swift
+++ b/Kado/UIComponents/CounterQuickLogView.swift
@@ -3,8 +3,9 @@ import KadoCore
 
 /// Quick-log control for counter habits on the detail view.
 /// Shows today's value next to the target, with `−` and `+`
-/// buttons on either side. Minus is disabled at zero. A success
-/// haptic fires once when `todayValue` first meets `target`.
+/// buttons on either side. Minus is disabled at zero. Every tap
+/// ticks; the one that meets `target` plays `.success`
+/// (`QuickLogFeedback`).
 struct CounterQuickLogView: View {
     let target: Double
     let todayValue: Double
@@ -57,8 +58,8 @@ struct CounterQuickLogView: View {
             RoundedRectangle(cornerRadius: KadoRadius.card)
                 .fill(Color.kadoBackgroundSecondary)
         )
-        .sensoryFeedback(.success, trigger: targetReached) { old, new in
-            !old && new
+        .sensoryFeedback(trigger: todayValue) { old, new in
+            QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
         }
     }
 }

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -170,10 +170,10 @@ struct HabitRowView: View {
             binaryCheckButton
         case .negative:
             negativePill
-        case .counter(let target):
-            counterStepper(target: target)
-        case .timer(let targetSeconds):
-            timerAddFiveChip(target: targetSeconds)
+        case .counter:
+            counterStepper
+        case .timer:
+            timerAddFiveChip
         }
     }
 
@@ -188,7 +188,7 @@ struct HabitRowView: View {
     /// full session editor (existing `TimerLogSheet`) is reachable
     /// from the row's context menu via "Log specific value…".
     @ViewBuilder
-    private func timerAddFiveChip(target: TimeInterval) -> some View {
+    private var timerAddFiveChip: some View {
         if let onTimerAddFiveMinutes {
             ViewThatFits(in: .horizontal) {
                 HStack(spacing: 8) {
@@ -196,9 +196,6 @@ struct HabitRowView: View {
                     timerChip(action: onTimerAddFiveMinutes)
                 }
                 timerChip(action: onTimerAddFiveMinutes)
-            }
-            .sensoryFeedback(trigger: state.valueToday ?? 0) { old, new in
-                QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
             }
         }
     }
@@ -283,14 +280,10 @@ struct HabitRowView: View {
     /// point, so it is the minus that gives way. Decrement is disabled
     /// at zero so "no completion" stays equivalent to "not started
     /// today" (matches CompletionLogger semantics).
-    @ViewBuilder
-    private func counterStepper(target: Double) -> some View {
+    private var counterStepper: some View {
         ViewThatFits(in: .horizontal) {
             counterStepperFull
             counterStepperPlusOnly
-        }
-        .sensoryFeedback(trigger: state.valueToday ?? 0) { old, new in
-            QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
         }
     }
 
@@ -360,11 +353,14 @@ struct HabitRowView: View {
         Text(Int(state.valueToday ?? 0), format: .number)
     }
 
-    /// Whole minutes, floored — the same rounding as the VoiceOver
-    /// phrase, so the two never disagree.
     private var timerCountText: Text {
-        let minutes = Int((state.valueToday ?? 0) / 60)
-        return Text("\(minutes)m")
+        Text("\(todayMinutes)m")
+    }
+
+    /// Whole minutes, floored. Both the visual count and the VoiceOver
+    /// phrase read this, so the two can't disagree.
+    private var todayMinutes: Int {
+        Int((state.valueToday ?? 0) / 60)
     }
 
     // MARK: - Formatting helpers
@@ -404,9 +400,8 @@ struct HabitRowView: View {
             let v = Int(state.valueToday ?? 0)
             return String(localized: "\(v) of \(Int(target))")
         case .timer(let targetSeconds):
-            let v = Int((state.valueToday ?? 0) / 60)
             let t = Int(targetSeconds / 60)
-            return String(localized: "\(v) of \(t) minutes")
+            return String(localized: "\(todayMinutes) of \(t) minutes")
         }
     }
 
@@ -509,12 +504,17 @@ private extension HabitRowView {
     }
 }
 
+// The timer row is here on purpose: at AX sizes its count and chip
+// once wrapped to `35 / m` `+5 / m`, and this preview held no timer to
+// show it. Keep every trailing control represented.
 #Preview("Dynamic Type XXXL") {
     let binary = Habit(name: "Morning meditation", frequency: .daily, type: .binary, createdAt: .now)
     let counter = Habit(name: "Drink water", frequency: .daily, type: .counter(target: 8), createdAt: .now)
+    let timer = Habit(name: "Read", frequency: .daily, type: .timer(targetSeconds: 1800), createdAt: .now)
     return List {
         HabitRowView(habit: binary, state: HabitRowView.previewState(for: binary.type, value: 1), streak: 6, scorePercent: 78, onToggle: {})
         HabitRowView(habit: counter, state: HabitRowView.previewState(for: counter.type, value: 3), streak: 2, scorePercent: 55, onToggle: nil)
+        HabitRowView(habit: timer, state: HabitRowView.previewState(for: timer.type, value: 2100), streak: 9, scorePercent: 88, onToggle: nil)
     }
     .environment(\.dynamicTypeSize, .accessibility3)
 }

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -10,11 +10,15 @@ import KadoCore
 ///   lived on Detail.
 /// - **Trailing**: type-aware control. Binary, counter, and timer
 ///   share a 28pt-circle icon vocabulary (checkmark, `−` / `+`,
-///   `+5m`). Negative is the deliberate exception — it keeps a
-///   text "Slipped" pill so a slip never reads as a "done"
-///   achievement at a glance. In every case the *filled* variant
-///   is the recorded state and the tinted / outlined variant is
-///   the ready-to-record state.
+///   `+5m`). Counter and timer also carry the day's count
+///   (`− 3 +`, `12m +5m`): the ring says how far toward the target,
+///   the count says how many — and past the target, where the ring
+///   is already full, it is the one thing a tap still moves.
+///   Negative is the deliberate exception — it keeps a text
+///   "Slipped" pill so a slip never reads as a "done" achievement
+///   at a glance. In every case the *filled* variant is the
+///   recorded state and the tinted / outlined variant is the
+///   ready-to-record state.
 struct HabitRowView: View {
     let habit: Habit
     let state: HabitRowState
@@ -34,6 +38,8 @@ struct HabitRowView: View {
     var onOpenDetail: (() -> Void)? = nil
     var onEdit: (() -> Void)? = nil
     var onArchive: (() -> Void)? = nil
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var isComplete: Bool { state.status == .complete }
 
@@ -173,30 +179,43 @@ struct HabitRowView: View {
 
     // MARK: - Timer chip
 
-    /// Trailing `+5m` quick-log chip. Tap adds five minutes to today's
-    /// session — the fast-path power-user action. The leading ring
-    /// communicates progress; the full session editor (existing
-    /// `TimerLogSheet`) is reachable from the row's context menu via
-    /// "Log specific value…".
+    /// Trailing `12m +5m`: today's minutes, then the quick-log chip.
+    /// Tap adds five minutes to today's session — the fast-path
+    /// power-user action. Collapses to the chip alone when the row
+    /// can't host both — Dynamic Type AX sizes — since a chip that
+    /// wraps to `+5 / m` is worse than a count VoiceOver still reads.
+    /// The leading ring communicates progress toward the target; the
+    /// full session editor (existing `TimerLogSheet`) is reachable
+    /// from the row's context menu via "Log specific value…".
     @ViewBuilder
     private func timerAddFiveChip(target: TimeInterval) -> some View {
         if let onTimerAddFiveMinutes {
-            Button(action: onTimerAddFiveMinutes) {
-                Text("+5m")
-                    .font(.callout.weight(.semibold).monospacedDigit())
-                    .padding(.vertical, 4)
-                    .padding(.horizontal, 10)
-                    .background(
-                        Capsule().fill(habit.color.color.opacity(0.15))
-                    )
-                    .foregroundStyle(habit.color.color)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    countLabel(timerCountText)
+                    timerChip(action: onTimerAddFiveMinutes)
+                }
+                timerChip(action: onTimerAddFiveMinutes)
             }
-            .buttonStyle(.borderless)
-            .accessibilityLabel(String(localized: "Add 5 minutes"))
             .sensoryFeedback(trigger: state.valueToday ?? 0) { old, new in
                 QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
             }
         }
+    }
+
+    private func timerChip(action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text("+5m")
+                .font(.callout.weight(.semibold).monospacedDigit())
+                .padding(.vertical, 4)
+                .padding(.horizontal, 10)
+                .background(
+                    Capsule().fill(habit.color.color.opacity(0.15))
+                )
+                .foregroundStyle(habit.color.color)
+        }
+        .buttonStyle(.borderless)
+        .accessibilityLabel(String(localized: "Add 5 minutes"))
     }
 
     @ViewBuilder
@@ -258,48 +277,52 @@ struct HabitRowView: View {
 
     // MARK: - Counter stepper
 
-    /// Inline `−  value/target  +` stepper. Collapses to `value/target +`
-    /// (no minus) when the row width can't host both buttons — the
-    /// usual case at Dynamic Type XXL+ where the labels grow large.
-    /// Decrement is disabled at zero so "no completion" stays equivalent
-    /// to "not started today" (matches CompletionLogger semantics).
+    /// Inline `− value +` stepper. Collapses to `value +` (no minus)
+    /// when the row width can't host both buttons — the usual case at
+    /// Dynamic Type XXL+ where the labels grow large; the count is the
+    /// point, so it is the minus that gives way. Decrement is disabled
+    /// at zero so "no completion" stays equivalent to "not started
+    /// today" (matches CompletionLogger semantics).
     @ViewBuilder
     private func counterStepper(target: Double) -> some View {
         ViewThatFits(in: .horizontal) {
-            counterStepperFull(target: target)
-            counterStepperPlusOnly(target: target)
+            counterStepperFull
+            counterStepperPlusOnly
         }
         .sensoryFeedback(trigger: state.valueToday ?? 0) { old, new in
             QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
         }
     }
 
-    private func counterStepperFull(target: Double) -> some View {
+    private var counterStepperFull: some View {
         HStack(spacing: 8) {
-            Button(action: { onCounterDecrement?() }) {
-                Image(systemName: "minus")
-                    .font(.callout.weight(.semibold))
-                    .frame(width: 28, height: 28)
-                    .background(Circle().fill(Color.kadoPaper200))
-                    .foregroundStyle(canDecrement ? Color.kadoForeground : Color.kadoForegroundSecondary)
-            }
-            .buttonStyle(.borderless)
-            .disabled(!canDecrement)
-            .accessibilityLabel(String(localized: "Decrement"))
-
-            Button(action: { onCounterIncrement?() }) {
-                Image(systemName: "plus")
-                    .font(.callout.weight(.semibold))
-                    .frame(width: 28, height: 28)
-                    .background(Circle().fill(habit.color.color.opacity(0.15)))
-                    .foregroundStyle(habit.color.color)
-            }
-            .buttonStyle(.borderless)
-            .accessibilityLabel(String(localized: "Increment"))
+            counterMinusButton
+            countLabel(counterCountText)
+            counterPlusButton
         }
     }
 
-    private func counterStepperPlusOnly(target: Double) -> some View {
+    private var counterStepperPlusOnly: some View {
+        HStack(spacing: 8) {
+            countLabel(counterCountText)
+            counterPlusButton
+        }
+    }
+
+    private var counterMinusButton: some View {
+        Button(action: { onCounterDecrement?() }) {
+            Image(systemName: "minus")
+                .font(.callout.weight(.semibold))
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(Color.kadoPaper200))
+                .foregroundStyle(canDecrement ? Color.kadoForeground : Color.kadoForegroundSecondary)
+        }
+        .buttonStyle(.borderless)
+        .disabled(!canDecrement)
+        .accessibilityLabel(String(localized: "Decrement"))
+    }
+
+    private var counterPlusButton: some View {
         Button(action: { onCounterIncrement?() }) {
             Image(systemName: "plus")
                 .font(.callout.weight(.semibold))
@@ -313,6 +336,35 @@ struct HabitRowView: View {
 
     private var canDecrement: Bool {
         (state.valueToday ?? 0) > 0
+    }
+
+    // MARK: - Count label
+
+    /// The day's recorded value, beside the stepper or chip. Plain
+    /// foreground until the target is met, the habit colour after —
+    /// the same rule as `CounterQuickLogView`'s big number. Digits
+    /// roll on change so a tap past the target still visibly lands;
+    /// Reduce Motion swaps the roll for a plain replace.
+    private func countLabel(_ text: Text) -> some View {
+        text
+            .font(.callout.weight(.semibold).monospacedDigit())
+            .foregroundStyle(isComplete ? habit.color.color : Color.kadoForeground)
+            // A count is one short token; it must never split into
+            // `35 / m` across lines at large Dynamic Type.
+            .fixedSize(horizontal: true, vertical: false)
+            .contentTransition(.numericText(value: state.valueToday ?? 0))
+            .animation(reduceMotion ? nil : KadoMotion.fast, value: state.valueToday)
+    }
+
+    private var counterCountText: Text {
+        Text(Int(state.valueToday ?? 0), format: .number)
+    }
+
+    /// Whole minutes, floored — the same rounding as the VoiceOver
+    /// phrase, so the two never disagree.
+    private var timerCountText: Text {
+        let minutes = Int((state.valueToday ?? 0) / 60)
+        return Text("\(minutes)m")
     }
 
     // MARK: - Formatting helpers
@@ -342,9 +394,8 @@ struct HabitRowView: View {
 
     /// Value-only progress phrase for counter / timer rows. Empty for
     /// binary / negative (their state lives in `accessibilityLabel`).
-    /// Surfaced here because the visual `value/target` text was
-    /// removed in favor of the leading progress ring — VoiceOver
-    /// users still need the numbers.
+    /// The row shows the value but not the target — the ring carries
+    /// that — so VoiceOver gets both numbers here.
     private var accessibilityProgressText: String {
         switch habit.type {
         case .binary, .negative:
@@ -454,6 +505,7 @@ private extension HabitRowView {
         HabitRowView(habit: counter, state: HabitRowView.previewState(for: counter.type, value: 3), streak: 2, scorePercent: 55, onToggle: nil)
         HabitRowView(habit: counter, state: HabitRowView.previewState(for: counter.type, value: 12), streak: 7, scorePercent: 92, onToggle: nil)
         HabitRowView(habit: timer, state: HabitRowView.previewState(for: timer.type, value: 750), streak: 3, scorePercent: 60, onToggle: nil)
+        HabitRowView(habit: timer, state: HabitRowView.previewState(for: timer.type, value: 2100), streak: 9, scorePercent: 88, onToggle: nil)
     }
 }
 

--- a/Kado/UIComponents/HabitRowView.swift
+++ b/Kado/UIComponents/HabitRowView.swift
@@ -193,8 +193,8 @@ struct HabitRowView: View {
             }
             .buttonStyle(.borderless)
             .accessibilityLabel(String(localized: "Add 5 minutes"))
-            .sensoryFeedback(.success, trigger: isComplete) { old, new in
-                !old && new
+            .sensoryFeedback(trigger: state.valueToday ?? 0) { old, new in
+                QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
             }
         }
     }
@@ -269,8 +269,8 @@ struct HabitRowView: View {
             counterStepperFull(target: target)
             counterStepperPlusOnly(target: target)
         }
-        .sensoryFeedback(.success, trigger: isComplete) { old, new in
-            !old && new
+        .sensoryFeedback(trigger: state.valueToday ?? 0) { old, new in
+            QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
         }
     }
 

--- a/Kado/UIComponents/QuickLogFeedback.swift
+++ b/Kado/UIComponents/QuickLogFeedback.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// The haptic a quick-log control plays when the day's recorded value
+/// changes. One rule for every stepper and chip — the Today row, the
+/// detail quick-log, the calendar day popover — so a tap feels the same
+/// wherever it lands.
+///
+/// Exactly one feedback per change:
+/// - `.success` when the change carries the value from below the
+///   target to at or above it — the moment the day is done.
+/// - `.selection` for every other change: each step below the target,
+///   each step past it, each decrement. This is the tick that was
+///   missing past the target (#81), where the ring is already full
+///   and there was nothing left to tell the user the tap registered.
+/// - `nil` when the value didn't move.
+///
+/// `.selection`, not `.increase` / `.decrease`: those two compile on
+/// iOS and never play — Apple's docs for both read *"Only plays
+/// feedback on watchOS and visionOS."* `.selection` is the iOS kind
+/// for movement through discrete values.
+///
+/// Apply through `sensoryFeedback(trigger:) { old, new in … }` on the
+/// value the control reads, so it also fires for VoiceOver rotor
+/// actions that drive the same state.
+nonisolated enum QuickLogFeedback {
+    static func feedback(oldValue: Double, newValue: Double, target: Double) -> SensoryFeedback? {
+        guard newValue != oldValue else { return nil }
+        if oldValue < target && newValue >= target {
+            return .success
+        }
+        return .selection
+    }
+}

--- a/Kado/UIComponents/QuickLogFeedback.swift
+++ b/Kado/UIComponents/QuickLogFeedback.swift
@@ -1,13 +1,16 @@
 import SwiftUI
+import KadoCore
 
-/// The haptic a quick-log control plays when the day's recorded value
-/// changes. One rule for every stepper and chip — the Today row, the
-/// detail quick-log, the calendar day popover — so a tap feels the same
-/// wherever it lands.
+/// The haptic a quick-log mutation plays when it moves the day's
+/// recorded value. One rule for every stepper and chip — the Today
+/// row, the detail quick-log, the calendar day popover — so a tap
+/// feels the same wherever it lands.
 ///
 /// Exactly one feedback per change:
-/// - `.success` when the change carries the value from below the
-///   target to at or above it — the moment the day is done.
+/// - `.success` when the change carries the value from not-done to
+///   done — the moment the target is met. "Done" is the same rule as
+///   `HabitRowState`: at or above a positive target, anything above
+///   zero when the target isn't positive.
 /// - `.selection` for every other change: each step below the target,
 ///   each step past it, each decrement. This is the tick that was
 ///   missing past the target (#81), where the ring is already full
@@ -19,15 +22,67 @@ import SwiftUI
 /// feedback on watchOS and visionOS."* `.selection` is the iOS kind
 /// for movement through discrete values.
 ///
-/// Apply through `sensoryFeedback(trigger:) { old, new in … }` on the
-/// value the control reads, so it also fires for VoiceOver rotor
-/// actions that drive the same state.
+/// Apply at the **mutation site**, not on the control: the view that
+/// saves records a `QuickLogEvent` and a stable ancestor carries
+/// `.quickLogFeedback(_:)`. Keying a control on the value it displays
+/// ticks for changes the user didn't make (a day rollover zeroes every
+/// row at once, a CloudKit sync, a container swap) and misses the tap
+/// that re-creates the control (a row moving between Today's sections).
 nonisolated enum QuickLogFeedback {
     static func feedback(oldValue: Double, newValue: Double, target: Double) -> SensoryFeedback? {
         guard newValue != oldValue else { return nil }
-        if oldValue < target && newValue >= target {
+        if !meets(oldValue, target: target) && meets(newValue, target: target) {
             return .success
         }
         return .selection
+    }
+
+    /// Mirrors `HabitRowState.resolveAgainstTarget`: a non-positive
+    /// target is met by any recorded value.
+    private static func meets(_ value: Double, target: Double) -> Bool {
+        target > 0 ? value >= target : value > 0
+    }
+}
+
+/// One quick-log mutation, as the haptic sees it. The view that
+/// performed the mutation keeps the latest event in `@State`; the
+/// `sequence` makes two identical consecutive steps distinct, so the
+/// trigger still fires.
+nonisolated struct QuickLogEvent: Equatable, Sendable {
+    let sequence: Int
+    let feedback: SensoryFeedback?
+
+    /// The event for a mutation that moved a habit's day value
+    /// `oldValue → newValue`, sequenced after `previous`. `nil` for
+    /// binary and negative habits — a toggle has no step to tick.
+    static func next(
+        after previous: QuickLogEvent?,
+        type: HabitType,
+        oldValue: Double,
+        newValue: Double
+    ) -> QuickLogEvent? {
+        let target: Double
+        switch type {
+        case .counter(let count):
+            target = count
+        case .timer(let seconds):
+            target = seconds
+        case .binary, .negative:
+            return nil
+        }
+        return QuickLogEvent(
+            sequence: (previous?.sequence ?? 0) + 1,
+            feedback: QuickLogFeedback.feedback(oldValue: oldValue, newValue: newValue, target: target)
+        )
+    }
+}
+
+extension View {
+    /// Plays the haptic for the latest quick-log mutation. Put it on an
+    /// ancestor whose identity never changes — the Today `List`, the
+    /// detail `ScrollView` — so a tap that re-creates the row it landed
+    /// on still ticks, and nothing but a tap does.
+    func quickLogFeedback(_ event: QuickLogEvent?) -> some View {
+        sensoryFeedback(trigger: event) { _, new in new?.feedback }
     }
 }

--- a/Kado/Views/HabitDetail/DayEditPopover.swift
+++ b/Kado/Views/HabitDetail/DayEditPopover.swift
@@ -23,6 +23,12 @@ struct DayEditPopover: View {
 
     @State private var counterValue: Int = 0
     @State private var timerMinutes: Int = 0
+    /// Bumped by every stepper tap; `stepFeedback` is the haptic that
+    /// tap earned. Keyed on the tap rather than on the value because
+    /// `seedLocalState()` moves the value too, on appear, and opening
+    /// the popover must not tick.
+    @State private var stepTick: Int = 0
+    @State private var stepFeedback: SensoryFeedback? = nil
     @State private var noteText: String = ""
     @State private var isNoteExpanded: Bool = false
     @FocusState private var isNoteFocused: Bool
@@ -37,6 +43,7 @@ struct DayEditPopover: View {
         }
         .padding()
         .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
+        .sensoryFeedback(trigger: stepTick) { stepFeedback }
         .onAppear { seedLocalState() }
     }
 
@@ -125,6 +132,7 @@ struct DayEditPopover: View {
                 value: Binding(
                     get: { counterValue },
                     set: { newValue in
+                        recordStep(from: counterValue, to: newValue, target: target)
                         counterValue = newValue
                         onSetCounter(Double(newValue))
                     }
@@ -147,6 +155,7 @@ struct DayEditPopover: View {
                 value: Binding(
                     get: { timerMinutes },
                     set: { newValue in
+                        recordStep(from: timerMinutes, to: newValue, target: targetMinutes)
                         timerMinutes = newValue
                         onSetTimerSeconds(TimeInterval(newValue) * 60)
                     }
@@ -226,6 +235,15 @@ struct DayEditPopover: View {
             }
             .buttonStyle(.plain)
         }
+    }
+
+    private func recordStep(from old: Int, to new: Int, target: Int) {
+        stepFeedback = QuickLogFeedback.feedback(
+            oldValue: Double(old),
+            newValue: Double(new),
+            target: Double(target)
+        )
+        stepTick += 1
     }
 
     private func commitNote() {

--- a/Kado/Views/HabitDetail/DayEditPopover.swift
+++ b/Kado/Views/HabitDetail/DayEditPopover.swift
@@ -23,12 +23,6 @@ struct DayEditPopover: View {
 
     @State private var counterValue: Int = 0
     @State private var timerMinutes: Int = 0
-    /// Bumped by every stepper tap; `stepFeedback` is the haptic that
-    /// tap earned. Keyed on the tap rather than on the value because
-    /// `seedLocalState()` moves the value too, on appear, and opening
-    /// the popover must not tick.
-    @State private var stepTick: Int = 0
-    @State private var stepFeedback: SensoryFeedback? = nil
     @State private var noteText: String = ""
     @State private var isNoteExpanded: Bool = false
     @FocusState private var isNoteFocused: Bool
@@ -43,7 +37,6 @@ struct DayEditPopover: View {
         }
         .padding()
         .frame(minWidth: 260, idealWidth: 300, maxWidth: 340)
-        .sensoryFeedback(trigger: stepTick) { stepFeedback }
         .onAppear { seedLocalState() }
     }
 
@@ -132,7 +125,6 @@ struct DayEditPopover: View {
                 value: Binding(
                     get: { counterValue },
                     set: { newValue in
-                        recordStep(from: counterValue, to: newValue, target: target)
                         counterValue = newValue
                         onSetCounter(Double(newValue))
                     }
@@ -155,7 +147,6 @@ struct DayEditPopover: View {
                 value: Binding(
                     get: { timerMinutes },
                     set: { newValue in
-                        recordStep(from: timerMinutes, to: newValue, target: targetMinutes)
                         timerMinutes = newValue
                         onSetTimerSeconds(TimeInterval(newValue) * 60)
                     }
@@ -235,15 +226,6 @@ struct DayEditPopover: View {
             }
             .buttonStyle(.plain)
         }
-    }
-
-    private func recordStep(from old: Int, to new: Int, target: Int) {
-        stepFeedback = QuickLogFeedback.feedback(
-            oldValue: Double(old),
-            newValue: Double(new),
-            target: Double(target)
-        )
-        stepTick += 1
     }
 
     private func commitNote() {

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -33,6 +33,10 @@ struct HabitDetailView: View {
     @State private var showingTimerSheet = false
     @State private var showingScoreInfo = false
     @State private var editingDay: Date? = nil
+    /// The latest quick-log or popover step, for the haptic — one seam
+    /// for both, so a popover step on today doesn't also tick through
+    /// the quick-log control that displays the same value.
+    @State private var quickLog: QuickLogEvent?
     /// Seeded in `.onAppear` rather than defaulted to `.now`: `@State`
     /// is initialised before the environment is injected, so a wall-clock
     /// default would leak in ahead of `\.today` and open the grid on the
@@ -96,6 +100,7 @@ struct HabitDetailView: View {
         }
         .scrollContentBackground(.hidden)
         .background(Color.kadoBackground.ignoresSafeArea())
+        .quickLogFeedback(quickLog)
         .onAppear { if displayedMonth == nil { displayedMonth = today } }
         .navigationTitle("")
         .navigationBarTitleDisplayMode(.inline)
@@ -198,16 +203,31 @@ struct HabitDetailView: View {
 
     private func incrementCounter() {
         guard let record else { return }
-        CompletionLogger(calendar: calendar).incrementCounter(for: record, on: loggingInstant, in: modelContext)
+        let logger = CompletionLogger(calendar: calendar)
+        let before = logger.value(for: record, on: loggingInstant)
+        logger.incrementCounter(for: record, on: loggingInstant, in: modelContext)
+        recordQuickLog(from: before, to: before + 1)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
     private func decrementCounter() {
         guard let record else { return }
-        CompletionLogger(calendar: calendar).decrementCounter(for: record, on: loggingInstant, in: modelContext)
+        let logger = CompletionLogger(calendar: calendar)
+        let before = logger.value(for: record, on: loggingInstant)
+        logger.decrementCounter(for: record, on: loggingInstant, in: modelContext)
+        recordQuickLog(from: before, to: max(0, before - 1))
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
+    }
+
+    /// Derived from the mutation, not read back: the store may still
+    /// hold a just-deleted record until the save lands.
+    private func recordQuickLog(from old: Double, to new: Double) {
+        guard let event = QuickLogEvent.next(after: quickLog, type: habit.type, oldValue: old, newValue: new) else {
+            return
+        }
+        quickLog = event
     }
 
     // MARK: - Past-day popover mutations
@@ -234,7 +254,10 @@ struct HabitDetailView: View {
 
     private func setCounter(_ value: Double, on day: Date) {
         guard let record else { return }
-        CompletionLogger(calendar: calendar).setCounter(for: record, on: day, to: value, in: modelContext)
+        let logger = CompletionLogger(calendar: calendar)
+        let before = logger.value(for: record, on: day)
+        logger.setCounter(for: record, on: day, to: value, in: modelContext)
+        recordQuickLog(from: before, to: max(0, value))
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
@@ -247,12 +270,15 @@ struct HabitDetailView: View {
             return
         }
         guard let record else { return }
-        CompletionLogger(calendar: calendar).logTimerSession(
+        let logger = CompletionLogger(calendar: calendar)
+        let before = logger.value(for: record, on: day)
+        logger.logTimerSession(
             for: record,
             seconds: seconds,
             on: day,
             in: modelContext
         )
+        recordQuickLog(from: before, to: seconds)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
@@ -271,11 +297,13 @@ struct HabitDetailView: View {
         guard let snapshot = completion(on: day),
               let existing = modelContext.completionRecord(id: snapshot.id)
         else { return }
+        let before = existing.value
         if existing.note != nil {
             existing.value = 0
         } else {
             CompletionLogger(calendar: calendar).delete(existing, in: modelContext)
         }
+        recordQuickLog(from: before, to: 0)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }

--- a/Kado/Views/Today/TodayView.swift
+++ b/Kado/Views/Today/TodayView.swift
@@ -35,6 +35,12 @@ struct TodayView: View {
     @State private var path = NavigationPath()
     @State private var sheet: TodaySheet?
     @State private var confirmingArchiveOf: UUID?
+    /// The latest `−` / `+` / `+5m` tap, for the haptic. Recorded by
+    /// the mutation rather than observed on the row: a row keyed on
+    /// its own value ticks when the day rolls over or a sync lands,
+    /// and misses the tap that moves it between sections (a new
+    /// `ForEach` identity sees no old → new).
+    @State private var quickLog: QuickLogEvent?
 
     /// Whether the tip nudge is showing. Seeded in `.onAppear` rather
     /// than in the property's initial value, because `@State` is set up
@@ -216,6 +222,7 @@ struct TodayView: View {
             }
             .scrollContentBackground(.hidden)
             .background(Color.kadoBackground.ignoresSafeArea())
+            .quickLogFeedback(quickLog)
             .refreshable {
                 try? await Task.sleep(for: .seconds(1))
             }
@@ -381,8 +388,10 @@ struct TodayView: View {
 
     private func incrementCounter(_ habitID: UUID) {
         guard let record = record(for: habitID) else { return }
-        CompletionLogger(calendar: calendar)
-            .incrementCounter(for: record, on: loggingInstant, in: modelContext)
+        let logger = CompletionLogger(calendar: calendar)
+        let before = logger.value(for: record, on: loggingInstant)
+        logger.incrementCounter(for: record, on: loggingInstant, in: modelContext)
+        recordQuickLog(for: record, from: before, to: before + 1)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
         checkMilestones(for: record)
@@ -390,19 +399,33 @@ struct TodayView: View {
 
     private func decrementCounter(_ habitID: UUID) {
         guard let record = record(for: habitID) else { return }
-        CompletionLogger(calendar: calendar)
-            .decrementCounter(for: record, on: loggingInstant, in: modelContext)
+        let logger = CompletionLogger(calendar: calendar)
+        let before = logger.value(for: record, on: loggingInstant)
+        logger.decrementCounter(for: record, on: loggingInstant, in: modelContext)
+        recordQuickLog(for: record, from: before, to: max(0, before - 1))
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
     }
 
     private func addFiveMinutes(_ habitID: UUID) {
         guard let record = record(for: habitID) else { return }
-        CompletionLogger(calendar: calendar)
-            .incrementCounter(for: record, on: loggingInstant, by: 300, in: modelContext)
+        let logger = CompletionLogger(calendar: calendar)
+        let before = logger.value(for: record, on: loggingInstant)
+        logger.incrementCounter(for: record, on: loggingInstant, by: 300, in: modelContext)
+        recordQuickLog(for: record, from: before, to: before + 300)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
         checkMilestones(for: record)
+    }
+
+    /// The step is known here exactly — `+1`, `−1` floored at zero,
+    /// `+300` — so the haptic is derived from the mutation, not read
+    /// back from a store that may still hold a just-deleted record.
+    private func recordQuickLog(for record: HabitRecord, from old: Double, to new: Double) {
+        guard let event = QuickLogEvent.next(after: quickLog, type: record.type, oldValue: old, newValue: new) else {
+            return
+        }
+        quickLog = event
     }
 
     private func checkMilestones(for record: HabitRecord) {

--- a/KadoTests/QuickLogFeedbackTests.swift
+++ b/KadoTests/QuickLogFeedbackTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import SwiftUI
 @testable import Kado
+import KadoCore
 
 /// The haptic a quick-log control plays for a change of the day's
 /// recorded value. One feedback per change: `.success` on the edge
@@ -58,9 +59,39 @@ struct QuickLogFeedbackTests {
         #expect(feedback(9, 8) == .selection)
     }
 
-    @Test("A zero target never reports a success edge")
+    @Test("A zero target is met by the first recorded value, as HabitRowState resolves it")
     func zeroTarget() {
-        #expect(feedback(0, 1, target: 0) == .selection)
+        #expect(feedback(0, 1, target: 0) == .success)
         #expect(feedback(1, 2, target: 0) == .selection)
+        #expect(feedback(1, 0, target: 0) == .selection)
+    }
+
+    // MARK: - QuickLogEvent
+
+    @Test("Events are sequenced so identical consecutive steps still differ")
+    func eventSequence() {
+        let first = QuickLogEvent.next(after: nil, type: .counter(target: 8), oldValue: 3, newValue: 4)
+        let second = QuickLogEvent.next(after: first, type: .counter(target: 8), oldValue: 3, newValue: 4)
+        #expect(first?.sequence == 1)
+        #expect(second?.sequence == 2)
+        #expect(first != second)
+        #expect(first?.feedback == .selection)
+        #expect(second?.feedback == .selection)
+    }
+
+    @Test("An event carries the rule's feedback for the habit's own target")
+    func eventFeedback() {
+        let counter = QuickLogEvent.next(after: nil, type: .counter(target: 8), oldValue: 7, newValue: 8)
+        #expect(counter?.feedback == .success)
+        let timer = QuickLogEvent.next(after: nil, type: .timer(targetSeconds: 1800), oldValue: 1500, newValue: 1800)
+        #expect(timer?.feedback == .success)
+        let past = QuickLogEvent.next(after: nil, type: .timer(targetSeconds: 1800), oldValue: 1800, newValue: 2100)
+        #expect(past?.feedback == .selection)
+    }
+
+    @Test("Binary and negative habits produce no event")
+    func noEventForToggles() {
+        #expect(QuickLogEvent.next(after: nil, type: .binary, oldValue: 0, newValue: 1) == nil)
+        #expect(QuickLogEvent.next(after: nil, type: .negative, oldValue: 0, newValue: 1) == nil)
     }
 }

--- a/KadoTests/QuickLogFeedbackTests.swift
+++ b/KadoTests/QuickLogFeedbackTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import SwiftUI
+@testable import Kado
+
+/// The haptic a quick-log control plays for a change of the day's
+/// recorded value. One feedback per change: `.success` on the edge
+/// where the target is met, `.selection` for every other tap — the
+/// taps past the target that used to be silent (#81) included.
+@Suite("QuickLogFeedback")
+struct QuickLogFeedbackTests {
+
+    private func feedback(_ old: Double, _ new: Double, target: Double = 8) -> SensoryFeedback? {
+        QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target)
+    }
+
+    @Test("An unchanged value plays nothing")
+    func unchanged() {
+        #expect(feedback(3, 3) == nil)
+        #expect(feedback(0, 0) == nil)
+        #expect(feedback(12, 12) == nil)
+    }
+
+    @Test("A step below the target is a selection tick")
+    func belowToBelow() {
+        #expect(feedback(3, 4) == .selection)
+        #expect(feedback(0, 1) == .selection)
+    }
+
+    @Test("Reaching the target is a success")
+    func belowToAt() {
+        #expect(feedback(7, 8) == .success)
+    }
+
+    @Test("Jumping past the target in one step is still a success")
+    func belowToPast() {
+        #expect(feedback(7, 12) == .success)
+    }
+
+    @Test("A step from the target upward is a selection tick, not silence")
+    func atToAbove() {
+        #expect(feedback(8, 9) == .selection)
+    }
+
+    @Test("Every step past the target keeps ticking")
+    func aboveToAbove() {
+        #expect(feedback(11, 12) == .selection)
+        #expect(feedback(12, 13) == .selection)
+    }
+
+    @Test("A decrement below the target is a selection tick")
+    func decrementBelow() {
+        #expect(feedback(4, 3) == .selection)
+    }
+
+    @Test("Stepping down off the target is a selection tick, never a success")
+    func decrementOffTarget() {
+        #expect(feedback(8, 7) == .selection)
+        #expect(feedback(9, 8) == .selection)
+    }
+
+    @Test("A zero target never reports a success edge")
+    func zeroTarget() {
+        #expect(feedback(0, 1, target: 0) == .selection)
+        #expect(feedback(1, 2, target: 0) == .selection)
+    }
+}

--- a/docs/plans/2026-09/counter-tap-feedback/compound.md
+++ b/docs/plans/2026-09/counter-tap-feedback/compound.md
@@ -1,6 +1,6 @@
 ---
 name: Counter tap feedback compound
-description: Retrospective on giving every quick-log tap a haptic and bringing the count back into the Today row — the iOS-silent SensoryFeedback kinds, the popover that seeds its own state, and the Dynamic Type regression the preview couldn't show
+description: Retrospective on giving every quick-log tap a haptic and bringing the count back into the Today row — the iOS-silent SensoryFeedback kinds, why a haptic must be keyed on the mutation and not on displayed state, and the Dynamic Type regression the preview couldn't show
 type: project
 ---
 
@@ -17,12 +17,14 @@ Every `+` / `−` / `+5m` tap on the four quick-log controls now ticks
 (`.selection`), with `.success` kept for the tap that meets the target,
 through one tested rule, `QuickLogFeedback`. The Today row shows the
 day's count again — `− 3 +`, `12m +5m` — at every value, reversing the
-ring-only decision from `today-row-actions`. Two deviations from the
-plan: the calendar popover keys its haptic on the tap rather than on the
-value, and the timer row needed the counter's `ViewThatFits` fallback.
-The headline lesson is that the feedback the issue suggested,
-`.increase` / `.decrease`, compiles on iOS and never plays — a fact the
-SDK's swiftinterface doesn't carry and only Apple's doc page states.
+ring-only decision from `today-row-actions`. The big deviation from the
+plan came from the code review, after build: keying each control's
+haptic on the value it displays was the wrong seam, and the haptic
+moved to the **mutation sites** as a `QuickLogEvent`. Two lessons lead:
+the feedback the issue suggested, `.increase` / `.decrease`, compiles on
+iOS and never plays — a fact only Apple's doc page states — and a
+haptic keyed on displayed state fires for every reason that state moves,
+of which the user's tap is only one.
 
 ## Decisions made
 
@@ -43,9 +45,15 @@ SDK's swiftinterface doesn't carry and only Apple's doc page states.
 - **Presentation only**: `state.valueToday` formatted in the row;
   `HabitRowState` unchanged. Timer minutes floor like the VoiceOver
   phrase so the two never disagree.
-- **The popover keys on the tap**: its `Binding` setter is the only
-  user-driven path; it computes the feedback and bumps a `stepTick`. See
-  Surprises.
+- **The haptic is recorded where the value is written**: the mutation
+  functions in `TodayView` and `HabitDetailView` read the value before,
+  derive the value after from the step they apply, and store a sequenced
+  `QuickLogEvent`; one `.quickLogFeedback(_:)` on the `List` / the
+  `ScrollView` plays it. `HabitRowView`, `CounterQuickLogView` and
+  `DayEditPopover` are display-only. See Surprises for why.
+- **The "Log specific value…" sheets keep their own save `.success`**:
+  they save through their own logger call, not through the recording
+  functions, so a save is one haptic, not two.
 - **Timer fallback drops the count, keeps the chip**: at Dynamic Type AX
   sizes `35m +5m` gives way to `+5m` alone. The chip is the action; the
   count is still in `accessibilityValue`.
@@ -68,19 +76,31 @@ SDK's swiftinterface doesn't carry and only Apple's doc page states.
 - **Lesson**: haptic kinds are a per-platform table, not an availability
   annotation. Check the doc page for the kind, not the SDK.
 
-### A popover that seeds its own state ticks on open
+### The value the control displays is the wrong trigger
 
-- **What happened**: `DayEditPopover` seeds `counterValue` in
-  `.onAppear` (0 → today's value). A haptic keyed on that value — the
-  plan's "trigger on whatever the label reads" — would tick every time
-  the popover opens, and play `.success` on a day already done.
-- **What we did**: key on the tap. The `Binding` setter records the
-  feedback for old → new and bumps `stepTick`; one
-  `.sensoryFeedback(trigger: stepTick) { stepFeedback }` on the body
-  covers both steppers.
-- **Lesson**: value-keyed `sensoryFeedback` is only right when the value
-  moves *because* of the user. Anything that seeds, syncs or resets the
-  value under the view needs a tap-keyed trigger instead.
+- **What happened**: the build keyed each control's haptic on the value
+  it shows (`state.valueToday`, `todayValue`), as the plan said. The
+  first crack showed during build: `DayEditPopover` seeds its value in
+  `.onAppear`, so it would have ticked on open — patched locally with a
+  tap counter. The review then found the same fault everywhere else, in
+  four shapes: a new day zeroes every row's value on the first
+  foreground → N ticks on launch (the old `.success` edge never fired on
+  value → 0, so this was a regression, not the "same exposure" the plan
+  claimed); a not-scheduled row that gets logged moves to the other
+  `ForEach`, a new identity that sees no old → new → the first tap on it
+  was silent, the very #81 class; a popover step on today also moved the
+  quick-log control's value → two haptics; and the log sheets stacked
+  their save `.success` on the row's tick.
+- **What we did**: hoisted the haptic to the mutation sites. They know
+  `(old, new, target)` exactly — the step is a fixed `+1`, `−1` floored
+  at zero, `+300`, or the explicit value — so each records a sequenced
+  `QuickLogEvent` and one `.quickLogFeedback(_:)` on a stable ancestor
+  plays it. Every control-level haptic went away, the popover patch
+  included (it is byte-identical to `main` again).
+- **Lesson**: a haptic answers *"did my tap land?"*, so it must be keyed
+  on the tap. Displayed state moves for many reasons — seed, rollover,
+  sync, container swap, a re-created row — and a trigger on it can't
+  tell them apart. Record the event where the write happens.
 
 ### The Dynamic Type regression the preview couldn't show
 
@@ -114,16 +134,21 @@ SDK's swiftinterface doesn't carry and only Apple's doc page states.
 
 ## For the next person
 
-- `QuickLogFeedback` is the single place the haptic rule lives. If a new
-  quick-log control appears (a watch complication, a widget intent's
-  in-app echo), apply it there; don't add a `.success` edge beside it.
-- The Today row keys on `state.valueToday`, so a value that moves under
-  the row — CloudKit sync, the midnight rollover — ticks once. The
-  `.success` edge already had that exposure. If it is ever reported,
-  the plan's Risks section describes the tap-keyed swap; the rule
-  doesn't change.
-- The popover is tap-keyed **on purpose**; #80 (its stuck display) can
-  change the popover's state model without touching the trigger.
+- `QuickLogFeedback` is the single place the haptic rule lives, and
+  `QuickLogEvent.next(after:type:oldValue:newValue:)` is how a mutation
+  reports itself. A new quick-log path (a watch action, an intent's
+  in-app echo) records an event in the function that writes the value;
+  it does **not** put a `.sensoryFeedback` on the control.
+- The value *after* is derived from the step, never read back: after
+  `context.delete` the relationship can still hold the record until the
+  save lands, so a read-back would say `1` where the user sees `0`.
+- The binary / negative toggles still key `.success` on `state.status`
+  in `HabitRowView` — untouched by this PR, and they carry the same
+  rollover exposure (a completed row goes `.complete → .none` on the
+  first foreground of a new day). Moving toggles onto the same event is
+  a small follow-up; it needs a decision on what un-ticking plays.
+- `DayEditPopover` is untouched relative to `main`; #80 can restructure
+  it freely.
 - The count label is `.fixedSize(horizontal:)`. It's short by nature; if
   a count ever reaches four digits at AX5 it overflows rather than wraps,
   which is the right failure.
@@ -153,20 +178,27 @@ SDK's swiftinterface doesn't carry and only Apple's doc page states.
   is the preview's `.accessibility3`; `accessibility-extra-extra-extra-large`
   is the ceiling; `large` is default). XcodeBuildMCP can't set it, and a
   preview only covers the row types it holds.
-- **[→ CLAUDE.md]** A value-keyed `.sensoryFeedback` on a view that
-  seeds its own `@State` in `.onAppear` ticks on appear. Key such views
-  on the tap.
+- **[→ CLAUDE.md]** Key a tap haptic on the **mutation**, not on the
+  state a control displays. `.sensoryFeedback(trigger: displayedValue)`
+  fires on seed-on-appear, the day rollover, a CloudKit sync, a
+  container swap, and misses a tap that re-creates the view (a row moving
+  between `ForEach`es). Pattern: the function that writes records a
+  sequenced event in `@State`; one `.sensoryFeedback(trigger:)` on a
+  stable ancestor plays it (`QuickLogEvent` / `.quickLogFeedback(_:)`).
+- **[→ CLAUDE.md]** Run `/code-review` before the on-device check, not
+  after. It found four wiring faults in a build that had green unit and
+  UI suites and a clean screenshot pass — none of which can see a haptic.
 - **[local]** The row's ring-only design is reverted; the count is back
   by decision, not by accident.
 
 ## Metrics
 
-- Tasks completed: 5 of 5
-- Tests added: 9 (`QuickLogFeedbackTests`)
-- Commits: 6 on the branch (plan, four tasks, compound)
-- Files touched: 7 (`QuickLogFeedback.swift`, its tests, `HabitRowView`,
-  `CounterQuickLogView`, `DayEditPopover`, `Localizable.xcstrings`, the
-  plan)
+- Tasks completed: 5 of 5, plus one review pass
+- Tests added: 12 (`QuickLogFeedbackTests`)
+- Commits: 7 on the branch (plan, four tasks, compound, review fix)
+- Files touched: 9 (`QuickLogFeedback.swift`, its tests, `HabitRowView`,
+  `CounterQuickLogView`, `TodayView`, `HabitDetailView`,
+  `CompletionLogger`, `Localizable.xcstrings`, the plan)
 
 ## References
 

--- a/docs/plans/2026-09/counter-tap-feedback/compound.md
+++ b/docs/plans/2026-09/counter-tap-feedback/compound.md
@@ -1,0 +1,180 @@
+---
+name: Counter tap feedback compound
+description: Retrospective on giving every quick-log tap a haptic and bringing the count back into the Today row — the iOS-silent SensoryFeedback kinds, the popover that seeds its own state, and the Dynamic Type regression the preview couldn't show
+type: project
+---
+
+# Compound — Counter tap feedback
+
+**Date**: 2026-09-11
+**Status**: complete
+**Plan**: [plan.md](./plan.md)
+**Branch / PR**: `feature/counter-tap-feedback` · [#85](https://github.com/scastiel/kado/pull/85) · closes [#81](https://github.com/scastiel/kado/issues/81)
+
+## Summary
+
+Every `+` / `−` / `+5m` tap on the four quick-log controls now ticks
+(`.selection`), with `.success` kept for the tap that meets the target,
+through one tested rule, `QuickLogFeedback`. The Today row shows the
+day's count again — `− 3 +`, `12m +5m` — at every value, reversing the
+ring-only decision from `today-row-actions`. Two deviations from the
+plan: the calendar popover keys its haptic on the tap rather than on the
+value, and the timer row needed the counter's `ViewThatFits` fallback.
+The headline lesson is that the feedback the issue suggested,
+`.increase` / `.decrease`, compiles on iOS and never plays — a fact the
+SDK's swiftinterface doesn't carry and only Apple's doc page states.
+
+## Decisions made
+
+- **`.selection` per tap, `.success` on the edge, one rule**:
+  `QuickLogFeedback.feedback(oldValue:newValue:target:)` returns exactly
+  one feedback per change, so the two never stack on the tap that meets
+  the target. The rule is a pure `nonisolated enum` in the app target;
+  `SensoryFeedback` is `Equatable`, so nine cases pin it.
+- **All four controls, not just the reported one**: the Today row, the
+  detail quick-log and the calendar popover shared the edge-only pattern
+  (the popover had nothing). A tap should feel the same wherever it lands.
+- **Count always visible, value only**: `− 3 +` reads as the classic
+  stepper without explanation; the ring still carries the target
+  relation under target and the filled disc says "met" past it. Reverts
+  *"drop value/target text; the ring is sufficient"* — the ring
+  structurally can't express past-target, which is where the reporter
+  was.
+- **Presentation only**: `state.valueToday` formatted in the row;
+  `HabitRowState` unchanged. Timer minutes floor like the VoiceOver
+  phrase so the two never disagree.
+- **The popover keys on the tap**: its `Binding` setter is the only
+  user-driven path; it computes the feedback and bumps a `stepTick`. See
+  Surprises.
+- **Timer fallback drops the count, keeps the chip**: at Dynamic Type AX
+  sizes `35m +5m` gives way to `+5m` alone. The chip is the action; the
+  count is still in `accessibilityValue`.
+- **One catalog key, `%lldm` → `%lld min`**: mirrors `+5m` → `+5 min`.
+  The counter's number uses `Text(_:format:)` and needs no key.
+
+## Surprises and how we handled them
+
+### `.increase` / `.decrease` are silent on iOS
+
+- **What happened**: the issue proposed
+  `.sensoryFeedback(.increase, trigger:)`. The SDK declares every
+  `SensoryFeedback` kind `@available(iOS 17.0, …)`, and the
+  swiftinterface strips doc comments, so nothing at compile time says
+  otherwise. Apple's doc page for each kind does: *"Only plays feedback
+  on watchOS and visionOS."*
+- **What we did**: fetched the per-kind doc pages before planning
+  (`SensoryFeedback/increase`, `/selection`) and used `.selection`,
+  whose page reads *"Only plays feedback on iOS and watchOS."*
+- **Lesson**: haptic kinds are a per-platform table, not an availability
+  annotation. Check the doc page for the kind, not the SDK.
+
+### A popover that seeds its own state ticks on open
+
+- **What happened**: `DayEditPopover` seeds `counterValue` in
+  `.onAppear` (0 → today's value). A haptic keyed on that value — the
+  plan's "trigger on whatever the label reads" — would tick every time
+  the popover opens, and play `.success` on a day already done.
+- **What we did**: key on the tap. The `Binding` setter records the
+  feedback for old → new and bumps `stepTick`; one
+  `.sensoryFeedback(trigger: stepTick) { stepFeedback }` on the body
+  covers both steppers.
+- **Lesson**: value-keyed `sensoryFeedback` is only right when the value
+  moves *because* of the user. Anything that seeds, syncs or resets the
+  value under the view needs a tap-keyed trigger instead.
+
+### The Dynamic Type regression the preview couldn't show
+
+- **What happened**: the `"Dynamic Type XXXL"` preview holds a binary
+  and a counter row — no timer. At AX3 on the simulator the timer row's
+  `35m` and `+5m` chip both wrapped mid-token (`35 / m`, `+5 / m`),
+  because the count now shares the trailing space with the chip.
+- **What we did**: gave the timer trailing the counter's `ViewThatFits`
+  (`35m +5m`, then the chip alone) and `.fixedSize(horizontal:)` on the
+  count so it can never split. Verified at AX3 and AX5 with
+  `xcrun simctl ui <udid> content_size accessibility-extra-large` /
+  `accessibility-extra-extra-extra-large`, then reset to `large`.
+- **Lesson**: a Dynamic Type preview only covers the row types you put
+  in it. The simulator's content size is settable from the shell even
+  though the run tools can't set it, and a seeded launch plus one
+  screenshot per size is a two-minute check.
+
+## What worked well
+
+- **A pure rule with nine tests** for a six-line function. It pins the
+  "no double haptic on the edge" invariant, which no preview or
+  simulator run can hear.
+- **The screenshot seed as the pixel-check dataset**: launching with
+  `-uiTestRun -uiTestResetState -uiTestSeedProduction
+  -uiTestSeedForScreenshots` gives a counter mid-fill and an unlogged
+  timer on a fresh simulator. Bumping the seed's today values locally
+  (12 / 2100s) and `git checkout`-ing them back showed the complete and
+  over-target rows without tap primitives.
+- **`ViewThatFits` as the one answer for large text** — the counter had
+  it; the timer just needed the same shape.
+
+## For the next person
+
+- `QuickLogFeedback` is the single place the haptic rule lives. If a new
+  quick-log control appears (a watch complication, a widget intent's
+  in-app echo), apply it there; don't add a `.success` edge beside it.
+- The Today row keys on `state.valueToday`, so a value that moves under
+  the row — CloudKit sync, the midnight rollover — ticks once. The
+  `.success` edge already had that exposure. If it is ever reported,
+  the plan's Risks section describes the tap-keyed swap; the rule
+  doesn't change.
+- The popover is tap-keyed **on purpose**; #80 (its stuck display) can
+  change the popover's state model without touching the trigger.
+- The count label is `.fixedSize(horizontal:)`. It's short by nature; if
+  a count ever reaches four digits at AX5 it overflows rather than wraps,
+  which is the right failure.
+- VoiceOver output is unchanged (`Drink water, counter, target 8` /
+  `3 of 8, streak 2, score 55 percent`): the row is one combined element
+  with an explicit label and value, and the new `Text` never reaches
+  the screen reader on its own.
+- Haptics can't be verified on a simulator. The rule is tested; the
+  wiring is one modifier per control; one on-device pass is still owed
+  before the PR leaves draft.
+- The App Store Today captures now show counter rows without a count.
+  Re-run `make screenshots` with the next listing refresh.
+- Seen at AX sizes, pre-existing, not touched here: the binary checkmark
+  glyph overflows its 28pt circle, the "Slipped" pill breaks into three
+  lines at AX5, and the habit name is a fixed 15pt system font. Worth an
+  issue of their own.
+
+## Generalizable lessons
+
+- **[→ CLAUDE.md]** `SensoryFeedback` kinds are a per-platform table,
+  not an availability annotation: `.increase`, `.decrease`, `.start`,
+  `.stop` and `.pathComplete` compile on iOS and never play; `.selection`,
+  `.impact`, `.success`, `.warning`, `.error` do. The swiftinterface
+  strips the note — read the kind's doc page.
+- **[→ CLAUDE.md]** Set Dynamic Type on a simulator with
+  `xcrun simctl ui <udid> content_size <size>` (`accessibility-extra-large`
+  is the preview's `.accessibility3`; `accessibility-extra-extra-extra-large`
+  is the ceiling; `large` is default). XcodeBuildMCP can't set it, and a
+  preview only covers the row types it holds.
+- **[→ CLAUDE.md]** A value-keyed `.sensoryFeedback` on a view that
+  seeds its own `@State` in `.onAppear` ticks on appear. Key such views
+  on the tap.
+- **[local]** The row's ring-only design is reverted; the count is back
+  by decision, not by accident.
+
+## Metrics
+
+- Tasks completed: 5 of 5
+- Tests added: 9 (`QuickLogFeedbackTests`)
+- Commits: 6 on the branch (plan, four tasks, compound)
+- Files touched: 7 (`QuickLogFeedback.swift`, its tests, `HabitRowView`,
+  `CounterQuickLogView`, `DayEditPopover`, `Localizable.xcstrings`, the
+  plan)
+
+## References
+
+- [#81](https://github.com/scastiel/kado/issues/81) — the report;
+  [#80](https://github.com/scastiel/kado/issues/80) — the popover's stuck
+  display, same email, separate PR.
+- [`SensoryFeedback.increase`](https://developer.apple.com/documentation/swiftui/sensoryfeedback/increase)
+  and [`SensoryFeedback.selection`](https://developer.apple.com/documentation/swiftui/sensoryfeedback/selection)
+  — the platform notes.
+- `docs/plans/2026-04/today-row-actions/compound.md` — the ring-only
+  decision this reverses.

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -1,0 +1,283 @@
+# Plan — Counter tap feedback
+
+**Date**: 2026-09-11
+**Status**: ready to build
+**Research**: none — planned directly from
+[#81](https://github.com/scastiel/kado/issues/81), which already names the
+code sites and the cause. Assumptions are called out inline.
+
+## Summary
+
+On Today, tapping `+` on a counter row past its target gives nothing back:
+the ring is already full, the `.success` haptic only fires on the
+not-complete → complete edge, and the row shows no number. After tap 11 the
+user can't tell whether the tap registered or what the count is. This plan
+gives every quick-log tap a haptic tick (`.selection`, with `.success` kept
+for the moment the target is met) across the four controls that share the
+edge-only pattern, and brings a count back into the Today row's stepper —
+`− 3 +` at every value, not only past the target — for counter and timer
+habits alike.
+
+One finding worth its own line: the `.increase` / `.decrease` feedback the
+issue suggests **compiles on iOS and never plays** — Apple's docs for both:
+*"Only plays feedback on watchOS and visionOS."* `.selection` is the iOS
+kind for movement through discrete values (*"Only plays feedback on iOS and
+watchOS"*), so that's what every tap uses.
+
+## Decisions locked in
+
+- **Haptic rule, one place**: `.success` when a change crosses from below
+  the target to at-or-above it; `.selection` for every other change of the
+  recorded value (increments past the target, every decrement); nothing
+  when the value doesn't change. Exactly one feedback per tap — the two
+  never stack on the edge.
+- The rule is a pure `nonisolated enum QuickLogFeedback` in the app target
+  (`SensoryFeedback` is `Equatable`, so it's unit-testable), applied through
+  the `sensoryFeedback(trigger:) { old, new in … }` overload, which
+  replaces the existing `.sensoryFeedback(.success, trigger:) { !old && new }`
+  chains rather than sitting beside them.
+- **All four quick-log controls** get the rule: `HabitRowView.counterStepper`
+  and `timerAddFiveChip` (Today), `CounterQuickLogView` (Detail),
+  `DayEditPopover`'s counter and timer steppers (calendar). Binary /
+  negative toggles are untouched — a toggle has no "every tap" case.
+- **The count is always visible in the row**: `− 3 +` for counters, `12m +5m`
+  for timers, at every value including `0`. This reverts the
+  *"drop value/target text; the ring is sufficient"* decision in
+  `docs/plans/2026-04/today-row-actions/compound.md` — the ring
+  structurally can't express past-target, and the classic stepper idiom
+  answers "what's the count now" without explanation. Value only, no
+  `/target`: the ring carries the target relation under target, and the
+  filled disc says "met" past it.
+- The count is **presentation only** — `state.valueToday` formatted in the
+  view; `HabitRowState` doesn't change. Timer minutes floor to the minute
+  (`Int(value / 60)`), the same rounding `accessibilityProgressText`
+  already uses.
+- Haptics trigger on the **recorded value**, not on the tap — same as the
+  existing `.success` today. A value that changes under the row from a
+  CloudKit sync or the midnight rollover will tick once; that's the
+  precedent the `.success` edge already set. See Risks for the swap if it
+  proves annoying.
+- The count animates with `.contentTransition(.numericText(value:))` under
+  `KadoMotion.fast`, disabled when `accessibilityReduceMotion` is on.
+- VoiceOver output is unchanged: the row is `.accessibilityElement(children:
+  .combine)` with an explicit label / value, so the new `Text` never reaches
+  the screen reader twice; the `N of target` phrase stays in
+  `accessibilityValue` because the visual drops the target.
+
+## Task list
+
+### Task 1: `QuickLogFeedback` rule (tests first)
+
+**Goal**: one tested function that says which haptic a change of the day's
+recorded value plays.
+
+**Changes**:
+- `KadoTests/QuickLogFeedbackTests.swift` (write first, `test_sim` red):
+  - unchanged value → `nil`
+  - below → below (3 → 4, target 8) → `.selection`
+  - below → at (7 → 8) → `.success`
+  - below → past in one step (7 → 12) → `.success`
+  - at → above (8 → 9) → `.selection` — **the reported silence**
+  - above → above (11 → 12) → `.selection`
+  - decrement below (4 → 3) → `.selection`
+  - decrement off the target (8 → 7) → `.selection`, never `.success`
+  - target 0 (a legacy or degenerate habit): 0 → 1 → `.selection`
+- `Kado/UIComponents/QuickLogFeedback.swift`:
+  ```swift
+  nonisolated enum QuickLogFeedback {
+      static func feedback(oldValue: Double, newValue: Double, target: Double) -> SensoryFeedback?
+  }
+  ```
+  Doc comment names the `.increase` / `.decrease` trap so nobody
+  "simplifies" it back.
+
+**Tests / verification**:
+- `test_sim` green; nine cases above.
+
+**Commit message (suggested)**: `feat(today): add the quick-log haptic rule`
+
+---
+
+### Task 2: Wire the Today row — counter stepper and timer chip
+
+**Goal**: every `+` / `−` / `+5m` tap on Today ticks; the target edge still
+plays `.success`.
+
+**Changes**:
+- `Kado/UIComponents/HabitRowView.swift`:
+  - `counterStepper(target:)`: replace `.sensoryFeedback(.success, trigger:
+    isComplete) { !old && new }` with
+    `.sensoryFeedback(trigger: state.valueToday ?? 0) { old, new in
+    QuickLogFeedback.feedback(oldValue: old, newValue: new, target: target) }`.
+  - `timerAddFiveChip(target:)`: same, with `targetSeconds`.
+  - The modifier stays on the `ViewThatFits` / chip, outside the buttons,
+    so the VoiceOver rotor actions (`rowAccessibilityActions`) tick too —
+    they drive the same callbacks and the same state.
+
+**Tests / verification**:
+- `build_run_sim` (iPhone 17 Pro): tap `+` on a counter row 12 times on a
+  target of 10 — haptics can't be felt in the simulator, so the check is
+  that the build compiles and the row still fills / completes; the rule
+  itself is Task 1's tests. On device: a tick per tap, `.success` once at
+  10, ticks again at 11 and 12, a tick per `−`.
+- `test_sim` still green (`TodayRowTests`, `HabitRowStateTests`).
+
+**Commit message (suggested)**: `fix(today): tick on every counter and timer tap, not only at the target`
+
+---
+
+### Task 3: Wire the Detail screen — quick-log control and calendar popover
+
+**Goal**: the detail quick-log and the calendar day popover feel the same as
+the row.
+
+**Changes**:
+- `Kado/UIComponents/CounterQuickLogView.swift`: replace the
+  `targetReached`-edge `.sensoryFeedback` with the rule, trigger
+  `todayValue`.
+- `Kado/Views/HabitDetail/DayEditPopover.swift`:
+  - `counterControl(target:)`: `.sensoryFeedback(trigger: counterValue) {
+    old, new in QuickLogFeedback.feedback(oldValue: Double(old), newValue:
+    Double(new), target: Double(target)) }` on the `Stepper`.
+  - `timerControl(targetMinutes:)`: same on `timerMinutes` against
+    `targetMinutes`.
+  - **#80 lands in this file.** Trigger on whichever value the popover's
+    label reads — today that's the local `@State`; if #80's fix makes
+    `currentValue` the source of truth, the trigger moves with it. Either
+    order works; whichever PR merges second rebases a two-line hunk.
+- Update `CounterQuickLogView`'s docstring ("A success haptic fires once
+  when …") to describe the rule.
+
+**Tests / verification**:
+- `build_sim` clean. Previews for both files still render.
+- On device: `Stepper` taps in the popover tick; the system `Stepper` has
+  no haptic of its own, so no double-tick to check for.
+
+**Commit message (suggested)**: `fix(habit-detail): tick on every quick-log and popover stepper tap`
+
+---
+
+### Task 4: Show the count in the Today row
+
+**Goal**: `− 3 +` on counter rows and `12m +5m` on timer rows, at every
+value, so the number past the target — and every tap's effect — is visible.
+
+**Changes**:
+- `Kado/UIComponents/HabitRowView.swift`:
+  - New `countLabel` subview: `Text(Int(state.valueToday ?? 0), format:
+    .number)` for counters (no catalog key — a bare number), `Text("\(minutes)m")`
+    for timers. `.font(.callout.weight(.semibold).monospacedDigit())`,
+    `habit.color.color` when `isComplete`, `Color.kadoForeground` otherwise
+    — the same colour rule as `CounterQuickLogView`'s big number.
+    `.contentTransition(.numericText(value:))` + `.animation(reduceMotion ?
+    nil : KadoMotion.fast, value: state.valueToday)`; add
+    `@Environment(\.accessibilityReduceMotion)` to the row.
+  - `counterStepperFull`: `− count +`. `counterStepperPlusOnly` (the
+    Dynamic Type XXL+ fallback): `count +` — the count is the point of the
+    change, so it survives the collapse; the `−` is what gives way.
+  - `timerAddFiveChip`: `HStack(spacing: 8) { countLabel; chip }`.
+  - Stale comments: the type docstring's **Trailing** bullet, the
+    `counterStepper` doc (still says `− value/target +` from before the
+    ring), and `accessibilityProgressText`'s "surfaced here because the
+    visual text was removed" — now "the visual shows the value; VoiceOver
+    also needs the target".
+  - Previews: extend `"Counter — partial / overshoot"` with a `0` counter
+    row and an over-target timer row (`2100s` on `1800s`); `"Dynamic Type
+    XXXL"` and `"Dark"` already hold counter rows and pick the change up.
+- `Kado/Resources/Localizable.xcstrings`: one new key, `%lldm` — FR
+  `%lld min`, mirroring `+5m` → `+5 min`. Comment: "Minutes logged today,
+  before the +5m chip on a timer Today row. Argument is whole minutes."
+  Hand-authored; the catalog is source.
+
+**Tests / verification**:
+- `test_sim`: `LocalizationCoverageTests` passes with the new key.
+- `screenshot` after `build_run_sim` on iPhone 17 Pro: a `0`, a partial, a
+  complete and an over-target counter row, and a timer row. Check the `−`
+  doesn't jump when the count crosses 9 → 10 (monospaced digits keep same-
+  length counts steady; if the one-digit → two-digit step looks jumpy, give
+  the label a `@ScaledMetric` `minWidth` — build-time polish, not a
+  decision).
+- Dynamic Type XXXL preview: the row collapses to `count +` and the name
+  still gets its line. Increase Contrast: `kadoForeground` on `kadoPaper50`
+  is the row's own text colour, nothing new to check.
+- iPad Air (M4) `build_sim`: compiles; the row is width-independent.
+- VoiceOver on the row: label / value unchanged (`Drink water, counter,
+  target 8` / `3 of 8, streak 2, score 55 percent`).
+
+**Commit message (suggested)**: `feat(today): show the day's count in the counter stepper and timer chip`
+
+---
+
+### Task 5: Visual and accessibility pass, then compound
+
+**Goal**: the definition of done, on the two surfaces that changed.
+
+**Changes**:
+- Fixups from the screenshot pass, if any, squashed into Task 4.
+- `docs/plans/2026-09/counter-tap-feedback/compound.md`: the `.increase`
+  trap, the reversal of the ring-only row decision and why, anything the
+  visual pass caught.
+- Mark the PR ready; link #81 with `Closes #81`.
+
+**Tests / verification**:
+- `build_sim` iPhone + iPad, no new warnings; `test_sim` green;
+  `make e2e` green (the UI suite doesn't read the count today, but the row
+  identifier and combined element must still resolve).
+
+**Commit message (suggested)**: `docs(plans): compound the counter tap feedback`
+
+## Integration checkpoints
+
+- **SwiftData / CloudKit / HealthKit / widgets**: none. No schema, no
+  snapshot-shape change; the widget snapshot builder is untouched.
+- **Issue #80** shares `DayEditPopover` — see Task 3 for the trigger note.
+- **Localization**: one new key (`%lldm`), pinned by
+  `LocalizationCoverageTests`.
+- **App Store screenshots**: the Today captures under
+  `docs/app-store/screenshots/` show counter rows without a count. They
+  drift after Task 4; re-run `make screenshots` with the next listing
+  refresh rather than in this PR (a simulator per language per device, half
+  an hour — see `docs/app-store/README.md`).
+
+## Risks and mitigation
+
+- **Haptics can't be verified in the simulator.** The rule is pinned by
+  unit tests; the wiring is a one-line modifier per control. Budget one
+  on-device check (TestFlight or a cable) before marking the PR ready —
+  it's the reporter's complaint, and `test_sim` can't hear it.
+- **A tick for a change the user didn't make** (sync, midnight). Same
+  exposure the `.success` edge already has. If it's ever reported, switch
+  the trigger to a per-tap `@State` counter incremented in the button
+  action and compute the feedback from `(valueToday, valueToday + step,
+  target)` — the step is fixed (1, or 300s), so the prediction is exact.
+  `QuickLogFeedback` doesn't change.
+- **Row width at large Dynamic Type.** `ViewThatFits` already drops the
+  `−`; the count adds one to two digits to both variants. If the XXXL
+  preview clips the name, the plus-only variant can drop the count last —
+  `accessibilityValue` still carries the number, so nothing is lost for
+  the users most likely to be at that size.
+- **`.numericText` and Reduce Motion.** The transition only animates under
+  an explicit animation; gating `.animation(value:)` on `reduceMotion` is
+  the whole fix. The ring's `KadoMotion.base` animation isn't gated today
+  — 200 ms ease-out is below the threshold where Reduce Motion matters —
+  but the count's transition is gated because it's a new, more visible
+  motion.
+
+## Open questions
+
+- [ ] `0` at rest, or hide the count until something is logged? The plan
+  shows `0` (the classic stepper; a disabled `−` beside it reads as
+  "nothing yet"). Decide on the screenshot in Task 4 if `0m +5m` looks
+  noisy on a fresh Today.
+
+## Out of scope
+
+- **#80** — the popover's stuck display. Separate bug, separate PR; the
+  two touch different lines of `DayEditPopover`.
+- **`MonthlyCalendarView` treating any counter value as `.completed`**
+  (noted in #80). Grid styling, not row feedback.
+- **Per-habit haptic profiles** (the deferred idea in
+  `today-row-actions/plan.md`). One rule for every control first.
+- **Watch app** quick-log haptics — `.increase` / `.decrease` do play
+  there, which is a different design.
+- **Re-shooting the App Store listing** — with the next listing change.

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -157,7 +157,7 @@ the row.
 
 ---
 
-### Task 4: Show the count in the Today row
+### Task 4: Show the count in the Today row ✅
 
 **Goal**: `− 3 +` on counter rows and `12m +5m` on timer rows, at every
 value, so the number past the target — and every tap's effect — is visible.
@@ -276,6 +276,21 @@ value, so the number past the target — and every tap's effect — is visible.
   section describes for the row, needed here for a different reason. If
   #80 moves the popover off local state, the trigger stays where it is —
   it never depended on the state.
+- **Task 4**: the Dynamic Type pass caught a real regression the XXXL
+  preview couldn't (it holds no timer row): at AX3 the timer row's `35m`
+  and its `+5m` chip both wrapped mid-token — `35 / m`, `+5 / m` — because
+  the count now shares the trailing space with the chip. Fixed with the
+  same `ViewThatFits` fallback the counter already had (`35m +5m`, then
+  the chip alone) and `.fixedSize(horizontal:)` on the count so it can
+  never split. Verified at AX3 and AX5 on the simulator via
+  `simctl ui <udid> content_size`, which the run tools can't set. Seen
+  alongside, **pre-existing** and untouched: the binary checkmark glyph
+  overflows its 28pt circle at AX sizes, the "Slipped" pill breaks into
+  three lines at AX5, and the habit name is a fixed 15pt system font.
+- **Task 4**: to see the complete and over-target rows without tap
+  primitives, the screenshot seed's today values were bumped locally
+  (water 5 → 12, read nil → 2100s), photographed, and `git checkout`-ed
+  back. Nothing of it is committed.
 
 ## Open questions
 

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -53,11 +53,13 @@ watchOS"*), so that's what every tap uses.
   view; `HabitRowState` doesn't change. Timer minutes floor to the minute
   (`Int(value / 60)`), the same rounding `accessibilityProgressText`
   already uses.
-- Haptics trigger on the **recorded value**, not on the tap — same as the
-  existing `.success` today. A value that changes under the row from a
-  CloudKit sync or the midnight rollover will tick once; that's the
-  precedent the `.success` edge already set. See Risks for the swap if it
-  proves annoying.
+- ~~Haptics trigger on the **recorded value**, not on the tap — same as
+  the existing `.success` today. A value that changes under the row from
+  a CloudKit sync or the midnight rollover will tick once; that's the
+  precedent the `.success` edge already set.~~ **Reversed after review**
+  (see Notes during build): the haptic is recorded at the **mutation
+  site** as a `QuickLogEvent` and played by one `.quickLogFeedback(_:)`
+  on a stable ancestor. The controls carry no haptic of their own.
 - The count animates with `.contentTransition(.numericText(value:))` under
   `KadoMotion.fast`, disabled when `accessibilityReduceMotion` is on.
 - VoiceOver output is unchanged: the row is `.accessibilityElement(children:
@@ -246,12 +248,13 @@ value, so the number past the target — and every tap's effect — is visible.
   unit tests; the wiring is a one-line modifier per control. Budget one
   on-device check (TestFlight or a cable) before marking the PR ready —
   it's the reporter's complaint, and `test_sim` can't hear it.
-- **A tick for a change the user didn't make** (sync, midnight). Same
-  exposure the `.success` edge already has. If it's ever reported, switch
-  the trigger to a per-tap `@State` counter incremented in the button
-  action and compute the feedback from `(valueToday, valueToday + step,
-  target)` — the step is fixed (1, or 300s), so the prediction is exact.
-  `QuickLogFeedback` doesn't change.
+- **A tick for a change the user didn't make** (sync, midnight). ~~Same
+  exposure the `.success` edge already has.~~ Wrong — the old edge fired
+  on `false → true` only and never on a value → 0 path, so a value-keyed
+  `.selection` was *new* exposure: every counter and timer row would
+  tick at once on the first foreground of a new day. Materialised in
+  review and fixed by the tap-keyed swap this bullet sketched; see Notes
+  during build.
 - **Row width at large Dynamic Type.** `ViewThatFits` already drops the
   `−`; the count adds one to two digits to both variants. If the XXXL
   preview clips the name, the plus-only variant can drop the count last —
@@ -276,7 +279,9 @@ value, so the number past the target — and every tap's effect — is visible.
   body covers both steppers. That's the "tap-keyed" alternative the Risks
   section describes for the row, needed here for a different reason. If
   #80 moves the popover off local state, the trigger stays where it is —
-  it never depended on the state.
+  it never depended on the state. *Superseded by the review fix below:
+  the popover's `stepTick` is gone; `HabitDetailView` records the event
+  where it writes the value.*
 - **Task 4**: the Dynamic Type pass caught a real regression the XXXL
   preview couldn't (it holds no timer row): at AX3 the timer row's `35m`
   and its `+5m` chip both wrapped mid-token — `35 / m`, `+5 / m` — because
@@ -292,6 +297,32 @@ value, so the number past the target — and every tap's effect — is visible.
   primitives, the screenshot seed's today values were bumped locally
   (water 5 → 12, read nil → 2100s), photographed, and `git checkout`-ed
   back. Nothing of it is committed.
+- **Review (`/code-review` on the finished branch)**: keying the row's
+  haptic on `state.valueToday` was the wrong seam, for four reasons the
+  review made concrete. (1) A new day zeroes every row's value on the
+  first foreground → N simultaneous ticks on launch; the old `.success`
+  edge never fired on value → 0, so this was a regression, not the
+  "same exposure" the plan claimed. (2) A not-scheduled row that gets
+  logged moves from the *other* `ForEach` to the *due* one — a new
+  identity that never sees old → new — so the first tap on it was
+  silent: the #81 class, still open for that case. (3) On Detail, a
+  popover step on today also moved `CounterQuickLogView`'s value → two
+  haptics per tap; and the "Log specific value…" sheets stacked their
+  own save `.success` on the row's tick. (4) `target ≤ 0` never played
+  `.success` while `HabitRowState` filled the badge. **Fix**: the
+  mutation sites — `TodayView.incrementCounter / decrementCounter /
+  addFiveMinutes`, `HabitDetailView`'s counterparts plus `setCounter /
+  setTimerSeconds / clear` — read the value before, derive the value
+  after from the step they apply (fixed `+1`, `−1` floored, `+300`, or
+  the explicit value), and record a sequenced `QuickLogEvent`; one
+  `.quickLogFeedback(quickLog)` sits on the Today `List` and the detail
+  `ScrollView`. `HabitRowView`, `CounterQuickLogView` and
+  `DayEditPopover` carry no haptic (the popover is byte-identical to
+  `main` again — nothing for #80 to rebase). The sheets keep their
+  `.success` because they save through their own logger call, not
+  through these functions. `Clear` ticks like any step to 0. The
+  zero-target rule now mirrors `HabitRowState`. `QuickLogFeedback`'s
+  nine cases are unchanged; three `QuickLogEvent` cases join them.
 
 ## Open questions
 

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -1,7 +1,8 @@
 # Plan — Counter tap feedback
 
 **Date**: 2026-09-11
-**Status**: ready to build
+**Status**: done
+**Compound**: [compound.md](./compound.md)
 **Research**: none — planned directly from
 [#81](https://github.com/scastiel/kado/issues/81), which already names the
 code sites and the cause. Assumptions are called out inline.
@@ -208,7 +209,7 @@ value, so the number past the target — and every tap's effect — is visible.
 
 ---
 
-### Task 5: Visual and accessibility pass, then compound
+### Task 5: Visual and accessibility pass, then compound ✅
 
 **Goal**: the definition of done, on the two surfaces that changed.
 
@@ -296,8 +297,9 @@ value, so the number past the target — and every tap's effect — is visible.
 
 - [ ] `0` at rest, or hide the count until something is logged? The plan
   shows `0` (the classic stepper; a disabled `−` beside it reads as
-  "nothing yet"). Decide on the screenshot in Task 4 if `0m +5m` looks
-  noisy on a fresh Today.
+  "nothing yet"). Shipped as `0` / `0m` — on the seeded Today the timer
+  row reads `0m +5m`, which scans as "0 minutes, add 5". Hiding it is a
+  one-line `if` in `countLabel` if it grates.
 
 ## Out of scope
 

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -98,7 +98,7 @@ recorded value plays.
 
 ---
 
-### Task 2: Wire the Today row — counter stepper and timer chip
+### Task 2: Wire the Today row — counter stepper and timer chip ✅
 
 **Goal**: every `+` / `−` / `+5m` tap on Today ticks; the target edge still
 plays `.success`.

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -126,7 +126,7 @@ plays `.success`.
 
 ---
 
-### Task 3: Wire the Detail screen — quick-log control and calendar popover
+### Task 3: Wire the Detail screen — quick-log control and calendar popover ✅
 
 **Goal**: the detail quick-log and the calendar day popover feel the same as
 the row.
@@ -262,6 +262,20 @@ value, so the number past the target — and every tap's effect — is visible.
   — 200 ms ease-out is below the threshold where Reduce Motion matters —
   but the count's transition is gated because it's a new, more visible
   motion.
+
+## Notes during build
+
+- **Task 3**: `DayEditPopover` can't key its haptic on the value the
+  label reads, as the plan said. The popover seeds `counterValue` /
+  `timerMinutes` in `.onAppear` (0 → today's value), so a value-keyed
+  trigger would tick — or play `.success` on a done day — every time the
+  popover *opens*. The popover keys on the tap instead: the `Binding`
+  setter (the only user-driven path) computes the feedback from old → new
+  and bumps a `stepTick`; one `.sensoryFeedback(trigger: stepTick)` on the
+  body covers both steppers. That's the "tap-keyed" alternative the Risks
+  section describes for the row, needed here for a different reason. If
+  #80 moves the popover off local state, the trigger stays where it is —
+  it never depended on the state.
 
 ## Open questions
 

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -326,7 +326,7 @@ value, so the number past the target — and every tap's effect — is visible.
 
 ## Open questions
 
-- [ ] `0` at rest, or hide the count until something is logged? The plan
+- [x] `0` at rest, or hide the count until something is logged? The plan
   shows `0` (the classic stepper; a disabled `−` beside it reads as
   "nothing yet"). Shipped as `0` / `0m` — on the seeded Today the timer
   row reads `0m +5m`, which scans as "0 minutes, add 5". Hiding it is a

--- a/docs/plans/2026-09/counter-tap-feedback/plan.md
+++ b/docs/plans/2026-09/counter-tap-feedback/plan.md
@@ -66,7 +66,7 @@ watchOS"*), so that's what every tap uses.
 
 ## Task list
 
-### Task 1: `QuickLogFeedback` rule (tests first)
+### Task 1: `QuickLogFeedback` rule (tests first) ✅
 
 **Goal**: one tested function that says which haptic a change of the day's
 recorded value plays.


### PR DESCRIPTION
## Why?

- #81: on Today, `+` on a counter row past its target gives nothing back — the ring is full, the `.success` haptic only fires on the not-complete → complete edge, and there is no number. After tap 11 the user can't tell whether the tap registered or what the count is.
- The `.increase` / `.decrease` feedback the issue suggests compiles on iOS and never plays — Apple's docs for both: *"Only plays feedback on watchOS and visionOS."*

## What?

- A haptic tick on every `+` / `−` / `+5m` tap and every popover step (Today row, Detail quick-log, calendar day popover incl. `Clear`). `.success` still marks the tap that meets the target; the two never stack.
- The Today row shows the day's count again — `− 3 +` on counters, `12m +5m` on timers — at every value, so a tap past the target visibly lands. Reverts the ring-only row decision from `today-row-actions`: the ring structurally can't express past-target.
- Digits roll on change; plain replace under Reduce Motion. VoiceOver output unchanged (`3 of 8, …` stays in the row's value).

## How?

- One pure, tested `QuickLogFeedback` rule (12 cases): `.success` on the not-done → done edge (same "done" as `HabitRowState`, incl. non-positive targets), `.selection` for every other change, `nil` when unchanged.
- **The haptic is keyed on the mutation, not on displayed state.** `TodayView` / `HabitDetailView`'s mutation functions read the value before, derive the value after from the step they apply (`+1`, `−1` floored, `+300`, or the explicit value), and record a sequenced `QuickLogEvent`; one `.quickLogFeedback(_:)` on the `List` / `ScrollView` plays it. `HabitRowView`, `CounterQuickLogView`, `DayEditPopover` carry no haptic — the popover is byte-identical to `main`, so #80 has nothing to rebase. The "Log specific value…" sheets keep their save `.success` (they save through their own logger call).
- Count is presentation only (`state.valueToday` formatted in the row). Timer trailing gains the counter's `ViewThatFits` fallback so at Dynamic Type AX sizes the count gives way to the chip instead of both wrapping mid-token — caught at AX3 on the simulator; the XXXL preview now holds a timer row so it can't slip again.
- One catalog key, `%lldm` → `%lld min`.
- Plan: [plan.md](docs/plans/2026-09/counter-tap-feedback/plan.md) · Compound: [compound.md](docs/plans/2026-09/counter-tap-feedback/compound.md)

Verified: `make test` 578/578, `make e2e` 5/5, iPhone 17 Pro + iPad Air 11" screenshots at default, AX3 and AX5 sizes. A `/code-review` pass on the first build found the value-keyed wiring wrong in four ways (launch-day burst of ticks, silent first tap on a not-scheduled row, doubles on Detail and from the log sheets, zero-target divergence) — all fixed by the hoist above, see the compound.

## Next steps

- [x] **On-device haptic check** — done on an iPhone 16 Pro, working as expected: a tick per tap, `.success` once at the target, ticks past it, a tick per `−`; a not-scheduled row's first `+` ticks; opening the calendar popover is silent, its steps and `Clear` tick; the morning after, opening the app does **not** buzz.
- [ ] Binary / negative toggles still key `.success` on `state.status` in `HabitRowView` (untouched, pre-existing) and carry the same rollover exposure — small follow-up once "what does un-ticking play" is decided.
- [ ] The App Store Today captures now lack the count — re-run `make screenshots` with the next listing refresh.
- [ ] Pre-existing at AX sizes, untouched here, worth an issue: binary checkmark glyph overflows its 28pt circle, "Slipped" breaks into three lines at AX5, habit name is a fixed 15pt font.
- [ ] `CLAUDE.md` candidates in the compound: SensoryFeedback platform table; key tap haptics on the mutation; `simctl ui … content_size` for Dynamic Type checks; run `/code-review` before the device check.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpPezuNyPqmPZRayspv4fG

