### PR TITLE
fix(habit-detail): delete a History row from its long-press menu (#87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,15 @@ repo. Guard against that with an explicit
   `Button { guard !flag else { return }; flag = true; Task { await work() } }`.
   Pattern: `TipJarView.tierButton` sets `purchasingTier` in the action,
   not inside `tip(_:)`, to block a double-tap double-purchase.
+- **`.swipeActions` only fires on the rows of a `List`.** On a row in
+  a `LazyVStack` / `VStack` it compiles, reads as wired, and never
+  fires — no warning, no log line. The History list on the detail
+  screen shipped that way for five months and survived a rewire
+  that described it as working (issue #87). Rows outside a `List`
+  get a `.contextMenu` instead, with the same action exposed through
+  `.accessibilityAction` so VoiceOver reaches it (pattern:
+  `CompletionHistoryList`, `HabitRowView`). Any gesture wired for
+  the first time gets tried once, by hand or in `KadoUITests`.
 
 ### Widget colours
 
@@ -897,7 +906,7 @@ nothing inside a test can change the simulator's appearance, and
 `simctl ui <udid> appearance` can, so the script sets it between the
 two passes.
 
-Four findings, each of which cost a cycle:
+Five findings, each of which cost a cycle:
 
 - **Never build the UI suite with `CODE_SIGNING_ALLOWED=NO`.** Kadō's
   app target carries the iCloud and App Group entitlements, and an
@@ -925,6 +934,14 @@ Four findings, each of which cost a cycle:
   watches for something that cannot appear until something scrolls.
   Scroll first (`KadoUITestCase.scrollTo`). The Dev mode toggle, last
   section in Settings, looked missing for a full 30s timeout this way.
+- **A context menu opened from a row half under the floating tab bar
+  drops the tap on its item.** `scrollTo` stops as soon as the row's
+  *centre* is hittable, which can leave its lower half beneath the
+  bar. A tap there works; a long-press opens the menu, and the tap on
+  Delete then lands dead centre on the item and does nothing — menu
+  still up, row still there. One more swipe, same tap, goes through.
+  Scroll a row wholly clear of the bar before long-pressing it
+  (`CompletionHistoryTests.scrollClearOfTabBar`).
 
 **Apply accessibility identifiers in the same commit as the view.**
 Retrofitting them across a grown app is what makes UI suites get

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -357,9 +357,11 @@ repo. Guard against that with an explicit
   screen shipped that way for five months and survived a rewire
   that described it as working (issue #87). Rows outside a `List`
   get a `.contextMenu` instead, with the same action exposed through
-  `.accessibilityAction` so VoiceOver reaches it (pattern:
-  `CompletionHistoryList`, `HabitRowView`). Any gesture wired for
-  the first time gets tried once, by hand or in `KadoUITests`.
+  `.accessibilityAction` and a footer line saying the menu exists —
+  `CompletionHistoryList` is the outside-a-`List` case; `HabitRowView`
+  (inside Today's `List`) is the older context-menu + Actions-rotor
+  precedent it copies. Any gesture wired for the first time gets
+  tried once, by hand or in `KadoUITests`.
 
 ### Widget colours
 
@@ -941,7 +943,7 @@ Five findings, each of which cost a cycle:
   Delete then lands dead centre on the item and does nothing — menu
   still up, row still there. One more swipe, same tap, goes through.
   Scroll a row wholly clear of the bar before long-pressing it
-  (`CompletionHistoryTests.scrollClearOfTabBar`).
+  (`KadoUITestCase.scrollClearOfTabBar`, beside `scrollTo`).
 
 **Apply accessibility identifiers in the same commit as the view.**
 Retrofitting them across a grown app is what makes UI suites get

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -1433,7 +1433,7 @@
       }
     },
     "Delete" : {
-      "comment" : "Long-press menu action and VoiceOver action on a completion history row that removes the completion.",
+      "comment" : "History row long-press / VoiceOver action that removes the completion.",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2229,6 +2229,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saisir une valeur…"
+          }
+        }
+      }
+    },
+    "Long-press a row to delete it." : {
+      "comment" : "Footer under the detail's History list, telling the user the rows have a long-press menu.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Long-press a row to delete it."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maintiens une ligne pour la supprimer."
           }
         }
       }

--- a/Kado/Resources/Localizable.xcstrings
+++ b/Kado/Resources/Localizable.xcstrings
@@ -1433,7 +1433,7 @@
       }
     },
     "Delete" : {
-      "comment" : "Swipe action in the completion history list that removes a completion.",
+      "comment" : "Long-press menu action and VoiceOver action on a completion history row that removes the completion.",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Kado/Services/CompletionLogger.swift
+++ b/Kado/Services/CompletionLogger.swift
@@ -127,7 +127,7 @@ struct CompletionLogger {
         }
     }
 
-    /// Removes a specific completion (used by history-list swipes).
+    /// Removes a specific completion (the History list's Delete).
     func delete(_ completion: CompletionRecord, in context: ModelContext) {
         context.delete(completion)
     }

--- a/Kado/Services/CompletionLogger.swift
+++ b/Kado/Services/CompletionLogger.swift
@@ -127,7 +127,8 @@ struct CompletionLogger {
         }
     }
 
-    /// Removes a specific completion (the History list's Delete).
+    /// Removes a specific completion: the History list's Delete, and the
+    /// day popover's Clear when the record carries no note.
     func delete(_ completion: CompletionRecord, in context: ModelContext) {
         context.delete(completion)
     }

--- a/Kado/Views/HabitDetail/CompletionHistoryList.swift
+++ b/Kado/Views/HabitDetail/CompletionHistoryList.swift
@@ -3,13 +3,16 @@ import SwiftUI
 import KadoCore
 
 /// Scrollable list of completions for a habit, sorted newest first.
-/// A row's long-press menu holds a destructive **Delete**, which hands
-/// the completion back through `onDelete`. A context menu rather than
-/// `swipeActions`, which SwiftUI only honours on the rows of a `List`
-/// — on a `LazyVStack` row it compiles, looks wired, and never fires
-/// (issue #87). Every row also exposes Delete as a VoiceOver action,
-/// the same way the Today row does. Empty state shows a neutral "No
-/// history yet" row.
+/// When `onDelete` is given, a row's long-press menu holds a
+/// destructive **Delete** that hands the completion back through it,
+/// and a footer says so — a long-press is invisible until someone
+/// tells you it's there. A context menu rather than `swipeActions`,
+/// which SwiftUI only honours on the rows of a `List` — on a
+/// `LazyVStack` row it compiles, looks wired, and never fires (issue
+/// #87). Every row also exposes Delete as a VoiceOver action, the same
+/// way the Today row does. Without `onDelete` the list is read-only:
+/// no menu, no action, no footer — the archived habit's case. Empty
+/// state shows a neutral "No history yet" row.
 ///
 /// Takes value-type snapshots for the same reason `HabitDetailView`
 /// does: its `ForEach` would otherwise hold `CompletionRecord`s from
@@ -22,7 +25,8 @@ import KadoCore
 struct CompletionHistoryList: View {
     let habitType: HabitType
     let completions: [Completion]
-    var onDelete: (Completion) -> Void = { _ in }
+    /// `nil` renders the list read-only.
+    var onDelete: ((Completion) -> Void)? = nil
 
     @Environment(\.calendar) private var calendar
     @Environment(\.today) private var today
@@ -60,12 +64,50 @@ struct CompletionHistoryList: View {
                     RoundedRectangle(cornerRadius: KadoRadius.card)
                         .fill(Color.kadoBackgroundSecondary)
                 )
+                if onDelete != nil {
+                    // Same job as the Today list's footer: the one
+                    // gesture on this list is the one nobody can see.
+                    Text("Long-press a row to delete it.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 16)
+                }
             }
         }
     }
 
+    /// The row, with its menu and VoiceOver action when the list is
+    /// editable. Branched rather than fed an empty `contextMenu`, so a
+    /// read-only row has no interaction at all — nothing to long-press
+    /// into and nothing in the Actions rotor.
     @ViewBuilder
     private func row(for completion: Completion) -> some View {
+        if let onDelete {
+            rowContent(for: completion)
+                .contextMenu {
+                    Button(role: .destructive) {
+                        onDelete(completion)
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                    .accessibilityIdentifier(AccessibilityID.HabitDetail.historyDeleteButton)
+                }
+                .accessibilityElement(children: .combine)
+                // On a leaf: `.combine` has already collapsed the row
+                // to one element. Keyed by the completion's id rather
+                // than its date, which is localized.
+                .accessibilityIdentifier(AccessibilityID.HabitDetail.historyRow(completion.id))
+                .accessibilityAction(named: Text("Delete")) {
+                    onDelete(completion)
+                }
+        } else {
+            rowContent(for: completion)
+                .accessibilityElement(children: .combine)
+                .accessibilityIdentifier(AccessibilityID.HabitDetail.historyRow(completion.id))
+        }
+    }
+
+    private func rowContent(for completion: Completion) -> some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 2) {
                 Text(relativeDate(for: completion.date))
@@ -93,22 +135,6 @@ struct CompletionHistoryList: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .contentShape(Rectangle())
-        .contextMenu {
-            Button(role: .destructive) {
-                onDelete(completion)
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
-            .accessibilityIdentifier(AccessibilityID.HabitDetail.historyDeleteButton)
-        }
-        .accessibilityElement(children: .combine)
-        // On a leaf: `.combine` has already collapsed the row to one
-        // element. Keyed by the completion's id rather than its date,
-        // which is localized.
-        .accessibilityIdentifier(AccessibilityID.HabitDetail.historyRow(completion.id))
-        .accessibilityAction(named: Text("Delete")) {
-            onDelete(completion)
-        }
     }
 
     /// Relative labels are anchored to the **logical** today, not
@@ -172,6 +198,11 @@ struct CompletionHistoryList: View {
         .modelContainer(PreviewContainer.shared)
 }
 
+#Preview("Read-only (archived)") {
+    CompletionHistoryListPreviewWrapper(habitName: "Morning meditation", editable: false)
+        .modelContainer(PreviewContainer.shared)
+}
+
 #Preview("Empty") {
     ScrollView {
         CompletionHistoryList(habitType: .binary, completions: [])
@@ -187,11 +218,13 @@ struct CompletionHistoryList: View {
 
 private struct CompletionHistoryListPreviewWrapper: View {
     let habitName: String
+    var editable = true
 
     @Query private var habits: [HabitRecord]
 
-    init(habitName: String) {
+    init(habitName: String, editable: Bool = true) {
         self.habitName = habitName
+        self.editable = editable
         _habits = Query(filter: #Predicate<HabitRecord> { $0.name == habitName })
     }
 
@@ -200,7 +233,8 @@ private struct CompletionHistoryListPreviewWrapper: View {
             if let habit = habits.first {
                 CompletionHistoryList(
                     habitType: habit.type,
-                    completions: (habit.completions ?? []).compactMap(\.snapshot)
+                    completions: (habit.completions ?? []).compactMap(\.snapshot),
+                    onDelete: editable ? { _ in } : nil
                 )
                 .padding()
             } else {

--- a/Kado/Views/HabitDetail/CompletionHistoryList.swift
+++ b/Kado/Views/HabitDetail/CompletionHistoryList.swift
@@ -3,10 +3,12 @@ import SwiftUI
 import KadoCore
 
 /// Scrollable list of completions for a habit, sorted newest first.
-/// Deleting a row hands the completion back through `onDelete` — but
-/// note the gesture wired to it is `swipeActions` on a `LazyVStack`
-/// row, which SwiftUI ignores outside a `List`; nothing reaches
-/// `onDelete` today (issue #87). Empty state shows a neutral "No
+/// A row's long-press menu holds a destructive **Delete**, which hands
+/// the completion back through `onDelete`. A context menu rather than
+/// `swipeActions`, which SwiftUI only honours on the rows of a `List`
+/// — on a `LazyVStack` row it compiles, looks wired, and never fires
+/// (issue #87). Every row also exposes Delete as a VoiceOver action,
+/// the same way the Today row does. Empty state shows a neutral "No
 /// history yet" row.
 ///
 /// Takes value-type snapshots for the same reason `HabitDetailView`
@@ -91,12 +93,21 @@ struct CompletionHistoryList: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .contentShape(Rectangle())
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+        .contextMenu {
             Button(role: .destructive) {
                 onDelete(completion)
             } label: {
                 Label("Delete", systemImage: "trash")
             }
+            .accessibilityIdentifier(AccessibilityID.HabitDetail.historyDeleteButton)
+        }
+        .accessibilityElement(children: .combine)
+        // On a leaf: `.combine` has already collapsed the row to one
+        // element. Keyed by the completion's id rather than its date,
+        // which is localized.
+        .accessibilityIdentifier(AccessibilityID.HabitDetail.historyRow(completion.id))
+        .accessibilityAction(named: Text("Delete")) {
+            onDelete(completion)
         }
     }
 

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -340,7 +340,7 @@ struct HabitDetailView: View {
         WidgetReloader.reloadAll(using: modelContext)
     }
 
-    /// Swipe-to-delete from the history list.
+    /// Delete from a History row's long-press menu.
     private func deleteCompletion(_ snapshot: Completion) {
         guard let existing = completionRecord(for: snapshot) else { return }
         CompletionLogger(calendar: calendar).delete(existing, in: modelContext)

--- a/Kado/Views/HabitDetail/HabitDetailView.swift
+++ b/Kado/Views/HabitDetail/HabitDetailView.swift
@@ -125,7 +125,7 @@ struct HabitDetailView: View {
                 CompletionHistoryList(
                     habitType: habit.type,
                     completions: completions,
-                    onDelete: deleteCompletion
+                    onDelete: historyDelete
                 )
             }
             .padding()
@@ -338,6 +338,18 @@ struct HabitDetailView: View {
         recordQuickLog(from: before, to: 0)
         try? modelContext.save()
         WidgetReloader.reloadAll(using: modelContext)
+    }
+
+    /// What the History list gets to delete with: nothing once the
+    /// habit is archived, like every other mutation on this screen.
+    /// A `guard` rather than `isArchived ? nil : deleteCompletion` —
+    /// the ternary over a `@MainActor` method reference is one the
+    /// compiler can't type ("failed to produce diagnostic"), and
+    /// inline in the body it surfaces as "ambiguous use of 'init'" on
+    /// the enclosing `ScrollView`.
+    private var historyDelete: ((Completion) -> Void)? {
+        guard !isArchived else { return nil }
+        return { deleteCompletion($0) }
     }
 
     /// Delete from a History row's long-press menu.

--- a/KadoUITests/CompletionHistoryTests.swift
+++ b/KadoUITests/CompletionHistoryTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+/// Deleting a completion from the detail's History list, end to end
+/// (issue #87).
+///
+/// The list draws its rows in a `LazyVStack`, and the delete on them
+/// was `swipeActions` — which SwiftUI honours only on the rows of a
+/// `List`. It compiled, was rewired and described as working, and
+/// never fired. Nothing short of the real gesture on the real screen
+/// can tell an inert modifier from a working one, so this drives it:
+/// the seeded counter habit, a long-press on its newest row, Delete,
+/// and a look at what is left.
+final class CompletionHistoryTests: KadoUITestCase {
+
+    @MainActor
+    func testDeletingARowFromItsLongPressMenuRemovesIt() {
+        let app = launchApp(devMode: true)
+
+        tapTab(.today, in: app)
+        waitForTodayRows(in: app)
+        openCounterHabitDetail(in: app)
+
+        // History sits under the calendar, below the fold, and its rows
+        // are lazy: none is in the hierarchy until it scrolls in. The
+        // newest row is yesterday's — the seed logs the counter habit on
+        // odd days-ago only, so today is empty.
+        let rows = historyRows(in: app)
+        let first = rows.firstMatch
+        scrollTo(first, in: app)
+        scrollClearOfTabBar(first, in: app)
+        let deleted = first.identifier
+        XCTAssertTrue(
+            deleted.hasPrefix(AccessibilityID.HabitDetail.historyRowPrefix),
+            "Expected a History row, got “\(deleted)”."
+        )
+
+        first.press(forDuration: 1)
+        let delete = app.buttons[AccessibilityID.HabitDetail.historyDeleteButton].firstMatch
+        XCTAssertTrue(
+            delete.waitForExistence(timeout: 5),
+            "Long-pressing a History row should open a menu with Delete in it."
+        )
+        capture(app, "history-row-menu")
+        delete.tap()
+
+        XCTAssertTrue(
+            app.descendants(matching: .any)[deleted].waitForNonExistence(timeout: 5),
+            "Delete should remove the row it was chosen on — this is issue #87."
+        )
+        // The list itself stays: fourteen completions remain, and the
+        // one below has moved up into the first slot.
+        XCTAssertTrue(rows.firstMatch.waitForExistence(timeout: 5), "The History list should still have rows.")
+        XCTAssertNotEqual(rows.firstMatch.identifier, deleted)
+        capture(app, "history-after-delete")
+    }
+
+    /// Scrolls until `element` sits wholly above the floating tab bar.
+    ///
+    /// `scrollTo` stops as soon as the element's *centre* can be tapped,
+    /// which leaves a row at the bottom of the screen with its lower
+    /// half under the bar. That is enough for a tap, but not for a
+    /// long-press: the menu opens, and then the tap on its Delete is
+    /// dropped — reproduced on the first run of this test, with the
+    /// tap landing dead centre on the item and the menu staying up.
+    /// One swipe further and the same tap goes through. iPad has no
+    /// bar at the bottom, so there is nothing to clear there.
+    @MainActor
+    private func scrollClearOfTabBar(_ element: XCUIElement, in app: XCUIApplication) {
+        let bar = app.tabBars.firstMatch
+        guard bar.exists else { return }
+        var swipes = 0
+        while element.frame.maxY > bar.frame.minY && swipes < 3 {
+            app.swipeUp(velocity: .slow)
+            swipes += 1
+        }
+        XCTAssertTrue(
+            element.exists && element.frame.maxY <= bar.frame.minY,
+            "Never scrolled \(element) clear of the tab bar."
+        )
+    }
+
+    /// The History rows currently realized, addressed by the identifier
+    /// prefix: the seed draws completion ids fresh each run.
+    @MainActor
+    private func historyRows(in app: XCUIApplication) -> XCUIElementQuery {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier BEGINSWITH %@",
+                AccessibilityID.HabitDetail.historyRowPrefix
+            ))
+    }
+}

--- a/KadoUITests/CompletionHistoryTests.swift
+++ b/KadoUITests/CompletionHistoryTests.swift
@@ -21,20 +21,18 @@ final class CompletionHistoryTests: KadoUITestCase {
         openCounterHabitDetail(in: app)
 
         // History sits under the calendar, below the fold, and its rows
-        // are lazy: none is in the hierarchy until it scrolls in. The
-        // newest row is yesterday's — the seed logs the counter habit on
-        // odd days-ago only, so today is empty.
-        let rows = historyRows(in: app)
-        let first = rows.firstMatch
+        // are lazy: none is in the hierarchy until it scrolls in. Coming
+        // down from the top, the first row realized is the newest —
+        // yesterday's, since the seed logs the counter habit on odd
+        // days-ago only. Its id is taken here, before any further
+        // scrolling can change what `firstMatch` resolves to.
+        let first = historyRows(in: app).firstMatch
         scrollTo(first, in: app)
-        scrollClearOfTabBar(first, in: app)
         let deleted = first.identifier
-        XCTAssertTrue(
-            deleted.hasPrefix(AccessibilityID.HabitDetail.historyRowPrefix),
-            "Expected a History row, got “\(deleted)”."
-        )
+        let row = app.descendants(matching: .any)[deleted]
+        scrollClearOfTabBar(row, in: app)
 
-        first.press(forDuration: 1)
+        row.press(forDuration: 1)
         let delete = app.buttons[AccessibilityID.HabitDetail.historyDeleteButton].firstMatch
         XCTAssertTrue(
             delete.waitForExistence(timeout: 5),
@@ -44,49 +42,20 @@ final class CompletionHistoryTests: KadoUITestCase {
         delete.tap()
 
         XCTAssertTrue(
-            app.descendants(matching: .any)[deleted].waitForNonExistence(timeout: 5),
+            row.waitForNonExistence(timeout: 5),
             "Delete should remove the row it was chosen on — this is issue #87."
         )
-        // The list itself stays: fourteen completions remain, and the
-        // one below has moved up into the first slot.
-        XCTAssertTrue(rows.firstMatch.waitForExistence(timeout: 5), "The History list should still have rows.")
-        XCTAssertNotEqual(rows.firstMatch.identifier, deleted)
+        // Only that row: the list is still there, headed by another one.
+        let remaining = historyRows(in: app).firstMatch
+        XCTAssertTrue(remaining.waitForExistence(timeout: 5), "The History list should still have rows.")
+        XCTAssertNotEqual(remaining.identifier, deleted)
         capture(app, "history-after-delete")
-    }
-
-    /// Scrolls until `element` sits wholly above the floating tab bar.
-    ///
-    /// `scrollTo` stops as soon as the element's *centre* can be tapped,
-    /// which leaves a row at the bottom of the screen with its lower
-    /// half under the bar. That is enough for a tap, but not for a
-    /// long-press: the menu opens, and then the tap on its Delete is
-    /// dropped — reproduced on the first run of this test, with the
-    /// tap landing dead centre on the item and the menu staying up.
-    /// One swipe further and the same tap goes through. iPad has no
-    /// bar at the bottom, so there is nothing to clear there.
-    @MainActor
-    private func scrollClearOfTabBar(_ element: XCUIElement, in app: XCUIApplication) {
-        let bar = app.tabBars.firstMatch
-        guard bar.exists else { return }
-        var swipes = 0
-        while element.frame.maxY > bar.frame.minY && swipes < 3 {
-            app.swipeUp(velocity: .slow)
-            swipes += 1
-        }
-        XCTAssertTrue(
-            element.exists && element.frame.maxY <= bar.frame.minY,
-            "Never scrolled \(element) clear of the tab bar."
-        )
     }
 
     /// The History rows currently realized, addressed by the identifier
     /// prefix: the seed draws completion ids fresh each run.
     @MainActor
     private func historyRows(in app: XCUIApplication) -> XCUIElementQuery {
-        app.descendants(matching: .any)
-            .matching(NSPredicate(
-                format: "identifier BEGINSWITH %@",
-                AccessibilityID.HabitDetail.historyRowPrefix
-            ))
+        elements(withIdentifierPrefix: AccessibilityID.HabitDetail.historyRowPrefix, in: app)
     }
 }

--- a/KadoUITests/DayEditPopoverTests.swift
+++ b/KadoUITests/DayEditPopoverTests.swift
@@ -112,42 +112,6 @@ final class DayEditPopoverTests: KadoUITestCase {
 
     // MARK: - Driving
 
-    /// Pushes the detail of the seeded counter habit.
-    @MainActor
-    private func openCounterHabitDetail(in app: XCUIApplication) {
-        openHabitDetail(showing: AccessibilityID.HabitDetail.quickLogIncrement, in: app)
-    }
-
-    /// Pushes the detail of the seeded timer habit.
-    @MainActor
-    private func openTimerHabitDetail(in app: XCUIApplication) {
-        openHabitDetail(showing: AccessibilityID.HabitDetail.logSessionButton, in: app)
-    }
-
-    /// Pushes Today rows in turn until the detail shows the button with
-    /// `marker`, and stays there.
-    ///
-    /// Today rows are keyed by a `UUID` the seed draws fresh each run,
-    /// so a habit can't be addressed by identifier from the list. Each
-    /// row is pushed and asked what it is; the seed has one habit of
-    /// each type among a handful, so this is a few pushes at most.
-    @MainActor
-    private func openHabitDetail(showing marker: String, in app: XCUIApplication) {
-        let rows = todayRows(in: app)
-        let scoreCard = app.buttons[AccessibilityID.HabitDetail.scoreCard]
-        let markerButton = app.buttons[marker]
-        for index in 0..<rows.count {
-            rows.element(boundBy: index).tap()
-            XCTAssertTrue(scoreCard.waitForExistence(timeout: 10), "Tapping a Today row should push its detail.")
-            if markerButton.waitForExistence(timeout: 2) {
-                return
-            }
-            app.navigationBars.buttons.firstMatch.tap()
-            XCTAssertTrue(scoreCard.waitForNonExistence(timeout: 10), "Popping the detail should return to Today.")
-        }
-        XCTFail("No Today row pushed a detail showing \(marker).")
-    }
-
     /// Taps the calendar cell for the given day, navigating back a
     /// month first when it falls in the previous one, and returns the
     /// day-of-month it tapped.

--- a/KadoUITests/KadoUITestCase.swift
+++ b/KadoUITests/KadoUITestCase.swift
@@ -169,6 +169,48 @@ class KadoUITestCase: XCTestCase {
         )
     }
 
+    /// Scrolls until `element` sits wholly above the floating tab bar.
+    ///
+    /// `scrollTo` stops as soon as the element's *centre* can be tapped,
+    /// which leaves a row at the bottom of the screen with its lower
+    /// half under the bar. That is enough for a tap, but not for a
+    /// long-press: the menu opens, and then the tap on its item is
+    /// dropped — reproduced on the first run of `CompletionHistoryTests`,
+    /// with the tap landing dead centre on Delete and the menu staying
+    /// up. One swipe further and the same tap goes through. iPad has no
+    /// bar at the bottom, so there is nothing to clear there.
+    @MainActor
+    func scrollClearOfTabBar(
+        _ element: XCUIElement,
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let bar = app.tabBars.firstMatch
+        guard bar.exists else { return }
+        var swipes = 0
+        while element.frame.maxY > bar.frame.minY && swipes < 3 {
+            app.swipeUp(velocity: .slow)
+            swipes += 1
+        }
+        XCTAssertTrue(
+            element.exists && element.frame.maxY <= bar.frame.minY,
+            "Never scrolled \(element) clear of the tab bar.",
+            file: file, line: line
+        )
+    }
+
+    /// The elements on screen whose identifier starts with `prefix`.
+    ///
+    /// For the identifier families keyed by a `UUID` the seed draws
+    /// fresh each run — a test can't know the id ahead of time, so it
+    /// asks for "any of them" and reads the id back off the element.
+    @MainActor
+    func elements(withIdentifierPrefix prefix: String, in app: XCUIApplication) -> XCUIElementQuery {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", prefix))
+    }
+
     /// The Today rows currently on screen, addressed by the identifier
     /// prefix rather than by habit name.
     ///
@@ -178,8 +220,7 @@ class KadoUITestCase: XCTestCase {
     /// which is what these tests actually mean.
     @MainActor
     func todayRows(in app: XCUIApplication) -> XCUIElementQuery {
-        app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier BEGINSWITH %@", "today.row."))
+        elements(withIdentifierPrefix: "today.row.", in: app)
     }
 
     /// Waits for the Today list to have rows in it.
@@ -200,14 +241,26 @@ class KadoUITestCase: XCTestCase {
 
     /// Pushes the detail of the seeded counter habit.
     @MainActor
-    func openCounterHabitDetail(in app: XCUIApplication) {
-        openHabitDetail(showing: AccessibilityID.HabitDetail.quickLogIncrement, in: app)
+    func openCounterHabitDetail(
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        openHabitDetail(
+            showing: AccessibilityID.HabitDetail.quickLogIncrement, in: app, file: file, line: line
+        )
     }
 
     /// Pushes the detail of the seeded timer habit.
     @MainActor
-    func openTimerHabitDetail(in app: XCUIApplication) {
-        openHabitDetail(showing: AccessibilityID.HabitDetail.logSessionButton, in: app)
+    func openTimerHabitDetail(
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        openHabitDetail(
+            showing: AccessibilityID.HabitDetail.logSessionButton, in: app, file: file, line: line
+        )
     }
 
     /// Pushes Today rows in turn until the detail shows the button with

--- a/KadoUITests/KadoUITestCase.swift
+++ b/KadoUITests/KadoUITestCase.swift
@@ -198,6 +198,55 @@ class KadoUITestCase: XCTestCase {
         )
     }
 
+    /// Pushes the detail of the seeded counter habit.
+    @MainActor
+    func openCounterHabitDetail(in app: XCUIApplication) {
+        openHabitDetail(showing: AccessibilityID.HabitDetail.quickLogIncrement, in: app)
+    }
+
+    /// Pushes the detail of the seeded timer habit.
+    @MainActor
+    func openTimerHabitDetail(in app: XCUIApplication) {
+        openHabitDetail(showing: AccessibilityID.HabitDetail.logSessionButton, in: app)
+    }
+
+    /// Pushes Today rows in turn until the detail shows the button with
+    /// `marker`, and stays there.
+    ///
+    /// Today rows are keyed by a `UUID` the seed draws fresh each run,
+    /// so a habit can't be addressed by identifier from the list. Each
+    /// row is pushed and asked what it is; the seed has one habit of
+    /// each type among a handful, so this is a few pushes at most.
+    @MainActor
+    func openHabitDetail(
+        showing marker: String,
+        in app: XCUIApplication,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let rows = todayRows(in: app)
+        let scoreCard = app.buttons[AccessibilityID.HabitDetail.scoreCard]
+        let markerButton = app.buttons[marker]
+        for index in 0..<rows.count {
+            rows.element(boundBy: index).tap()
+            XCTAssertTrue(
+                scoreCard.waitForExistence(timeout: 10),
+                "Tapping a Today row should push its detail.",
+                file: file, line: line
+            )
+            if markerButton.waitForExistence(timeout: 2) {
+                return
+            }
+            app.navigationBars.buttons.firstMatch.tap()
+            XCTAssertTrue(
+                scoreCard.waitForNonExistence(timeout: 10),
+                "Popping the detail should return to Today.",
+                file: file, line: line
+            )
+        }
+        XCTFail("No Today row pushed a detail showing \(marker).", file: file, line: line)
+    }
+
     /// Saves a screenshot into the result bundle, so a failing run can
     /// be looked at without re-running it.
     @MainActor

--- a/Shared/AccessibilityID.swift
+++ b/Shared/AccessibilityID.swift
@@ -122,6 +122,20 @@ enum AccessibilityID {
         /// The timer habit's "Log a session" button — what a test looks
         /// for to know it has pushed a *timer* habit's detail.
         static let logSessionButton = "habitDetail.logSession"
+        /// One row of the History list, keyed by the completion's
+        /// `UUID`: its date is localized, and the seed draws ids fresh
+        /// each run, so a test matches on the prefix and reads the id
+        /// back off the element. The row collapses to a single element
+        /// already, so this lands on a leaf.
+        static func historyRow(_ completionID: UUID) -> String {
+            historyRowPrefix + completionID.uuidString
+        }
+        /// What `historyRow` builds on, for an "any History row" query.
+        static let historyRowPrefix = "habitDetail.history.row."
+        /// The destructive Delete in a History row's long-press menu.
+        /// Identified rather than matched on its label, which is
+        /// "Supprimer" on the French simulator.
+        static let historyDeleteButton = "habitDetail.history.delete"
 
         /// The popover that edits one calendar day (`DayEditPopover`).
         enum DayEdit {


### PR DESCRIPTION
Fixes #87.

## Why?

- On a habit's detail screen, swiping a **History** row did nothing: there was no way to delete a single completion.
- The rows live in a `LazyVStack` inside the detail's `ScrollView`, and the delete was wired to `.swipeActions` — which SwiftUI only honours on the rows of a `List`. Outside one it compiles, looks wired, and never fires. Dead since #7; #83 rewired it to `HabitDetailView.deleteCompletion` and described it as working without trying it.

## What?

- Each History row now has a **long-press menu** with a destructive **Delete** — the option the issue leads with: it keeps the `LazyVStack` layout and matches the Today row's context menu.
- A **footer** under the list says so ("Long-press a row to delete it." / "Maintiens une ligne pour la supprimer."), the same job the Today list's footer does — a long-press is invisible until something tells you it's there.
- The same Delete is exposed as a **VoiceOver action** on the row (Actions rotor), the way `HabitRowView` does it.
- Each row collapses to a single accessibility element ("Yesterday, Fri Sep 11, 6/8") instead of three or four.
- **Archived habits stay read-only**: no menu, no rotor action, no footer — the review caught that a working Delete would have been the one ungated mutation on that screen.

## How?

- `CompletionHistoryList`: `.swipeActions` → `.contextMenu`, plus `.accessibilityElement(children: .combine)` / `.accessibilityIdentifier` / `.accessibilityAction(named:)` in the same chain order as `HabitRowView`. `onDelete` is optional; `nil` branches to a row with no interaction at all rather than an empty menu. `HabitDetailView` passes `nil` once archived (via a `guard`-shaped computed property — the `cond ? nil : method` ternary is one the compiler can't type). Resolution stays on `HabitDetailView.deleteCompletion` (#83).
- `AccessibilityID.HabitDetail.historyRow(_:)` (keyed by the completion's `UUID`, prefix-matchable) and `historyDeleteButton` — the menu item's identifier does come through to XCUITest, verified live.
- **UI test** `CompletionHistoryTests`: pushes the seeded counter habit, long-presses its newest History row (yesterday's), taps Delete, asserts the row is gone and the list still stands. `KadoUITestCase` gains the "push the seeded counter / timer habit" helpers (moved out of `DayEditPopoverTests`), `scrollClearOfTabBar`, and a shared `elements(withIdentifierPrefix:)`.
- Two findings recorded in `CLAUDE.md`: the `swipeActions`-outside-a-`List` trap, and a UI-test one that cost a cycle here — a context menu opened from a row half under the floating tab bar drops the tap on its item (tap lands dead centre, menu stays up); the test scrolls the row clear of the bar first.
- One new catalog key (the footer). Stale "swipe" comments updated (`CompletionLogger.delete`, `deleteCompletion`, the catalog's `Delete` comment).

Verified: `make test` green; `make e2e` green (9/9 UI tests, including the new one); light-mode screenshots of the menu, the post-delete list, and the footer in EN and FR captured on the iPhone 17 Pro simulator.

## Next steps

- **FR footer to check** by the native speaker: "Maintiens une ligne pour la supprimer." — written to match the Today footer's "maintiens pour modifier ou archiver".
- **VoiceOver, on a device**: SwiftUI may already surface `.contextMenu` items in the Actions rotor, in which case the explicit `.accessibilityAction` is a duplicate "Delete" entry. `HabitRowView` has the same shape (Edit / Archive in both places); if it is a duplicate, drop one in both views together.
- On this simulator the menu presents in the compact "actions only" style (no lifted preview of the row). System rendering; worth a glance on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LcFCzLPTfrtNq9HPkV6a41
