### PR TITLE
fix(celebration): draw the confetti in the theme's sage and paper, not the habit hues

### DIFF
--- a/Kado/UIComponents/ConfettiView.swift
+++ b/Kado/UIComponents/ConfettiView.swift
@@ -69,9 +69,23 @@ struct ConfettiView: View {
     /// and scaled with the shorter screen side, so an iPad gets the
     /// same burst shape rather than a phone-sized puff in a corner.
     private struct Particle {
-        /// The eight habit hues and the brand sage: a fistful of the
-        /// colours the user already lives with, not a new palette.
-        static let palette: [Color] = HabitColor.allCases.map(\.color) + [.kadoSage]
+        /// The theme, not the habit hues. Habit colours are Apple's
+        /// full-chroma system hues, and the app only ever shows them
+        /// washed — a ring at 0.25, a cell at 0.3–0.7 — so a hundred
+        /// of them opaque at once was the one loud thing on a paper
+        /// screen. Sage in four steps carries the burst, with a few
+        /// warm neutrals so it reads as torn paper rather than
+        /// plastic. Weighted toward the mid sages: the darkest step
+        /// and the neutrals are the minority. Every token is dynamic,
+        /// so dark mode comes for free.
+        static let palette: [Color] = [
+            .kadoSage300, .kadoSage300,
+            .kadoSage500, .kadoSage500,
+            .kadoSage,
+            .kadoSage900,
+            .kadoPaper300,
+            .kadoInk100,
+        ]
 
         enum Side {
             case leading

--- a/KadoUITests/DayCompletionCelebrationTests.swift
+++ b/KadoUITests/DayCompletionCelebrationTests.swift
@@ -28,10 +28,16 @@ final class DayCompletionCelebrationTests: KadoUITestCase {
             caption.waitForExistence(timeout: 5),
             "Completing the only habit due today should show the “All done for today” caption."
         )
-        // A beat in, so the confetti is mid-air in the picture rather
-        // than still bunched above the top edge.
-        Thread.sleep(forTimeInterval: 0.8)
-        capture(app, "celebration")
+        // Several frames across the burst rather than one: how far in
+        // the first lands depends on how long `waitForExistence` and
+        // the screenshot took on this machine, and a single frame timed
+        // for one run has landed on the last stragglers on the next. A
+        // burst lasts about two seconds; a frame every third of one
+        // guarantees a picture with the confetti mid-air.
+        for frame in 0..<4 {
+            capture(app, "celebration-\(frame)")
+            Thread.sleep(forTimeInterval: 0.3)
+        }
         XCTAssertEqual(app.state, .runningForeground)
     }
 


### PR DESCRIPTION
## Why?

- The day-complete confetti was the eight `HabitColor` system hues (`.red`, `.orange`, `.yellow`…) plus sage — Apple's full-chroma UI colours, drawn opaque, 160 pieces at once.
- Everywhere else the app shows a habit hue *washed* (a ring at 0.25, a capsule at 0.15, a matrix cell at 0.3–0.7). The burst was the one place they all appeared raw and in bulk, on a warm paper ground: a bag of Skittles on washi, and louder still on the near-black dark paper.
- It didn't earn its palette either: random eight-hue confetti doesn't read as "your habits", it reads as a party popper.

## What?

- The burst is now made of the theme: sage in four steps (weighted to the middle two) plus two warm neutrals (`kadoPaper300`, `kadoInk100`), so it reads as torn paper and leaves rather than plastic.
- Same shapes, same motion, same count. Dark mode follows automatically — every token is dynamic.
- Before / after, same test and same frame timing (left: `main`, light; middle: after, light; right: after, dark) — attached in the session; the frames come out of `DayCompletionCelebrationTests` as `celebration-0…3`.

## How?

- One-line palette swap in `ConfettiView.Particle.palette`; also removes the last literal colour list in the UI layer, in line with the "prefer semantic colours" rule.
- `DayCompletionCelebrationTests` now captures four frames a third of a second apart instead of one at 0.8 s: how far into the ~2 s burst a single frame lands depends on the machine, and here it had been landing on the last stragglers, which made the visual check unjudgeable. Export with `xcrun xcresulttool export attachments`.
- Verified: `build_sim` clean, `KadoTests` 566/566, the celebration UI test green in light and dark on a fresh iPhone 17 Pro simulator.

## Next steps

- If it still feels like a party in the hand, the next lever is density (drop `count` from 160 to ~100) and slightly longer, thinner strips — not more palette work.
- Deferred idea: a burst made of only today's completed habits' colours, washed — meaningful but needs plumbing through `DayProgress` / `WidgetSnapshotBuilder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NV6DEyDfBMJ3MjVSZLTq3D
